### PR TITLE
Fix channel names list for reading back in tifs from deepcell_input_dir

### DIFF
--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -233,7 +233,7 @@
     "data_xr_summed = load_utils.load_imgs_from_dir(data_dir=deepcell_input_dir,\n",
     "                                               files=[fov + '.tif' for fov in data_xr.coords['fovs'].values],\n",
     "                                               xr_dim_name='compartments',\n",
-    "                                               xr_channel_names=data_xr.coords['channels'].values.tolist())"
+    "                                               xr_channel_names=['nuclear_channel', 'membrane_channel'])"
    ]
   },
   {
@@ -319,7 +319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses and closes #304. Because we're reading in the summed nuclear and membrane channels, we need to make sure that the channel list we pass in actually corresponds to that (and not the original list of channels). This PR patches that up.

**How did you implement your changes**

We simply change `xr_channel_names` to `nuclear_summed` and `membrane_summed`.
