### PR TITLE
Fix name in setup call of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from os import path
 from setuptools import setup, find_packages
 
-VERSION = '0.2.5'
+VERSION = '0.2.6'
 
 
 def _parse_requirements(file_path):
@@ -21,7 +21,7 @@ except Exception:
     install_reqs = []
 
 setup(
-    name='ark',
+    name='ark-analysis',
     version=VERSION,
     packages=find_packages(),
     license='Modified Apache License 2.0',


### PR DESCRIPTION
**What is the purpose of this PR?**

The reason our PyPI project is still not deploying correctly is that the `name` argument in the call to `setup` of `setup.py` is incorrect. Currently, it is set to `'ark'`, which sadly, is already taken as a name on PyPI. This is why we got a 403 error on our last merge into master: we obviously didn't have the credentials to release a new version to that project.

**How did you implement your changes**

We need to change `name` to `'ark-analysis'` because that's the name of our project on PyPI. Also, bump the version number so nothing conflicts.

**Remaining issues**

If you're curious what `ark` is on PyPI, see this: https://pypi.org/project/ark/. It was a static website generator. However, it seems like the repo no longer exists. Aww, I wanted to see it so bad...
