### PR TITLE
Bump kiosk-client requirement

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,7 @@
+attrs>=20.3.0
 coveralls>=1.8.2,<2.0.0
 pytest<6.0.0
 pytest-cov<3.0.0
 pytest-mock<4.0.0
 pytest-pycodestyle<3.0.0
+six>=1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-attrs>=20.3.0
 jupyter>=1.0.0,<2
 jupyter_contrib_nbextensions>=0.5.1,<1
 kiosk-client>=0.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+attrs>=20.3.0
 jupyter>=1.0.0,<2
 jupyter_contrib_nbextensions>=0.5.1,<1
 kiosk-client>=0.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jupyter>=1.0.0,<2
 jupyter_contrib_nbextensions>=0.5.1,<1
-kiosk-client>=0.8.1
+kiosk-client>=0.8.4
 matplotlib>=2.2.2,<3
 git+git://github.com/ionpath/mibilib@v1.3.0
 numpy>=1.16.3,<2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     download_url='https://github.com/angelolab/ark-analysis/archive/v{}.tar.gz'.format(VERSION),
     install_requires=['jupyter>=1.0.0,<2',
                       'jupyter_contrib_nbextensions>=0.5.1,<1',
-                      'kiosk-client>=0.8.1',
+                      'kiosk-client>=0.8.4',
                       'matplotlib>=2.2.2,<3',
                       'numpy>=1.16.3,<2',
                       'pandas>=0.23.3,<1',


### PR DESCRIPTION
**What is the purpose of this PR?**

Because the `attrs` library updated 12-13 hours ago, `treq` also had to be updated, and by extension, `kiosk-client`. `master` is currently failing because we need to update our `requirements.txt` to match the version of `kiosk-client`.

**How did you implement your changes**

Simply bump the requirement in `requirements.txt` and `setup.py`.

**Remaining issues**

Is it best that we don't assert requirement ranges for `kiosk-client` for the time being?
