### PR TITLE
Add status updates to deepcell_service_utils

### DIFF
--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -46,6 +46,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
     if os.path.isfile(zip_path):
         warnings.warn(f'{zip_path} will be overwritten.')
 
+    print('Zipping preprocessed tif files.')
     with ZipFile(zip_path, 'w') as zipObj:
         for fov in fovs:
             filename = os.path.join(deepcell_input_dir, fov + '.tif')
@@ -54,9 +55,11 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
                                  'Invalid value for %s' % (fov, filename))
             zipObj.write(filename, os.path.basename(filename))
 
+    print('Uploading files to DeppCell server.')
     run_deepcell_task(zip_path, deepcell_output_dir, host, job_type)
     os.remove(zip_path)
 
+    print('Extracting tif files from DeepCell response.')
     # extract the .tif output
     zip_files = glob.glob(os.path.join(deepcell_output_dir, '*.zip'))
     zip_files.sort(key=os.path.getmtime)


### PR DESCRIPTION
**What is the purpose of this PR?**

To add logging for `deepcell_service_utils` to describe the current stage of the pipeline. closes #283 

**How did you implement your changes**

Added logging when: creating the zip file, calling kiosk-client, and extracting the tif files from the output of deepcell. 

**Remaining issues**

kiosk-client writes its own logs (using Python `logging` module). Maybe it is worth thinking if/how to integrate with it so we can show these logs in the pipeline (for example, currently there will be no indication in our pipeline if there was a problem when uploading the files to deepcell server).
