### PR TITLE
Fix calculation of p_pos in calcuate_enrichment_stats

### DIFF
--- a/ark/utils/spatial_analysis_utils.py
+++ b/ark/utils/spatial_analysis_utils.py
@@ -307,7 +307,7 @@ def calculate_enrichment_stats(close_num, close_num_rand):
             # Calculate z score based on distribution
             z[j, k] = (close_num[j, k] - muhat[j, k]) / sigmahat[j, k]
             # Calculate both positive and negative enrichment p values
-            p_pos[j, k] = (1 + (np.sum(tmp >= close_num[j, k]))) / (bootstrap_num + 1)
+            p_pos[j, k] = (1 + (np.sum(tmp > close_num[j, k]))) / (bootstrap_num + 1)
             p_neg[j, k] = (1 + (np.sum(tmp < close_num[j, k]))) / (bootstrap_num + 1)
 
     # Get fdh_br adjusted p values


### PR DESCRIPTION
**What is the purpose of this PR?**

A very basic PR to address a simple yet crucial bug in `calculate_enrichment_stats` where we change `p_pos` to strictly greater than in checking. Addresses and closes #129.

**How did you implement your changes**

We change `>=` to `>` in the calculation.
