### PR TITLE
Add scale argument to create_deepcell_output and run_deepcell_task functions

### DIFF
--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -10,7 +10,7 @@ from ark.utils import misc_utils
 
 
 def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
-                           suffix='_feature_0', host='https://deepcell.org', job_type='multiplex'):
+                           suffix='_feature_0', host='https://deepcell.org', job_type='multiplex', scale=1.0):
     """ Handles all of the necessary data manipulation for running deepcell tasks.
 
         Creates .zip files (to be used as input for DeepCell),
@@ -35,6 +35,9 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
             job_type (str):
                 Name of job workflow (multiplex, segmentation, tracking)
                 Default: 'multiplex'
+            scale (float):
+                Value to rescale data by
+                Default: 1.0
         Raises:
             ValueError:
                 Raised if there is some fov X (from fovs list) s.t.
@@ -78,7 +81,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
 
     # pass the zip file to deepcell.org
     print('Uploading files to DeepCell server.')
-    run_deepcell_task(zip_path, deepcell_output_dir, host, job_type)
+    run_deepcell_task(zip_path, deepcell_output_dir, host, job_type, scale)
 
     # extract the .tif output
     print('Extracting tif files from DeepCell response.')
@@ -92,7 +95,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
 
 
 def run_deepcell_task(input_dir, output_dir, host='https://deepcell.org',
-                      job_type='multiplex'):
+                      job_type='multiplex',scale=1.0):
     """Uses kiosk-client to run DeepCell task and saves output to output_dir.
         More configuration parameters can be set than those currently used.
         (https://github.com/vanvalenlab/kiosk-client)
@@ -108,13 +111,18 @@ def run_deepcell_task(input_dir, output_dir, host='https://deepcell.org',
             job_type (str):
                 Name of job workflow (multiplex, segmentation, tracking).
                 Default: 'multiplex'
+            scale (float):
+                Value to rescale data by
+                Default: 1.0
     """
 
     mgr_kwargs = {
         'host': host,
         'job_type': job_type,
         'download_results': True,
-        'output_dir': output_dir
+        'output_dir': output_dir,
+        'scale': str(scale)
+        
     }
 
     mgr = manager.BatchProcessingJobManager(**mgr_kwargs)

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -10,7 +10,8 @@ from ark.utils import misc_utils
 
 
 def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
-                           suffix='_feature_0', host='https://deepcell.org', job_type='multiplex', scale=1.0):
+                           suffix='_feature_0', host='https://deepcell.org', job_type='multiplex',
+                           scale=1.0):
     """ Handles all of the necessary data manipulation for running deepcell tasks.
 
         Creates .zip files (to be used as input for DeepCell),
@@ -95,7 +96,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
 
 
 def run_deepcell_task(input_dir, output_dir, host='https://deepcell.org',
-                      job_type='multiplex',scale=1.0):
+                      job_type='multiplex', scale=1.0):
     """Uses kiosk-client to run DeepCell task and saves output to output_dir.
         More configuration parameters can be set than those currently used.
         (https://github.com/vanvalenlab/kiosk-client)
@@ -122,7 +123,6 @@ def run_deepcell_task(input_dir, output_dir, host='https://deepcell.org',
         'download_results': True,
         'output_dir': output_dir,
         'scale': str(scale)
-        
     }
 
     mgr = manager.BatchProcessingJobManager(**mgr_kwargs)

--- a/ark/utils/deepcell_service_utils_test.py
+++ b/ark/utils/deepcell_service_utils_test.py
@@ -7,7 +7,7 @@ import pytest
 from ark.utils.deepcell_service_utils import create_deepcell_output
 
 
-def mocked_run_deepcell(input_dir, output_dir, host, job_type):
+def mocked_run_deepcell(input_dir, output_dir, host, job_type, scale):
     pathlib.Path(os.path.join(output_dir, 'fov1_feature_0.tif')).touch()
     pathlib.Path(os.path.join(output_dir, 'fov2_feature_0.tif')).touch()
     pathlib.Path(os.path.join(output_dir, 'fov3_feature_0.tif')).touch()


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses and closes #322 . This change allows users to add a scale value as input to create_deepcell_output, which rescales the data before prediction.

**How did you implement your changes**

I added ```scale``` as an input argument to the ```create_deepcell_output``` and ```run_deepcell_task``` functions in the util module. The default value is 1.0 for both functions. Finally, before the value is submitted to the server, it is converted from float to string, as required by the deepcell API. I figured that most users would intuitively provide the scale value as a float.
