### PR TITLE
No enrichment randomized and testing patch

### DIFF
--- a/ark/analysis/spatial_analysis_test.py
+++ b/ark/analysis/spatial_analysis_test.py
@@ -19,7 +19,7 @@ def _make_distance_matrix(enrichment_type, dist_lim):
 
     if enrichment_type == "none":
         # Create a 60 x 60 euclidian distance matrix of random values for no enrichment
-        np.random.seed(42)
+        np.random.seed(0)
         rand_mat = np.random.randint(0, 200, size=(60, 60))
         np.fill_diagonal(rand_mat[:, :], 0)
 

--- a/ark/analysis/spatial_analysis_test.py
+++ b/ark/analysis/spatial_analysis_test.py
@@ -19,6 +19,7 @@ def _make_distance_matrix(enrichment_type, dist_lim):
 
     if enrichment_type == "none":
         # Create a 60 x 60 euclidian distance matrix of random values for no enrichment
+        np.random.seed(42) # because the meaning of life ;-)
         rand_mat = np.random.randint(0, 200, size=(60, 60))
         np.fill_diagonal(rand_mat[:, :], 0)
 
@@ -244,11 +245,11 @@ def test_calculate_channel_spatial_enrichment():
     # Extract the p-values and z-scores of the distance of marker 1 vs marker 2 for no enrichment
     # as tested against a random set of distances between centroids
     assert stats_no_enrich.loc["Point8", "p_pos", 2, 3] > .05
-    assert stats_no_enrich.loc["Point8", "p_pos", 2, 3] > .05
+    assert stats_no_enrich.loc["Point8", "p_neg", 2, 3] > .05
     assert abs(stats_no_enrich.loc["Point8", "z", 2, 3]) < 2
 
     assert stats_no_enrich.loc["Point9", "p_pos", 3, 2] > .05
-    assert stats_no_enrich.loc["Point9", "p_pos", 3, 2] > .05
+    assert stats_no_enrich.loc["Point9", "p_neg", 3, 2] > .05
     assert abs(stats_no_enrich.loc["Point9", "z", 3, 2]) < 2
 
 
@@ -310,11 +311,11 @@ def test_calculate_cluster_spatial_enrichment():
     # Extract the p-values and z-scores of the distance of marker 1 vs marker 2 for no enrichment
     # as tested against a random set of distances between centroids
     assert stats_no_enrich.loc["Point8", "p_pos", "Pheno1", "Pheno2"] > .05
-    assert stats_no_enrich.loc["Point8", "p_pos", "Pheno1", "Pheno2"] > .05
+    assert stats_no_enrich.loc["Point8", "p_neg", "Pheno1", "Pheno2"] > .05
     assert abs(stats_no_enrich.loc["Point8", "z", "Pheno1", "Pheno2"]) < 2
 
     assert stats_no_enrich.loc["Point8", "p_pos", "Pheno2", "Pheno1"] > .05
-    assert stats_no_enrich.loc["Point8", "p_pos", "Pheno2", "Pheno1"] > .05
+    assert stats_no_enrich.loc["Point8", "p_neg", "Pheno2", "Pheno1"] > .05
     assert abs(stats_no_enrich.loc["Point8", "z", "Pheno2", "Pheno1"]) < 2
 
 

--- a/ark/analysis/spatial_analysis_test.py
+++ b/ark/analysis/spatial_analysis_test.py
@@ -19,7 +19,7 @@ def _make_distance_matrix(enrichment_type, dist_lim):
 
     if enrichment_type == "none":
         # Create a 60 x 60 euclidian distance matrix of random values for no enrichment
-        np.random.seed(42) # because the meaning of life ;-)
+        np.random.seed(42)
         rand_mat = np.random.randint(0, 200, size=(60, 60))
         np.fill_diagonal(rand_mat[:, :], 0)
 


### PR DESCRIPTION
The no enrichment cases for channel and cluster enrichment currently rely on a completely random generation of an array, which can cause the p-values and especially the z-scores to fail. For now, adding a random seed for that test will do the trick.

Duplicate tests for no enrichment also appeared, so we'll need to update those to test for p_neg (which was missing).

I still think it would be useful to implement a smarter way to randomly generate no_enrich tests in the near future without having to set a random seed, but for now, this should do the trick.