### PR TITLE
Remove documentation for test_utils.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,7 +185,7 @@ def run_apidoc(_):
     cmd_path = 'sphinx-apidoc'
 
     # do not generate any documentation for test files
-    ignore = '../ark/*/*_test.py'
+    ignore = '../ark/*/*test*.py'
 
     # should probably remove this
     if hasattr(sys, 'real_prefix'):


### PR DESCRIPTION
**What is the purpose of this PR?**

A very mini-PR to stop generating documentation for `test_utils.py`. Addresses and closes #251.

**How did you implement your changes**

We simply modify `conf.py` in `docs` to ignore every filename containing test in its name, not just those with a test suffix.

**Remaining issues**

If there are any other functions we don't want to generate documentation for, please feel free to let me know and we can address that in this PR too.