### PR TITLE
Binning nuclear labels

### DIFF
--- a/ark/utils/segmentation_utils.py
+++ b/ark/utils/segmentation_utils.py
@@ -39,15 +39,15 @@ def split_large_nuclei(cell_segmentation_mask, nuc_segmentation_mask, cell_ids):
     """Splits nuclei that are bigger than the corresponding cell into multiple pieces
 
     Args:
-        cell_segmentation_mask (np.ndarray):
+        cell_segmentation_mask (numpy.ndarray):
             mask of cell segmentations
-        nuc_segmentation_mask (np.ndarray):
+        nuc_segmentation_mask (numpy.ndarray):
             mask of nuclear segmentations
-        cell_ids (np.ndarray):
+        cell_ids (numpy.ndarray):
             the unique cells in the segmentation mask
 
     Returns:
-        np.ndarray:
+        numpy.ndarray:
             modified nuclear segmentation mask
     """
 
@@ -63,19 +63,16 @@ def split_large_nuclei(cell_segmentation_mask, nuc_segmentation_mask, cell_ids):
         nuc_id = find_nuclear_mask_id(nuc_segmentation_mask=nuc_segmentation_mask,
                                       cell_coords=coords)
 
-        if nuc_id is None:
-            # no nucleus found within this cell
-            pass
-        else:
+        # only proceed if there's a valid nuc_id
+        if nuc_id is not None:
             # figure out if nuclear label is completely contained within cell label
             cell_vals = nuc_segmentation_mask[tuple(coords.T)]
             nuc_count = np.sum(cell_vals == nuc_id)
 
             nuc_mask = nuc_segmentation_mask == nuc_id
-            if nuc_count == np.sum(nuc_mask):
-                # nucleus is contained within the cell
-                pass
-            else:
+
+            # only proceed if parts of the nucleus are outside of the cell
+            if nuc_count != np.sum(nuc_mask):
                 # relabel nuclear counts within the cell
                 cell_mask = cell_segmentation_mask == cell
                 new_nuc_mask = np.logical_and(cell_mask, nuc_mask)


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://github.com/angelolab/ark-analysis/tree/master/docs/contributing.md) before opening your PR**

**What is the purpose of this PR?**
Currently, when we match nuclei to cells, we don't require that the nucleus be smaller than the cell. If the nuclear segmentation has errors, this can result in non-biological readouts. 

This PR adds the option to separate out nuclei that are larger than a cell, and relabel the portion that falls within a cell, to remove this issue

**How did you implement your changes**
Added a function that takes a nuclear mask and a cell mask, and relabels any nuclei that have pixels outside of the boundaries of the corresponding cell they map to. 

**Remaining issues**

Still need to integrate this into the overall segmentation pipeline
