### PR TITLE
Remove unnecessary headings from documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@
 
 .. toctree::
    :hidden:
-   :caption: Libraries
+   :caption: Modules
    :maxdepth: 4
 
    analysis <_markdown/ark.analysis>


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses and closes #296. Our documentation has a few textual artifacts that don't need to be there and are confusing because they are empty headings. This PR focuses on nuking all of that.

**How did you implement your changes**

We add a function in `conf.py` to make the documentation pages prettier and easier to follow along.

**Remaining issues**

If there is anything else we need to nuke from these pages (ex. removing all the repetitive `ark.analysis`, `ark.segmentation`, and `ark.utils`), I can further edit `conf.py` to do that.
