### PR TITLE
Stitching test functions

### DIFF
--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -518,6 +518,16 @@ def combine_point_directories(dir_path):
 
 
 def stitch_images(data_xr, num_cols):
+    """
+    Combines the results of images from data_xr into one xarray
+
+    Args:
+        data_xr (xr.DataArray): xarray containing nuclear and membrane channels over many fovs
+        num_cols (int): number of columns in the data array
+
+    Returns:
+        stitched_xr (xr.DataArray): the result of stitching of data_xr
+    """
     num_imgs = data_xr.shape[0]
     num_rows = math.ceil(num_imgs / num_cols)
     row_len = data_xr.shape[1]
@@ -545,6 +555,21 @@ def stitch_images(data_xr, num_cols):
 
 
 def split_img_stack(stack_dir, output_dir, stack_list, indices, names, channels_first=True):
+    """
+    Splits the channels in a given directory of images into separate files
+
+    Args:
+        stack_dir (str): where we read the input files
+        output_dir (str): where we write the split channel data
+        stack_list: the names of the files we want to read from stack_dir
+        indices (list): the indices we want to pull data from
+        names (list): the corresponding names of the channels
+        channel_first (bool): whether we index at the beginning or end of the array
+
+    Returns:
+        Saved images in the output_dir
+    """
+
     for stack_name in stack_list:
         img_stack = io.imread(os.path.join(stack_dir, stack_name))
         img_dir = os.path.join(output_dir, os.path.splitext(stack_name)[0])

--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -519,14 +519,14 @@ def combine_point_directories(dir_path):
 
 def stitch_images(data_xr, num_cols):
     """
-    Combines the results of images from data_xr into one xarray
+    Stitch together a stack of different channels from different FOVs into a single 2D image for each channel
 
     Args:
-        data_xr (xr.DataArray): xarray containing nuclear and membrane channels over many fovs
-        num_cols (int): number of columns in the data array
+        data_xr (xr.DataArray): xarray containing image data from multiple fovs and channels
+        num_cols (int): number of images stitched together horizontally
 
     Returns:
-        stitched_xr (xr.DataArray): the result of stitching of data_xr
+        stitched_xr (xr.DataArray): the stitched image data
     """
     num_imgs = data_xr.shape[0]
     num_rows = math.ceil(num_imgs / num_cols)
@@ -561,13 +561,13 @@ def split_img_stack(stack_dir, output_dir, stack_list, indices, names, channels_
     Args:
         stack_dir (str): where we read the input files
         output_dir (str): where we write the split channel data
-        stack_list: the names of the files we want to read from stack_dir
+        stack_list (list): the names of the files we want to read from stack_dir
         indices (list): the indices we want to pull data from
         names (list): the corresponding names of the channels
         channel_first (bool): whether we index at the beginning or end of the array
 
     Returns:
-        Saved images in the output_dir
+        None: images are saved in the output_dir
     """
 
     for stack_name in stack_list:

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -482,19 +482,19 @@ def test_combine_point_directories():
 
 
 def test_stitch_images():
-    fovs = ['fov1', 'fov2']
+    fovs = ['fov' + str(i) for i in range(40)]
     chans = ['nuc1', 'nuc2', 'mem1', 'mem2']
 
-    img_data = np.ones((2, 10, 10, 4), dtype="int16")
+    img_data = np.ones((40, 10, 10, 4), dtype="int16")
     img_data[0, :, :, 1] += 1
     img_data[0, :, :, 3] += 2
 
     data_xr = xr.DataArray(img_data, coords=[fovs, range(10), range(10), chans],
                            dims=["fovs", "rows", "cols", "channels"])
 
-    stitched_xr = data_utils.stitch_images(data_xr, data_xr.shape[2])
+    stitched_xr = data_utils.stitch_images(data_xr, 5)
 
-    assert stitched_xr.shape[2] == 10 * 10
+    assert stitched_xr.shape == (1, 40 / 5 * 10, 40 / 8 * 10, 4)
 
 
 def test_split_img_stack():

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -474,11 +474,6 @@ def test_combine_point_directories():
         os.mkdir(os.path.join(temp_dir, "test", "subdir1", "point1"))
         os.mkdir(os.path.join(temp_dir, "test", "subdir2", "point2"))
 
-        # junk_img = np.zeros((1024, 1024, 3))
-
-        # io.imsave(os.path.join(temp_dir, "test", "subdir1", "point1"), junk_img)
-        # io.imsave(os.path.join(temp_dir, "test", "subdir2", "point2"), junk_img)
-
         data_utils.combine_point_directories(os.path.join(temp_dir, "test"))
 
         assert os.path.exists(os.path.join(temp_dir, "test", "combined_folder"))

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -517,6 +517,12 @@ def test_split_img_stack():
         assert os.path.exists(os.path.join(output_dir, "channel_data", "chan1.tiff"))
         assert os.path.exists(os.path.join(output_dir, "channel_data", "chan2.tiff"))
 
+        sample_chan_1 = io.imread(os.path.join(output_dir, "channel_data", "chan1.tiff"))
+        sample_chan_2 = io.imread(os.path.join(output_dir, "channel_data", "chan2.tiff"))
+
+        assert sample_chan_1.shape == (1024, 1024, 2)
+        assert sample_chan_2.shape == (1024, 1024, 2)
+
         # now overwrite old channel_data.jpg file and test channel_first=True
         junk_img_chan_first = np.zeros((3, 1024, 1024))
         io.imsave(os.path.join(stack_dir, "channel_data.tiff"), junk_img_chan_first)
@@ -528,3 +534,9 @@ def test_split_img_stack():
 
         assert os.path.exists(os.path.join(output_dir, "channel_data", "chan1.tiff"))
         assert os.path.exists(os.path.join(output_dir, "channel_data", "chan2.tiff"))
+
+        sample_chan_1 = io.imread(os.path.join(output_dir, "channel_data", "chan1.tiff"))
+        sample_chan_2 = io.imread(os.path.join(output_dir, "channel_data", "chan2.tiff"))
+
+        assert sample_chan_1.shape == (2, 1024, 1024)
+        assert sample_chan_2.shape == (2, 1024, 1024)

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -501,42 +501,42 @@ def test_split_img_stack():
     with tempfile.TemporaryDirectory() as temp_dir:
         stack_dir = os.path.join(temp_dir, "stack_sample")
         output_dir = os.path.join(temp_dir, "output_sample")
-        stack_list = ["channel_data.tiff"]
+        stack_list = ["channel_data.tif"]
         indices = [0, 1]
-        names = ["chan1.tiff", "chan2.tiff"]
+        names = ["chan1.tif", "chan2.tif"]
 
         os.mkdir(os.path.join(temp_dir, "stack_sample"))
         os.mkdir(os.path.join(temp_dir, "output_sample"))
 
         # first test channel_first=False
-        junk_img_chan_last = np.zeros((1024, 1024, 3))
-        io.imsave(os.path.join(stack_dir, "channel_data.tiff"), junk_img_chan_last)
+        junk_img_chan_last = np.zeros((1024, 1024, 10))
+        io.imsave(os.path.join(stack_dir, "channel_data.tif"), junk_img_chan_last)
 
         data_utils.split_img_stack(stack_dir, output_dir, stack_list, indices, names, channels_first=False)
 
-        assert os.path.exists(os.path.join(output_dir, "channel_data", "chan1.tiff"))
-        assert os.path.exists(os.path.join(output_dir, "channel_data", "chan2.tiff"))
+        assert os.path.exists(os.path.join(output_dir, "channel_data", "chan1.tif"))
+        assert os.path.exists(os.path.join(output_dir, "channel_data", "chan2.tif"))
 
-        sample_chan_1 = io.imread(os.path.join(output_dir, "channel_data", "chan1.tiff"))
-        sample_chan_2 = io.imread(os.path.join(output_dir, "channel_data", "chan2.tiff"))
+        sample_chan_1 = io.imread(os.path.join(output_dir, "channel_data", "chan1.tif"))
+        sample_chan_2 = io.imread(os.path.join(output_dir, "channel_data", "chan2.tif"))
 
-        assert sample_chan_1.shape == (1024, 1024, 2)
-        assert sample_chan_2.shape == (1024, 1024, 2)
+        assert sample_chan_1.shape == (1024, 1024)
+        assert sample_chan_2.shape == (1024, 1024)
 
         # now overwrite old channel_data.jpg file and test channel_first=True
-        junk_img_chan_first = np.zeros((3, 1024, 1024))
-        io.imsave(os.path.join(stack_dir, "channel_data.tiff"), junk_img_chan_first)
+        junk_img_chan_first = np.zeros((10, 1024, 1024))
+        io.imsave(os.path.join(stack_dir, "channel_data.tif"), junk_img_chan_first)
 
         # clear the original channel_data directory so an error doesn't get thrown trying to recreate it
         rmtree(os.path.join(output_dir, "channel_data"))
 
-        data_utils.split_img_stack(stack_dir, output_dir, stack_list, indices, names)
+        data_utils.split_img_stack(stack_dir, output_dir, stack_list, indices, names, channels_first=True)
 
-        assert os.path.exists(os.path.join(output_dir, "channel_data", "chan1.tiff"))
-        assert os.path.exists(os.path.join(output_dir, "channel_data", "chan2.tiff"))
+        assert os.path.exists(os.path.join(output_dir, "channel_data", "chan1.tif"))
+        assert os.path.exists(os.path.join(output_dir, "channel_data", "chan2.tif"))
 
-        sample_chan_1 = io.imread(os.path.join(output_dir, "channel_data", "chan1.tiff"))
-        sample_chan_2 = io.imread(os.path.join(output_dir, "channel_data", "chan2.tiff"))
+        sample_chan_1 = io.imread(os.path.join(output_dir, "channel_data", "chan1.tif"))
+        sample_chan_2 = io.imread(os.path.join(output_dir, "channel_data", "chan2.tif"))
 
-        assert sample_chan_1.shape == (2, 1024, 1024)
-        assert sample_chan_2.shape == (2, 1024, 1024)
+        assert sample_chan_1.shape == (1024, 1024)
+        assert sample_chan_2.shape == (1024, 1024)


### PR DESCRIPTION
A few data_utils functions don't have test functions: combine_point_directories, stitch_images, and split_img_stack. Additionally, stitch_images and split_img_stack also don't have documentation. This PR addresses it and closes #71.