### PR TITLE
Dedicated requirements file for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 
+# We add python path to enable testing jupyter notebooks
 install:
   - pip install -r requirements.txt
-  - pip install pytest==5.2.0 pytest-cov==2.5.1 pytest-pep8 coveralls
+  - pip install -r requirements-test.txt
   - export PYTHONPATH=$PWD
-  - echo $PYTHONPATH
 
 env:
   - MPLBACKEND=Agg

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest==5.2.0
+pytest-cov==2.5.1
+pytest-pep8
+coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,7 @@ scikit-image==0.16.2
 scikit-learn==0.21.2
 scipy==1.2.1
 xarray==0.12.3
-pytest==5.3.2
 netCDF4==1.5.3
-#ipykernel==5.1.3
 h5py==2.10.0
 tables==3.6.1
 jupyter>=1.0.0,<2


### PR DESCRIPTION
Consolidates all of the relevant test dependencies into a separate requirements-test.txt file. This makes it simpler to install locally, and avoids having to specify each in the .travis.yml file. 