### PR TITLE
Remove nbsphinx from conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,9 +56,7 @@ extensions = ['IPython.sphinxext.ipython_console_highlighting', # syntax-highlig
               'sphinx.ext.napoleon', # support for Google style docstrings (STAR)
               'sphinx.ext.todo', # support fo TODO
               'sphinx.ext.viewcode', # support for adding links to highlighted source code, looks at Python object descriptions and tries to find source files where objects are contained
-              'm2r2', # allows you to include Markdown files in .rst, use mdinclude for this, choosing this over m2r because m2r is not supported anymore
-              'nbsphinx', # support for Jupyter notebooks (STAR)
-              'nbsphinx_link'] # include notebook files from outside sphinx src root (STAR)]
+              'm2r2'] # allows you to include Markdown files in .rst, use mdinclude for this, choosing this over m2r because m2r is not supported anymore
 
 # set parameter to read Google docstring and not NumPy
 # redundant to add since it's default True but good to know

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ h5py==2.10.0
 jupyter>=1.0.0,<2
 jupyter_contrib_nbextensions==0.5.1
 matplotlib==2.2.2
-git+git://github.com/ionpath/mibitracker-client@v1.2.6
+git+git://github.com/ionpath/mibilib@v1.2.6
 netCDF4==1.5.3
 numpy==1.16.3
 pandas==0.24.2


### PR DESCRIPTION
**What is the purpose of this PR?**

The most recent readthedocs config for some reason throws a color error with the nbsphinx extension. We won't be needing Jupyter notebook support for our .md files anyways, so we'll need to delete them.

**How did you implement your changes**

Change the extensions variable in conf.py to not include nbsphinx and nbsphinx_link.
