### PR TITLE
Extraction bugfix

### DIFF
--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -23,7 +23,7 @@ def compute_marker_counts(input_images, segmentation_masks, nuclear_counts=False
             marker_counts (xarray): xarray containing segmented data of cells x markers
     """
 
-    unique_cell_num = len(np.unique(segmentation_masks.values).astype('int'))
+    unique_cell_ids = np.unique(segmentation_masks[..., 0].values)
 
     # define morphology properties to be extracted from regionprops
     object_properties = ["label", "area", "eccentricity", "major_axis_length",
@@ -34,12 +34,12 @@ def compute_marker_counts(input_images, segmentation_masks, nuclear_counts=False
                                     object_properties[:-1]), axis=None)
 
     # create np.array to hold compartment x cell x feature info
-    marker_counts_array = np.zeros((len(segmentation_masks.compartments), unique_cell_num,
+    marker_counts_array = np.zeros((len(segmentation_masks.compartments), len(unique_cell_ids),
                                     len(feature_names)))
 
     marker_counts = xr.DataArray(copy.copy(marker_counts_array),
                                  coords=[segmentation_masks.compartments,
-                                         np.unique(segmentation_masks.values).astype('int'),
+                                         unique_cell_ids.astype('int'),
                                          feature_names],
                                  dims=['compartments', 'cell_id', 'features'])
 
@@ -95,10 +95,10 @@ def compute_marker_counts(input_images, segmentation_masks, nuclear_counts=False
                 nuc_features = np.concatenate((nuc_counts, current_nuc_props), axis=None)
 
                 # add counts of each marker to appropriate column
-                marker_counts.loc['nuclear', nuc_id, marker_counts.features[1]:] = nuc_features
+                marker_counts.loc['nuclear', cell_id, marker_counts.features[1]:] = nuc_features
 
                 # add cell size to first column
-                marker_counts.loc['nuclear', nuc_id, marker_counts.features[0]] = \
+                marker_counts.loc['nuclear', cell_id, marker_counts.features[0]] = \
                     nuc_coords.shape[0]
 
     return marker_counts

--- a/ark/segmentation/marker_quantification_test.py
+++ b/ark/segmentation/marker_quantification_test.py
@@ -193,15 +193,25 @@ def test_generate_expression_matrix_multiple_compartments():
         channel_data,
         nuclear_counts=True)
 
+    # 7 total cells
     assert normalized.shape[0] == 7
 
+    # channel 0 has a constant value of 1
     assert np.all(normalized['chan0'] == np.repeat(1, len(normalized)))
-    assert np.all(normalized['chan1'] == np.repeat(5, len(normalized)))
-    assert np.all(normalized['chan2'] == normalized['chan2'])
 
-    # check that missing nucleus has size 0
+    # channel 1 has a constant value of 5
+    assert np.all(normalized['chan1'] == np.repeat(5, len(normalized)))
+
+    # these two channels should be equal for all cells
+    assert np.all(normalized['chan1'] == normalized['chan2'])
+
+    # check that cell with missing nucleus has size 0
     index = np.logical_and(normalized['label'] == 2, normalized['fov'] == 'Point0')
     assert normalized.loc[index, 'cell_size_nuclear'].values == 0
+
+    # check that correct nuclear label is assigned to all cells
+    normalized_with_nuc = normalized.loc[normalized['label'] != 2, ['label', 'label_nuclear']]
+    assert np.all(normalized_with_nuc['label'] * 2 == normalized_with_nuc['label_nuclear'])
 
 
 def test_compute_complete_expression_matrices():

--- a/ark/segmentation/marker_quantification_test.py
+++ b/ark/segmentation/marker_quantification_test.py
@@ -54,7 +54,7 @@ def test_compute_marker_counts():
     assert np.all(segmentation_output.loc['whole_cell', :, 'chan4'][3:] == 0)
 
     # check that cell sizes are correct
-    sizes = [np.sum(cell_mask == cell_id) for cell_id in [1, 2, 3, 4]]
+    sizes = [np.sum(cell_mask == cell_id) for cell_id in [1, 2, 3, 5]]
     assert np.array_equal(sizes, segmentation_output.loc['whole_cell', 1:, 'cell_size'])
 
     # check that regionprops size matches with cell size
@@ -116,7 +116,7 @@ def test_compute_marker_counts():
     assert np.all(segmentation_output_unequal.loc['nuclear', :, 'chan4'][3:] == 0)
 
     # check that cell sizes are correct
-    sizes = [np.sum(nuc_mask == cell_id) for cell_id in [1, 2, 3, 4]]
+    sizes = [np.sum(nuc_mask == cell_id) for cell_id in [1, 2, 3, 5]]
     assert np.array_equal(sizes, segmentation_output_unequal.loc['nuclear', 1:, 'cell_size'])
 
     assert np.array_equal(segmentation_output_unequal.loc['nuclear', 1:, 'cell_size'],
@@ -174,6 +174,9 @@ def test_generate_expression_matrix_multiple_compartments():
 
     # cell 2 in fov0 has no nucleus
     nuc_masks[0, nuc_masks[0, :, :, 0] == 2, 0] = 0
+
+    # all of the nuclei have a label that is 2x the label of the corresponding cell
+    nuc_masks *= 2
 
     unequal_masks = np.concatenate((cell_masks, nuc_masks), axis=-1)
     coords = [["Point0", "Point1"], range(40), range(40), ['whole_cell', 'nuclear']]

--- a/ark/utils/segmentation_utils_test.py
+++ b/ark/utils/segmentation_utils_test.py
@@ -12,7 +12,7 @@ def _create_test_extraction_data():
     cell_mask[4:10, 4:10] = 1
     cell_mask[15:25, 20:30] = 2
     cell_mask[27:32, 3:28] = 3
-    cell_mask[35:40, 15:22] = 4
+    cell_mask[35:40, 15:22] = 5
 
     # then create channels data
     channel_data = np.zeros((40, 40, 5), dtype="int16")


### PR DESCRIPTION
This closes #175. The wrong index was being passed for the nuclear compartment. Because our test data was essentially identical between nuclear IDs and cell_ids, this wasn't caught. I fixed the indexing issue, and modified the test data so that it is passed different values for cell and nuclear labels, which can then be compared to make sure the assignment was done correctly. 