### PR TITLE
Make cell size normalization and arcsinh transformation clearer

### DIFF
--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -237,8 +237,8 @@ def compute_complete_expression_matrices(segmentation_labels, tiff_dir, img_sub_
     cohort_len = len(points)
 
     # create the final dfs to store the processed data
-    combined_normalized_data = pd.DataFrame()
-    combined_transformed_data = pd.DataFrame()
+    combined_cell_size_normalized_data = pd.DataFrame()
+    combined_arcsinh_transformed_data = pd.DataFrame()
 
     # iterate over all the batches
     for batch_names, batch_files in zip(
@@ -258,13 +258,13 @@ def compute_complete_expression_matrices(segmentation_labels, tiff_dir, img_sub_
         current_labels = segmentation_labels.loc[batch_names, :, :, :]
 
         # segment the imaging data
-        normalized_data, transformed_data = generate_expression_matrix(
+        cell_size_normalized_data, arcsinh_transformed_data = generate_expression_matrix(
             segmentation_labels=current_labels,
             image_data=image_data
         )
 
         # now append to the final dfs to return
-        combined_normalized_data = combined_normalized_data.append(normalized_data)
-        combined_transformed_data = combined_transformed_data.append(transformed_data)
+        combined_cell_size_normalized_data = combined_cell_size_normalized_data.append(cell_size_normalized_data)
+        combined_arcsinh_transformed_data = combined_arcsinh_transformed_data.append(arcsinh_transformed_data)
 
-    return combined_normalized_data, combined_transformed_data
+    return combined_cell_size_normalized_data, combined_arcsinh_transformed_data

--- a/templates/Deepcell_Postprocessing.ipynb
+++ b/templates/Deepcell_Postprocessing.ipynb
@@ -149,8 +149,8 @@
    "metadata": {},
    "source": [
     "Returns:\n",
-    "* cell_size_normalized_data: computed by dividing the marker counts in segmentation_labels by their corresponding cell size, however, if the cell size is zero we leave the marker count as is\n",
-    "* arcsinh_transformed_data: the result of passing each value of cell_size_normalized_data * 100 through the arcsinh function, we add the multiplication of 100 to linearly scale the data beforehand"
+    "* cell_size_normalized_data: computed by dividing the marker counts in segmentation_labels by their corresponding cell size.\n",
+    "* arcsinh_transformed_data: first, linearly scale each value of cell_size_normalized_data by multiplying by 100. Then, pass the linearly scaled cell_size_normalized_data through the arcsinh function."
    ]
   },
   {
@@ -213,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/templates/Deepcell_Postprocessing.ipynb
+++ b/templates/Deepcell_Postprocessing.ipynb
@@ -153,7 +153,13 @@
     "# now extract the segmented imaging data to create normalized and transformed expression matrices\n",
     "# note that if you're loading your own dataset, please make sure all the imaging data is in the same folder\n",
     "# with each FOV given it's own folder and all FOVs having the same channels\n",
-    "combined_normalized_data, combined_transformed_data = \\\n",
+    "\n",
+    "# cell_size_normalized_data: computed by dividing the marker counts in segmentation_labels\n",
+    "# by their corresponding cell size, however, if the cell size is zero we leave the marker count as is\n",
+    "\n",
+    "# arcsinh_transformed_data: the result of passing each value of cell_size_normalized_data * 100 through the\n",
+    "# arcsinh function, we add the multiplication of 100 to linearly scale the data beforehand\n",
+    "combined_cell_size_normalized_data, combined_arcsinh_transformed_data = \\\n",
     "    marker_quantification.compute_complete_expression_matrices(segmentation_labels=segmentation_labels,\n",
     "                                                               tiff_dir=tiff_dir,\n",
     "                                                               img_sub_folder=\"TIFs\",\n",
@@ -183,8 +189,8 @@
    "outputs": [],
    "source": [
     "# save output as CSV\n",
-    "combined_normalized_data.to_csv(os.path.join(single_cell_dir, 'normalized_data.csv'), index=False)\n",
-    "combined_transformed_data.to_csv(os.path.join(single_cell_dir, 'transformed_data.csv'), index=False)"
+    "combined_cell_size_normalized_data.to_csv(os.path.join(single_cell_dir, 'cell_size_normalized_data.csv'), index=False)\n",
+    "combined_arcsinh_transformed_data.to_csv(os.path.join(single_cell_dir, 'arcsinh_transformed_data.csv'), index=False)"
    ]
   }
  ],
@@ -204,9 +210,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/templates/Deepcell_Postprocessing.ipynb
+++ b/templates/Deepcell_Postprocessing.ipynb
@@ -145,6 +145,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Returns:\n",
+    "* cell_size_normalized_data: computed by dividing the marker counts in segmentation_labels by their corresponding cell size, however, if the cell size is zero we leave the marker count as is\n",
+    "* arcsinh_transformed_data: the result of passing each value of cell_size_normalized_data * 100 through the arcsinh function, we add the multiplication of 100 to linearly scale the data beforehand"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -153,12 +162,6 @@
     "# now extract the segmented imaging data to create normalized and transformed expression matrices\n",
     "# note that if you're loading your own dataset, please make sure all the imaging data is in the same folder\n",
     "# with each FOV given it's own folder and all FOVs having the same channels\n",
-    "\n",
-    "# cell_size_normalized_data: computed by dividing the marker counts in segmentation_labels\n",
-    "# by their corresponding cell size, however, if the cell size is zero we leave the marker count as is\n",
-    "\n",
-    "# arcsinh_transformed_data: the result of passing each value of cell_size_normalized_data * 100 through the\n",
-    "# arcsinh function, we add the multiplication of 100 to linearly scale the data beforehand\n",
     "combined_cell_size_normalized_data, combined_arcsinh_transformed_data = \\\n",
     "    marker_quantification.compute_complete_expression_matrices(segmentation_labels=segmentation_labels,\n",
     "                                                               tiff_dir=tiff_dir,\n",
@@ -210,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Addresses and closes #120.

The current variable names are not that descriptive when it comes to cell size normalization and arcsinh transformation. We've gotten several questions from others about what exactly normalization and transformation meant. Renaming the variables and adding some more comments should do the trick.