### PR TITLE
Bump version number and ensure requirements.txt are installed properly on pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ install:
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r requirements-test.txt
   - travis_retry export PYTHONPATH=$PWD
+  # this is needed to install the requirements
+  - travis_retry python setup.py build_ext --inplace
 
 env:
   - MPLBACKEND=Agg

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - travis_retry pip install -r requirements-test.txt
   - travis_retry export PYTHONPATH=$PWD
   # this is needed to install the requirements
-  - travis_retry python setup.py build_ext --inplace
+  - travis_retry python setup.py install
 
 env:
   - MPLBACKEND=Agg

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ git:
 
 language: python
 
+python:
+  - 3.6
+
 # We add python path to enable testing jupyter notebooks
 install:
   - travis_retry pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os import path
 from distutils.command.build_ext import build_ext as DistUtilsBuildExt
 from setuptools import setup, find_packages
 
-VERSION = '0.3.6'
+VERSION = '0.2.7'
 VERSION_MIBILIB = '1.3.0'
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from distutils.command.build_ext import build_ext as DistUtilsBuildExt
 from setuptools import setup, find_packages
 
 VERSION = '0.3.6'
+VERSION_MIBILIB = '1.3.0'
 
 
 # define a parsing function for requirements.txt
@@ -25,38 +26,6 @@ except Exception as e:
     install_reqs = []
 
 
-# this mess is needed for numpy to build properly and to install the requirements
-class BuildExtension(setuptools.Command):
-    description = DistUtilsBuildExt.description
-    user_options = DistUtilsBuildExt.user_options
-    boolean_options = DistUtilsBuildExt.boolean_options
-    help_options = DistUtilsBuildExt.help_options
-
-    def __init__(self, *args, **kwargs):
-        from setuptools.command.build_ext import build_ext as SetupToolsBuildExt
-
-        # Bypass __setatrr__ to avoid infinite recursion.
-        self.__dict__['_command'] = SetupToolsBuildExt(*args, **kwargs)
-
-    def __getattr__(self, name):
-        return getattr(self._command, name)
-
-    def __setattr__(self, name, value):
-        setattr(self._command, name, value)
-
-    def initialize_options(self, *args, **kwargs):
-        return self._command.initialize_options(*args, **kwargs)
-
-    def finalize_options(self, *args, **kwargs):
-        ret = self._command.finalize_options(*args, **kwargs)
-        import numpy
-        self.include_dirs.append(numpy.get_include())
-        return ret
-
-    def run(self, *args, **kwargs):
-        return self._command.run(*args, **kwargs)
-
-
 setup(
     name='ark-analysis',
     version=VERSION,
@@ -66,9 +35,8 @@ setup(
     author='Angelo Lab',
     url='https://github.com/angelolab/ark-analysis',
     download_url='https://github.com/angelolab/ark-analysis/archive/v{}.tar.gz'.format(VERSION),
-    cmdclass={'build_ext': BuildExtension},
     install_requires=install_reqs,
-    setup_requires=['cython>=0.28', 'numpy>=1.16.3,<2'],
+    dependency_links=['http://github.com/ionpath/mibilib/archive/v{}.zip'.format(VERSION_MIBILIB)],
     extras_require={
         'tests': ['pytest',
                   'pytest-cov',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from os import path
+from distutils.command.build_ext import build_ext as DistUtilsBuildExt
 from setuptools import setup, find_packages
 
-VERSION = '0.2.6'
+VERSION = '0.3.6'
 
 
 # define a parsing function for requirements.txt
@@ -22,6 +23,39 @@ try:
 except Exception:
     install_reqs = []
 
+
+# this mess is needed for numpy to build properly and to install the requirements
+class BuildExtension(setuptools.Command):
+    description = DistUtilsBuildExt.description
+    user_options = DistUtilsBuildExt.user_options
+    boolean_options = DistUtilsBuildExt.boolean_options
+    help_options = DistUtilsBuildExt.help_options
+
+    def __init__(self, *args, **kwargs):
+        from setuptools.command.build_ext import build_ext as SetupToolsBuildExt
+
+        # Bypass __setatrr__ to avoid infinite recursion.
+        self.__dict__['_command'] = SetupToolsBuildExt(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._command, name)
+
+    def __setattr__(self, name, value):
+        setattr(self._command, name, value)
+
+    def initialize_options(self, *args, **kwargs):
+        return self._command.initialize_options(*args, **kwargs)
+
+    def finalize_options(self, *args, **kwargs):
+        ret = self._command.finalize_options(*args, **kwargs)
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+        return ret
+
+    def run(self, *args, **kwargs):
+        return self._command.run(*args, **kwargs)
+
+
 setup(
     name='ark-analysis',
     version=VERSION,
@@ -31,6 +65,7 @@ setup(
     author='Angelo Lab',
     url='https://github.com/angelolab/ark-analysis',
     download_url='https://github.com/angelolab/ark-analysis/archive/v{}.tar.gz'.format(VERSION),
+    cmdclass={'build_ext': BuildExtension},
     install_requires=install_reqs,
     extras_require={
         'tests': ['pytest',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
 # don't set install_reqs if we can't read requirements.txt
 try:
     install_reqs = _parse_requirements('requirements.txt')
-except Exception:
+except Exception as e:
     install_reqs = []
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import setuptools
 from os import path
 from distutils.command.build_ext import build_ext as DistUtilsBuildExt
 from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
     download_url='https://github.com/angelolab/ark-analysis/archive/v{}.tar.gz'.format(VERSION),
     cmdclass={'build_ext': BuildExtension},
     install_requires=install_reqs,
+    setup_requires=['cython>=0.28', 'numpy>=1.16.3,<2'],
     extras_require={
         'tests': ['pytest',
                   'pytest-cov',


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses #242. This PR may require more work after it is merged in because we can only see the final results after a merge into master.

Now that Omer has completely integrated deepcell with ark-analysis, we need to bump the version number. However, another issue needs to be addressed: running `pip install ark-analysis` will only install `ark-analysis`, but not any of the other dependencies.

**How did you implement your changes**

We use `deepcell-toolbox` as a guiding point for our changes.

**Remaining issues**

It seems like `deepcell-toolbox` specifically implemented some of their changes because they need to install `deepcell` as well. I'm not sure how much is actually applicable to us, it may potentially not work. If so, we'll need to open another PR to address the issues that come up.
