### PR TITLE
Fix marker ordering errors and verification for channel enrichment

### DIFF
--- a/ark/analysis/spatial_analysis.py
+++ b/ark/analysis/spatial_analysis.py
@@ -69,9 +69,6 @@ def calculate_channel_spatial_enrichment(dist_matrices_dict, marker_thresholds, 
     all_channel_data = all_data.drop(excluded_colnames, axis=1)
 
     # this will get refactored once the verification refactor PR gets merged in
-    # TODO: this is the really easy way to to this, but is it worth enforcing such strict
-    # guidelines (every marker present in marker_thresholds must be found in channel_titles
-    # and vice versa)
     if not np.all(set(marker_thresholds.iloc[:, 0]) == set(all_channel_data.columns)):
         raise ValueError(
             "The same markers must be found in marker thresholds and expression matrix columns"

--- a/ark/analysis/spatial_analysis.py
+++ b/ark/analysis/spatial_analysis.py
@@ -67,14 +67,22 @@ def calculate_channel_spatial_enrichment(dist_matrices_dict, marker_thresholds, 
 
     # Subsets the expression matrix to only have channel columns
     all_channel_data = all_data.drop(excluded_colnames, axis=1)
+
+    # this will get refactored once the verification refactor PR gets merged in
+    # TODO: this is the really easy way to to this, but is it worth enforcing such strict
+    # guidelines (every marker present in marker_thresholds must be found in channel_titles
+    # and vice versa)
+    if not np.all(set(marker_thresholds.iloc[:, 0]) == set(all_channel_data.columns)):
+        raise ValueError(
+            "The same markers must be found in marker thresholds and expression matrix columns"
+        )
+
+    # reorder all_channel_data's marker columns the same as they appear in marker_thresholds
+    all_channel_data = all_channel_data[marker_thresholds.iloc[:, 0].values]
     # List of all channels
     channel_titles = all_channel_data.columns
     # Length of channels list
     channel_num = len(channel_titles)
-
-    # Check to see if order of channel thresholds is same as in expression matrix
-    if not (list(marker_thresholds.iloc[:, 0]) == channel_titles).any():
-        raise ValueError("Threshold Markers do not match markers in Expression Matrix")
 
     # Create stats Xarray with the dimensions (fovs, stats variables, num_channels, num_channels)
     stats_raw_data = np.zeros((num_fovs, 7, channel_num, channel_num))

--- a/ark/analysis/spatial_analysis_test.py
+++ b/ark/analysis/spatial_analysis_test.py
@@ -100,10 +100,12 @@ def test_calculate_channel_spatial_enrichment():
                 bootstrap_num=100, dist_lim=dist_lim)
 
     with pytest.raises(ValueError):
-        # attempt to include marker thresholds that do not exist
-        bad_marker_thresholds = pd.DataFrame(np.zeros((20, 2)))
+        # attempt to include marker thresholds and marker columns that do not exist
+        bad_marker_thresholds = pd.DataFrame(np.zeros((21, 2)))
         bad_marker_thresholds.iloc[:, 1] = .5
-        bad_marker_thresholds.iloc[:, 0] = np.arange(10000, 10020) + 2
+        bad_marker_thresholds.iloc[:, 0] = np.arange(10, 31) + 2
+
+        all_data_no_enrich_bad = all_data_no_enrich.rename(columns={18: 200})
 
         _, stat_no_enrich = \
             spatial_analysis.calculate_channel_spatial_enrichment(

--- a/ark/utils/test_utils.py
+++ b/ark/utils/test_utils.py
@@ -640,7 +640,6 @@ def _make_threshold_mat(in_utils):
     thresh.iloc[:, 1] = .5
 
     if not in_utils:
-        # print(len(np.concatenate([np.arange(2, 14), np.arange(15, 23)])))
         thresh.iloc[:, 0] = np.concatenate([np.arange(2, 14), np.arange(15, 23)])
 
         # spatial analysis should still be correct regardless of the marker threshold ordering

--- a/ark/utils/test_utils.py
+++ b/ark/utils/test_utils.py
@@ -640,7 +640,11 @@ def _make_threshold_mat(in_utils):
     thresh.iloc[:, 1] = .5
 
     if not in_utils:
-        thresh.iloc[:, 0] = np.arange(20) + 2
+        # print(len(np.concatenate([np.arange(2, 14), np.arange(15, 23)])))
+        thresh.iloc[:, 0] = np.concatenate([np.arange(2, 14), np.arange(15, 23)])
+
+        # spatial analysis should still be correct regardless of the marker threshold ordering
+        thresh = thresh.sample(frac=1).reset_index(drop=True)
 
     return thresh
 


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses and closes #265. Also addresses and closes #266. We add a more robust method to verify that the markers in `all_channel_data` and `marker_thresholds` are the same between the two, and we ensure that they are ordered consistently as well. This only applies for channel enrichment.

**How did you implement your changes**

Use set equality to check if the markers are the same, and reindexing to enforce order.

**Remaining issues**

This is an extremely strict way of handling the various different types of `marker_thresholds` and `all_channel_data` values the user may pass in. From personal experience, expect all sorts of messes in this regard. This method may be a bit too strict, so I'm open to other ideas.
