### PR TITLE
Add virtual environment documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y gcc
 
 WORKDIR /scripts
 
-# copy over the requirements.txt and install dependencies
-COPY setup.py requirements.txt /opt/ark-analysis/
+# copy over the requirements.txt, install dependencies, and README
+COPY setup.py requirements.txt README.md /opt/ark-analysis/
 RUN pip install -r /opt/ark-analysis/requirements.txt
 
 # copy the scripts over

--- a/docs/_rtd/virtualenv.md
+++ b/docs/_rtd/virtualenv.md
@@ -20,11 +20,12 @@ Say yes to any prompts and your `conda` environment will be created!
  
 To verify installation, activate your `conda` environment with `conda activate <my_env>`. If you see `(<my_env>)` on the far left of the command prompt, you have successfully created and activated your environment. Type `conda deactivate` to exit at any time.
 
-### Installing packages
+### Setting up ark-analysis
 
-Inside your `conda` environment, you will need to run `pip install ark-analysis` to gain access to our repo. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library. For detailed explanations of the functions available to you, please look at the Libraries section of this documentation. 
+Inside your `conda` environment, you will need to run `pip install ark-analysis` to gain access to our repo. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library by running `import ark`. For detailed explanations of the functions available to you, please look at the Libraries section of this documentation. 
 
 `ark` relies on several other Python packages. Inside the `ark-analysis` repo (if you don't have it, first run `git clone https://github.com/angelolab/ark-analysis.git`), and with your virtual environment activated, you will need to install these other dependencies as well. Run `pip install -r requirements.txt` to do so. 
  
 Note that you will not have access to `ark` or the other libraries inside `requirements.txt` outside of this virtual environment. 
 
+You're now set to start working with `ark-analysis`!

--- a/docs/_rtd/virtualenv.md
+++ b/docs/_rtd/virtualenv.md
@@ -28,6 +28,6 @@ Note that you will not have access to `ark` or the other libraries inside `requi
  
 You're now set to start working with `ark-analysis`! Please look at [our contributing guidelines](contributing.md) for more information about development. For detailed explanations of the functions available to you in `ark`, please consult the Libraries section of this documentation. 
 
-### Using ark-analysis directly
+### Using ark functions directly
 
 If you will only be using functions in `ark` without developing on top of it, do not clone the repo. Simply run `pip install ark-analysis` to gain access to our functions. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library by running `import ark`. 

--- a/docs/_rtd/virtualenv.md
+++ b/docs/_rtd/virtualenv.md
@@ -1,6 +1,6 @@
 ## Setting Up Your Virtual Environment
 
-If you wish to do higher-level development on top of `ark`, we recommend setting up a virtual environment. We highly recommend using `conda` virtual environments. To be able ot set one up, you will need to install the Anaconda package.
+If you wish to do higher-level development on top of `ark`, we recommend setting up a virtual environment. We highly recommend using `conda` virtual environments. To be able to set one up, you will need to install the Anaconda package.
 
 ### Installing Anaconda
 

--- a/docs/_rtd/virtualenv.md
+++ b/docs/_rtd/virtualenv.md
@@ -22,7 +22,7 @@ To verify installation, activate your `conda` environment with `conda activate <
 
 ### Installing ark
 
-Inside your `conda` environment, you will need to run `pip install ark-analysis` to gain access to our repo. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library. For detailed explanations of the functions available to you, please look at the `Library` section of this documentation. 
+Inside your `conda` environment, you will need to run `pip install ark-analysis` to gain access to our repo. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library. For detailed explanations of the functions available to you, please look at the Libraries section of this documentation. 
  
 Note that you will not have access to `ark` outside of this virtual environment. 
 

--- a/docs/_rtd/virtualenv.md
+++ b/docs/_rtd/virtualenv.md
@@ -30,4 +30,5 @@ You're now set to start working with `ark-analysis`! Please look at [our contrib
 
 ### Using ark functions directly
 
-If you will only be using functions in `ark` without developing on top of it, do not clone the repo. Simply run `pip install ark-analysis` to gain access to our functions. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library by running `import ark`. 
+If you will only be using functions in `ark` without developing on top of it, do not clone the repo. Simply run `pip install ark-analysis` to gain access to our functions. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library by running `import ark`.
+ 

--- a/docs/_rtd/virtualenv.md
+++ b/docs/_rtd/virtualenv.md
@@ -14,7 +14,7 @@ We recommend using the graphical installer for ease of use.
 
 Now that Anaconda is installed, you can now create a `conda` environment. 
  
-To do so, on your command line, type `conda create -n <my_env> python=3.6`, where `<my_env>` is a name you set. We highly recommend setting `python=3.6` because this is the version of Python our code uses. 
+To do so, on your command line, type `conda create -n <my_env> python=3.6`, where `<my_env>` is a name you set. Our codebase only supports Python 3.6, so please do not change the `python=3.6` flag when creating your environment. 
  
 Say yes to any prompts and your `conda` environment will be created! 
  

--- a/docs/_rtd/virtualenv.md
+++ b/docs/_rtd/virtualenv.md
@@ -20,12 +20,14 @@ Say yes to any prompts and your `conda` environment will be created!
  
 To verify installation, activate your `conda` environment with `conda activate <my_env>`. If you see `(<my_env>)` on the far left of the command prompt, you have successfully created and activated your environment. Type `conda deactivate` to exit at any time.
 
-### Setting up ark-analysis
-
-Inside your `conda` environment, you will need to run `pip install ark-analysis` to gain access to our repo. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library by running `import ark`. For detailed explanations of the functions available to you, please look at the Libraries section of this documentation. 
+### Setting up ark-analysis for development
 
 `ark` relies on several other Python packages. Inside the `ark-analysis` repo (if you don't have it, first run `git clone https://github.com/angelolab/ark-analysis.git`), and with your virtual environment activated, you will need to install these other dependencies as well. Run `pip install -r requirements.txt` to do so. 
  
 Note that you will not have access to `ark` or the other libraries inside `requirements.txt` outside of this virtual environment. 
+ 
+You're now set to start working with `ark-analysis`! Please look at [our contributing guidelines](contributing.md) for more information about development. For detailed explanations of the functions available to you in `ark`, please consult the Libraries section of this documentation. 
 
-You're now set to start working with `ark-analysis`!
+### Using ark-analysis directly
+
+If you will only be using functions in `ark` without developing on top of it, do not clone the repo. Simply run `pip install ark-analysis` to gain access to our functions. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library by running `import ark`. 

--- a/docs/_rtd/virtualenv.md
+++ b/docs/_rtd/virtualenv.md
@@ -1,3 +1,28 @@
 ## Setting Up Your Virtual Environment
 
-Add information about how to set up Anaconda.
+If you wish to do higher-level development on top of `ark`, we recommend setting up a virtual environment. We highly recommend using `conda` virtual environments. To be able ot set one up, you will need to install the Anaconda package.
+
+### Installing Anaconda
+
+For a step-by-step guide of how to install Anaconda, please refer to these links:
+* https://docs.anaconda.com/anaconda/install/mac-os/ for Mac users
+* https://docs.anaconda.com/anaconda/install/windows/ for Windows users
+
+We recommend using the graphical installer for ease of use.
+
+### Creating a virtual environment
+
+Now that Anaconda is installed, you can now create a `conda` environment. 
+ 
+To do so, on your command line, type `conda create -n <my_env> python=3.6`, where `<my_env>` is a name you set. We highly recommend setting `python=3.6` because this is the version of Python our code uses. 
+ 
+Say yes to any prompts and your `conda` environment will be created! 
+ 
+To verify installation, activate your `conda` environment with `conda activate <my_env>`. If you see `(<my_env>)` on the far left of the command prompt, you have successfully created and activated your environment. Type `conda deactivate` to exit at any time.
+
+### Installing ark
+
+Inside your `conda` environment, you will need to run `pip install ark-analysis` to gain access to our repo. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library. For detailed explanations of the functions available to you, please look at the `Library` section of this documentation. 
+ 
+Note that you will not have access to `ark` outside of this virtual environment. 
+

--- a/docs/_rtd/virtualenv.md
+++ b/docs/_rtd/virtualenv.md
@@ -20,9 +20,11 @@ Say yes to any prompts and your `conda` environment will be created!
  
 To verify installation, activate your `conda` environment with `conda activate <my_env>`. If you see `(<my_env>)` on the far left of the command prompt, you have successfully created and activated your environment. Type `conda deactivate` to exit at any time.
 
-### Installing ark
+### Installing packages
 
 Inside your `conda` environment, you will need to run `pip install ark-analysis` to gain access to our repo. To verify installation, type `conda list ark-analysis` after completion. If `ark-analysis` is listed, the installation was successful. You can now access the `ark` library. For detailed explanations of the functions available to you, please look at the Libraries section of this documentation. 
+
+`ark` relies on several other Python packages. Inside the `ark-analysis` repo (if you don't have it, first run `git clone https://github.com/angelolab/ark-analysis.git`), and with your virtual environment activated, you will need to install these other dependencies as well. Run `pip install -r requirements.txt` to do so. 
  
-Note that you will not have access to `ark` outside of this virtual environment. 
+Note that you will not have access to `ark` or the other libraries inside `requirements.txt` outside of this virtual environment. 
 


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses and closes #202. We add documentation for creating virtual environments and installing our package via `pip` now that it has been deployed to PyPI. This will provide a foundation for users with more technical expertise to use ark.

**How did you implement your changes**

Content is added to `docs/_rtd/virtualenv.md` to generate documentation on ReadTheDocs about virtual environment creation with a `conda` setup and a `pip` installation of `ark-analysis`.

**Remaining issues**

This PR may also need to address an issue which prevents all the `install_requires` packages in `setup.py` from installing on top of running `pip install ark-analysis`. We could get around this by simply listing in this page which additional packages need to be installed. What do you guys think?
