### PR TITLE
Bump version number to 0.2.4 (prepare initial deployment)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from os import path
 from setuptools import setup, find_packages
 
-VERSION = '1.0.0'
+VERSION = '0.2.4'
 
 # set a long description which is basically the README
 with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
@@ -39,5 +39,8 @@ setup(
     },
     long_description=long_description,
     long_description_content_type='text/markdown',
-    classifiers=['Programming Language :: Python :: 3.6']
+    classifiers=['License :: OSI Approved :: Apache Software License',
+                 'Development Status :: 4 - Beta',
+                 'Programming Language :: Python :: 3',
+                 'Programming Language :: Python :: 3.6']
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
 
 setup(
     name='ark',
-    version='0.2.3',
+    version='1.0.0',
     packages=find_packages(),
     license='Modified Apache License 2.0',
     description='Toolbox for analysis on segmented images from MIBI',

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,21 @@
 from os import path
 from setuptools import setup, find_packages
 
+VERSION = '1.0.0'
+
 # set a long description which is basically the README
 with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
     long_description = f.read()
 
 setup(
     name='ark',
-    version='1.0.0',
+    version=VERSION,
     packages=find_packages(),
     license='Modified Apache License 2.0',
     description='Toolbox for analysis on segmented images from MIBI',
     author='Angelo Lab',
     url='https://github.com/angelolab/ark-analysis',
+    download_url='https://github.com/angelolab/ark-analysis/archive/{}.tar.gz'.format(VERSION),
     install_requires=['h5py',
                       'jupyter',
                       'jupyter_contrib_nbextensions',


### PR DESCRIPTION
**What is the purpose of this PR?**

Now that we've actually set up .travis.yml to deploy to PyPI, we now need to officially send a release to PyPI so our package will be able to be downloaded via pip.

**How did you implement your changes**

- Bump the version number to 1.0.0
- Separate the version number into a constant in `setup.py` so it can be easily located and updated when needed
- Add a `download_url` param in `setup.py` which points to the .tar.gz file generated on a new release, this file needs to be created separately by opening a new release on the repo

**Remaining issues**

- Make sure to tag this commit on merge into master. We should tag this commit with the version number. So in this case, the tag associated with this commit should be 1.0.0.
- Remember: to officially make this release open to the public, we also need to open a new release on GitHub so PyPI points to the correct download link (and one that actually exists).
- If deployment works, we're good to go!
- If not, then I'll open a separate debugging PR
- We need to update our documentation/`README` so users know they can `pip install ark-analysis`.
- We may need a separate PR to address any issues that come up with the pip installation of ark-analysis.
- `setup.py` will need frequent updates. For example, if new libraries are added, they need to be appended to the `install_requires` param list. Also, if we begin to support more Python versions in the future, the `classifiers` list also needs to be updated.
