### PR TITLE
Add dtype as an argument to generate_cell_table

### DIFF
--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -224,7 +224,7 @@ def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts
 
 
 def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
-                        is_mibitiff=False, fovs=None, batch_size=5):
+                        is_mibitiff=False, fovs=None, batch_size=5, dtype="int16"):
     """
     This function takes the segmented data and computes the expression matrices batch-wise
     while also validating inputs
@@ -243,7 +243,8 @@ def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
         batch_size (int):
             how large we want each of the batches of fovs to be when computing, adjust as
             necessary for speed and memory considerations
-
+        dtype (str/type):
+            data type of base images
     Returns:
         tuple (pandas.DataFrame, pandas.DataFrame):
 
@@ -288,11 +289,13 @@ def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
         # and extract the image data for each batch
         if is_mibitiff:
             image_data = load_utils.load_imgs_from_mibitiff(data_dir=tiff_dir,
-                                                            mibitiff_files=batch_files)
+                                                            mibitiff_files=batch_files,
+                                                            dtype=dtype)
         else:
             image_data = load_utils.load_imgs_from_tree(data_dir=tiff_dir,
                                                         img_sub_folder=img_sub_folder,
-                                                        fovs=batch_names)
+                                                        fovs=batch_names,
+                                                        dtype=dtype)
 
         # as well as the labels corresponding to each of them
         current_labels = segmentation_labels.loc[batch_names, :, :, :]


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses and closes #309 . The ```generate_cell_table``` was producing a ValueError if the base images were in any format other than ```'int16```, and now it can handle all of the formats that the load_images functions can handle.

**How did you implement your changes**

I added a ```dtype``` argument (with default = 'int16', which is the default for the load_images utility functions) to ```generate_cell_table```. This argument is then fed directly to the util.load_images function calls within the function.