### PR TITLE
compression parameter

### DIFF
--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -3,7 +3,7 @@ from twisted.internet import reactor
 from kiosk_client import manager
 import os
 import glob
-from zipfile import ZipFile
+from zipfile import ZipFile, ZIP_DEFLATED
 import warnings
 
 from ark.utils import misc_utils
@@ -65,7 +65,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
     # write all files to the zip file
     print('Zipping preprocessed tif files.')
 
-    with ZipFile(zip_path, 'w') as zipObj:
+    with ZipFile(zip_path, 'w', compression=ZIP_DEFLATED) as zipObj:
         for fov in fovs:
             # file has .tif extension
             if fov + '.tif' in input_files:


### PR DESCRIPTION
**What is the purpose of this PR?**
To change the implementation in`create_deepcell_output` so that the generated zip file will have a smaller size.
[Bug fix (closes #301)]

**How did you implement your changes**

`create_deepcell_output`generates the zip file using the zipfile module (https://docs.python.org/3/library/zipfile.html#zipfile-objects). the default value for the `compression` parameter in zipfile.ZipFile is `zipfile.ZIP_STORED` (uncompressed archive member). I changed the value to `zipfile.ZIP_DEFLATED` (the usual ZIP compression method). 
After changing this parameter, the zip file created by the notebook is the same size as one created manually.