### PR TITLE
Fix Segment_Image_Data plot overlay

### DIFF
--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "tags": []
    },
@@ -19,10 +19,6 @@
     "import os\n",
     "import skimage.io as io\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
-    "import sys\n",
-    "sys.path.append('..')\n",
-    "sys.path.append('../ark')\n",
     "\n",
     "from ark.utils import data_utils, load_utils, io_utils, plot_utils, deepcell_service_utils\n",
     "from ark.segmentation import marker_quantification"
@@ -37,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "tags": []
    },
@@ -127,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {
     "scrolled": true
    },
@@ -170,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -194,15 +190,11 @@
    },
    "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "Invalid value for xr_channel_names. xr_channel_names length should be 3, as the number of channels in the input data.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-7-fd306dfa6d83>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      3\u001b[0m                                                     \u001b[0mxr_channel_names\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'whole_cell'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m                                                     \u001b[0mdelimiter\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'_feature_0'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m                                                     force_ints=True)\n\u001b[0m\u001b[1;32m      6\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m \u001b[0msave_name\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdeepcell_output_dir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'segmentation_labels.xr'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Desktop/angelo/ark-analysis/ark/utils/load_utils.py\u001b[0m in \u001b[0;36mload_imgs_from_dir\u001b[0;34m(data_dir, files, delimiter, xr_dim_name, xr_channel_names, dtype, force_ints, channel_indices)\u001b[0m\n\u001b[1;32m    260\u001b[0m     \u001b[0;31m# make sure channels_names has the same length as the number of channels in the image\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    261\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mxr_channel_names\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mn_channels\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mxr_channel_names\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 262\u001b[0;31m         raise ValueError(f'Invalid value for xr_channel_names. xr_channel_names'\n\u001b[0m\u001b[1;32m    263\u001b[0m                          \u001b[0;34mf' length should be {n_channels}, as the number of channels'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    264\u001b[0m                          f' in the input data.')\n",
-      "\u001b[0;31mValueError\u001b[0m: Invalid value for xr_channel_names. xr_channel_names length should be 3, as the number of channels in the input data."
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "../ark/utils/load_utils.py:270: UserWarning: The loaded float32 images were forcefully overwritten with the supplied integer dtype int16\n",
+      "  warnings.warn(f\"The loaded {data_dtype} images were forcefully \"\n"
      ]
     }
    ],
@@ -234,20 +226,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
     "data_xr_summed = load_utils.load_imgs_from_dir(data_dir=deepcell_input_dir,\n",
+    "                                               files=[fov + '.tif' for fov in data_xr.coords['fovs'].values],\n",
     "                                               xr_dim_name='compartments',\n",
-    "                                               xr_channel_names=['whole_cell'],\n",
-    "                                               delimiter='_feature_0',\n",
+    "                                               xr_channel_names=data_xr.coords['channels'].values.tolist(),\n",
     "                                               force_ints=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 17,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -270,13 +262,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 18,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "extracting data from fov8\n"
+     ]
+    }
+   ],
    "source": [
     "# now extract the segmented imaging data to create normalized and transformed expression matrices\n",
     "# note that if you're loading your own dataset, please make sure all the imaging data is in the same folder\n",

--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -233,8 +233,7 @@
     "data_xr_summed = load_utils.load_imgs_from_dir(data_dir=deepcell_input_dir,\n",
     "                                               files=[fov + '.tif' for fov in data_xr.coords['fovs'].values],\n",
     "                                               xr_dim_name='compartments',\n",
-    "                                               xr_channel_names=data_xr.coords['channels'].values.tolist(),\n",
-    "                                               force_ints=True)"
+    "                                               xr_channel_names=data_xr.coords['channels'].values.tolist())"
    ]
   },
   {

--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -20,6 +20,10 @@
     "import skimage.io as io\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
+    "import sys\n",
+    "sys.path.append('..')\n",
+    "sys.path.append('../ark')\n",
+    "\n",
     "from ark.utils import data_utils, load_utils, io_utils, plot_utils, deepcell_service_utils\n",
     "from ark.segmentation import marker_quantification"
    ]
@@ -33,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "tags": []
    },
@@ -127,7 +131,16 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "../ark/utils/data_utils.py:41: UserWarning: ../data/example_dataset/input_data/deepcell_input/fov8.tif is a low contrast image\n",
+      "  io.imsave(save_path, out, plugin='tifffile')\n"
+     ]
+    }
+   ],
    "source": [
     "# load channels to be included in deepcell data\n",
     "channels = (nucs if nucs else []) + (mems if mems else [])\n",
@@ -157,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,13 +186,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "Invalid value for xr_channel_names. xr_channel_names length should be 3, as the number of channels in the input data.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-7-fd306dfa6d83>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      3\u001b[0m                                                     \u001b[0mxr_channel_names\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'whole_cell'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m                                                     \u001b[0mdelimiter\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'_feature_0'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m                                                     force_ints=True)\n\u001b[0m\u001b[1;32m      6\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m \u001b[0msave_name\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdeepcell_output_dir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'segmentation_labels.xr'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Desktop/angelo/ark-analysis/ark/utils/load_utils.py\u001b[0m in \u001b[0;36mload_imgs_from_dir\u001b[0;34m(data_dir, files, delimiter, xr_dim_name, xr_channel_names, dtype, force_ints, channel_indices)\u001b[0m\n\u001b[1;32m    260\u001b[0m     \u001b[0;31m# make sure channels_names has the same length as the number of channels in the image\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    261\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mxr_channel_names\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mn_channels\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mxr_channel_names\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 262\u001b[0;31m         raise ValueError(f'Invalid value for xr_channel_names. xr_channel_names'\n\u001b[0m\u001b[1;32m    263\u001b[0m                          \u001b[0;34mf' length should be {n_channels}, as the number of channels'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    264\u001b[0m                          f' in the input data.')\n",
+      "\u001b[0;31mValueError\u001b[0m: Invalid value for xr_channel_names. xr_channel_names length should be 3, as the number of channels in the input data."
+     ]
+    }
+   ],
    "source": [
     "segmentation_labels = load_utils.load_imgs_from_dir(data_dir=deepcell_output_dir,\n",
     "                                                    xr_dim_name='compartments',\n",
@@ -208,6 +234,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_xr_summed = load_utils.load_imgs_from_dir(data_dir=deepcell_input_dir,\n",
+    "                                               xr_dim_name='compartments',\n",
+    "                                               xr_channel_names=['whole_cell'],\n",
+    "                                               delimiter='_feature_0',\n",
+    "                                               force_ints=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 9,
    "metadata": {
     "pycharm": {
@@ -218,7 +257,7 @@
    "source": [
     "for fov in data_xr.fovs:\n",
     "    plot_utils.plot_overlay(segmentation_labels.loc[fov, :, :, \"whole_cell\"].values,\n",
-    "                            data_xr.loc[fov, :, :, :].values,\n",
+    "                            data_xr_summed.loc[fov, :, :, :].values,\n",
     "                            path=os.path.join(deepcell_output_dir, f'{fov.values}_overlay.tif'))"
    ]
   },
@@ -268,7 +307,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses and closes #285. By extension, addresses and closes #284. When more than 3 channels are specified, plot overlaying will fail. This is because we're trying to visualize the un-summed arrays, but we need to visualize the summed arrays across nuclear and membrane channels.

**How did you implement your changes**

`generate_deepcell_input` already handles the summing, so we just need to read that data from the directory `deepcell_input` and pass that to our overlay instead.