### PR TITLE
Add empty list validation for mibitiff loading

### DIFF
--- a/ark/utils/load_utils.py
+++ b/ark/utils/load_utils.py
@@ -35,8 +35,14 @@ def load_imgs_from_mibitiff(data_dir, mibitiff_files=None, channels=None, delimi
             xarray with shape [fovs, x_dim, y_dim, channels]
     """
 
+    if not os.path.isdir(data_dir):
+        raise ValueError(f"Invalid value for data_dir. {data_dir} is not a directory.")
+
     if not mibitiff_files:
         mibitiff_files = iou.list_files(data_dir, substrs=['.tif'])
+
+    if len(mibitiff_files) == 0:
+        raise ValueError("No mibitiff files specified in the data directory %s" % data_dir)
 
     # extract fov names w/ delimiter agnosticism
     fovs = iou.extract_delimited_names(mibitiff_files, delimiter=delimiter)
@@ -99,6 +105,9 @@ def load_imgs_from_tree(data_dir, img_sub_folder=None, fovs=None, channels=None,
         xarray.DataArray:
             xarray with shape [fovs, x_dim, y_dim, tifs]
     """
+
+    if not os.path.isdir(data_dir):
+        raise ValueError(f"Invalid value for data_dir. {data_dir} is not a directory.")
 
     if fovs is None:
         # get all fovs
@@ -220,6 +229,7 @@ def load_imgs_from_dir(data_dir, files=None, delimiter=None, xr_dim_name='compar
                 * The length of xr_channel_names (if provided) does not match the number
                  of channels in the input.
     """
+
     if not os.path.isdir(data_dir):
         raise ValueError(f"Invalid value for data_dir. {data_dir} is not a directory.")
 

--- a/ark/utils/load_utils.py
+++ b/ark/utils/load_utils.py
@@ -35,8 +35,7 @@ def load_imgs_from_mibitiff(data_dir, mibitiff_files=None, channels=None, delimi
             xarray with shape [fovs, x_dim, y_dim, channels]
     """
 
-    if not os.path.isdir(data_dir):
-        raise ValueError(f"Invalid value for data_dir. {data_dir} is not a directory.")
+    iou.validate_paths(data_dir)
 
     if not mibitiff_files:
         mibitiff_files = iou.list_files(data_dir, substrs=['.tif'])
@@ -106,8 +105,7 @@ def load_imgs_from_tree(data_dir, img_sub_folder=None, fovs=None, channels=None,
             xarray with shape [fovs, x_dim, y_dim, tifs]
     """
 
-    if not os.path.isdir(data_dir):
-        raise ValueError(f"Invalid value for data_dir. {data_dir} is not a directory.")
+    iou.validate_paths(data_dir)
 
     if fovs is None:
         # get all fovs
@@ -230,8 +228,7 @@ def load_imgs_from_dir(data_dir, files=None, delimiter=None, xr_dim_name='compar
                  of channels in the input.
     """
 
-    if not os.path.isdir(data_dir):
-        raise ValueError(f"Invalid value for data_dir. {data_dir} is not a directory.")
+    iou.validate_paths(data_dir)
 
     if files is None:
         imgs = iou.list_files(data_dir, substrs=['.tif', '.jpg', '.png'])

--- a/ark/utils/load_utils.py
+++ b/ark/utils/load_utils.py
@@ -218,14 +218,15 @@ def load_imgs_from_dir(data_dir, files=None, delimiter=None, xr_dim_name='compar
             xarray with shape [fovs, x_dim, y_dim, tifs]
 
     Raises:
-            ValueError:
-                Raised in the following cases:
-                 * data_dir is not a directory, <data_dir>/img is
-                not a file for some img in the input 'files' list, or no images are found.
-                * channels_indices are invalid according to the shape of the images.
-                * the provided dtype is too small to represent the data.
-                * The length of xr_channel_names (if provided) does not match the number
-                 of channels in the input.
+        ValueError:
+            Raised in the following cases:
+
+            - data_dir is not a directory, <data_dir>/img is
+              not a file for some img in the input 'files' list, or no images are found.
+            - channels_indices are invalid according to the shape of the images.
+            - the provided dtype is too small to represent the data.
+            - The length of xr_channel_names (if provided) does not match the number
+              of channels in the input.
     """
 
     iou.validate_paths(data_dir)

--- a/ark/utils/load_utils_test.py
+++ b/ark/utils/load_utils_test.py
@@ -9,9 +9,14 @@ def test_load_imgs_from_mibitiff():
     # invalid directory is provided
     with pytest.raises(ValueError):
         loaded_xr = \
-            load_utils.load_imgs_from_mibitiff('not_a_dir', channels=None, delimeter='_')
+            load_utils.load_imgs_from_mibitiff('not_a_dir', channels=None, delimiter='_')
 
     with tempfile.TemporaryDirectory() as temp_dir:
+        # temp_dir contains no images
+        with pytest.raises(ValueError):
+            loaded_xr = load_utils.load_imgs_from_mibitiff(temp_dir,
+                                                           channels=None,
+                                                           delimiter='_')
 
         # config test environment
         fovs, channels = test_utils.gen_fov_chan_names(num_fovs=2, num_chans=3, use_delimiter=True)
@@ -75,6 +80,11 @@ def test_load_imgs_from_tree():
 
     # test loading from within fov directories
     with tempfile.TemporaryDirectory() as temp_dir:
+        # temp_dir contains no images
+        with pytest.raises(ValueError):
+            loaded_xr = \
+                load_utils.load_imgs_from_tree(temp_dir, img_sub_folder="TIFs", dtype="int16")
+
         fovs, chans, imgs = test_utils.gen_fov_chan_names(num_fovs=3, num_chans=3,
                                                           return_imgs=True)
 

--- a/ark/utils/load_utils_test.py
+++ b/ark/utils/load_utils_test.py
@@ -6,6 +6,10 @@ from ark.utils import load_utils, test_utils
 
 
 def test_load_imgs_from_mibitiff():
+    # invalid directory is provided
+    with pytest.raises(ValueError):
+        loaded_xr = \
+            load_utils.load_imgs_from_mibitiff('not_a_dir', channels=None, delimeter='_')
 
     with tempfile.TemporaryDirectory() as temp_dir:
 
@@ -64,6 +68,11 @@ def test_load_imgs_from_mibitiff():
 
 
 def test_load_imgs_from_tree():
+    # invalid directory is provided
+    with pytest.raises(ValueError):
+        loaded_xr = \
+            load_utils.load_imgs_from_tree('not_a_dir', img_sub_folder="TIFs", dtype="int16")
+
     # test loading from within fov directories
     with tempfile.TemporaryDirectory() as temp_dir:
         fovs, chans, imgs = test_utils.gen_fov_chan_names(num_fovs=3, num_chans=3,

--- a/ark/utils/load_utils_test.py
+++ b/ark/utils/load_utils_test.py
@@ -85,6 +85,12 @@ def test_load_imgs_from_tree():
             loaded_xr = \
                 load_utils.load_imgs_from_tree(temp_dir, img_sub_folder="TIFs", dtype="int16")
 
+        with pytest.raises(ValueError):
+            # attempt to pass an empty channels list
+            loaded_xr = \
+                load_utils.load_imgs_from_tree(temp_dir, img_sub_folder="TIFs",
+                                               dtype="int16", channels=[])
+
         fovs, chans, imgs = test_utils.gen_fov_chan_names(num_fovs=3, num_chans=3,
                                                           return_imgs=True)
 
@@ -125,6 +131,7 @@ def test_load_imgs_from_tree():
 
         assert loaded_xr.equals(data_xr)
 
+    # test loading with data_xr containing float values
     with tempfile.TemporaryDirectory() as temp_dir:
         fovs, chans, imgs = test_utils.gen_fov_chan_names(num_fovs=1, num_chans=2,
                                                           return_imgs=True)
@@ -142,6 +149,22 @@ def test_load_imgs_from_tree():
 
             # test swap int16 -> float
             assert np.issubdtype(loaded_xr.dtype, np.floating)
+
+    # test loading with variable sizes
+    with tempfile.TemporaryDirectory() as temp_dir:
+        fovs, chans, imgs = test_utils.gen_fov_chan_names(num_fovs=3, num_chans=3,
+                                                          return_imgs=True)
+
+        filelocs, data_xr = test_utils.create_paired_xarray_fovs(
+            temp_dir, fovs, chans, img_shape=(10, 10), delimiter='_', fills=True, sub_dir="TIFs",
+            dtype="int16"
+        )
+
+        loaded_xr = \
+            load_utils.load_imgs_from_tree(temp_dir, img_sub_folder="TIFs", dtype="int16",
+                                           variable_sizes=True)
+
+        assert loaded_xr.shape == (3, 1024, 1024, 3)
 
 
 def test_load_imgs_from_dir():


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses and closes #271. Someone recently encountered a bug in `load_imgs_from_mibitiff` in which an empty list of `mibitiff_files` (which subsequently leads to an empty list of `fovs`) caused the loading process to freak out. We need to properly address this so the error message is clear.

**How did you implement your changes**

In addition to adding a basic check for an empty `mibitiff_files` list in the function, also add `data_dir` validation where needed.
