### PR TITLE
Extraction options

### DIFF
--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -15,7 +15,7 @@ import ark.settings as settings
 
 def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=False,
                           regionprops_features=None, split_large_nuclei=False,
-                          extraction='default', **kwargs):
+                          extraction='total_intensity', **kwargs):
     """Extract single cell protein expression data from channel TIFs for a single fov
 
     Args:
@@ -30,13 +30,18 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
         split_large_nuclei (bool):
             controls whether nuclei which have portions outside of the cell will get relabeled
         extraction (str):
-            extraction function used to compute marker counts. default is 'default'
+            extraction function used to compute marker counts. default is 'total_intensity'
         **kwargs:
             arbitrary keyword arguments
     Returns:
         xarray.DataArray:
             xarray containing segmented data of cells x markers
     """
+
+    misc_utils.verify_in_list(
+        extraction=[extraction],
+        extraction_options=list(extraction_function.keys())
+    )
 
     if regionprops_features is None:
         regionprops_features = ['label', 'area', 'eccentricity', 'major_axis_length',
@@ -164,7 +169,7 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
 
 
 def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts=False,
-                                 split_large_nuclei=False, extraction='default', **kwargs):
+                                 split_large_nuclei=False, extraction='total_intensity', **kwargs):
     """Create a matrix of cells by channels with the total counts of each marker in each cell.
 
     Args:
@@ -180,7 +185,7 @@ def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts
             boolean flag to determine whether nuclei which are larger than their assigned cell
             will get split into two different nuclear objects
         extraction (str):
-            extraction function used to compute marker counts. default is 'default'
+            extraction function used to compute marker counts. default is 'total_intensity'
         **kwargs:
             arbitrary keyword args
 
@@ -201,6 +206,11 @@ def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts
             nuclear_label='nuclear',
             compartment_names=segmentation_labels.compartments.values
         )
+
+    misc_utils.verify_in_list(
+        extraction=[extraction],
+        extraction_options=list(extraction_function.keys())
+    )
 
     misc_utils.verify_same_elements(segmentation_labels_fovs=segmentation_labels.fovs.values,
                                     img_data_fovs=image_data.fovs.values)
@@ -263,7 +273,7 @@ def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts
 
 def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
                         is_mibitiff=False, fovs=None, batch_size=5, dtype="int16",
-                        extraction='default', **kwargs):
+                        extraction='total_intensity', **kwargs):
     """This function takes the segmented data and computes the expression matrices batch-wise
     while also validating inputs
 
@@ -284,9 +294,9 @@ def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
         dtype (str/type):
             data type of base images
         extraction (str):
-            extraction function used to compute marker counts. default is 'default'
+            extraction function used to compute marker counts. default is 'total_intensity'
         **kwargs:
-            arbitrary keyword arguments
+            arbitrary keyword arguments for signal extraction
 
     Returns:
         tuple (pandas.DataFrame, pandas.DataFrame):å
@@ -303,6 +313,11 @@ def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
 
     # drop file extensions
     fovs = io_utils.remove_file_extensions(fovs)
+
+    misc_utils.verify_in_list(
+        extraction=[extraction],
+        extraction_options=list(extraction_function.keys())
+    )
 
     # check segmentation_labels for given fovs (img loaders will fail otherwise)
     misc_utils.verify_in_list(fovs=fovs,

--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -17,6 +17,7 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
                           regionprops_features=None, split_large_nuclei=False,
                           extraction='default', **kwargs):
     """Extract single cell protein expression data from channel TIFs for a single fov
+
     Args:
         input_images (xarray.DataArray):
             rows x columns x channels matrix of imaging data

--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -30,7 +30,7 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
             controls whether nuclei which have portions outside of the cell will get relabeled
         extraction (str):
             extraction function used to compute marker counts. default is 'default'
-        kwargs:
+        **kwargs:
             arbitrary keyword arguments
     Returns:
         xarray.DataArray:
@@ -180,7 +180,7 @@ def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts
             will get split into two different nuclear objects
         extraction (str):
             extraction function used to compute marker counts. default is 'default'
-        kwargs:
+        **kwargs:
             arbitrary keyword args
 
     Returns:
@@ -284,7 +284,7 @@ def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
             data type of base images
         extraction (str):
             extraction function used to compute marker counts. default is 'default'
-        kwargs:
+        **kwargs:
             arbitrary keyword arguments
 
     Returns:

--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -55,7 +55,7 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
         regionprops_features.append('label')
 
     # centroid is required
-    if 'centroid-0' not in regionprops_features and 'centroid' not in regionprops_features:
+    if not any(['centroid' in rpf for rpf in regionprops_features]):
         regionprops_features.append('centroid')
 
     # enforce post channel column is present and first

--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -30,7 +30,7 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
         split_large_nuclei (bool):
             controls whether nuclei which have portions outside of the cell will get relabeled
         extraction (str):
-            extraction function used to compute marker counts. default is 'total_intensity'
+            extraction function used to compute marker counts.
         **kwargs:
             arbitrary keyword arguments
     Returns:
@@ -39,7 +39,7 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
     """
 
     misc_utils.verify_in_list(
-        extraction=[extraction],
+        extraction=extraction,
         extraction_options=list(extraction_function.keys())
     )
 
@@ -185,7 +185,7 @@ def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts
             boolean flag to determine whether nuclei which are larger than their assigned cell
             will get split into two different nuclear objects
         extraction (str):
-            extraction function used to compute marker counts. default is 'total_intensity'
+            extraction function used to compute marker counts.
         **kwargs:
             arbitrary keyword args
 
@@ -208,7 +208,7 @@ def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts
         )
 
     misc_utils.verify_in_list(
-        extraction=[extraction],
+        extraction=extraction,
         extraction_options=list(extraction_function.keys())
     )
 
@@ -294,7 +294,7 @@ def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
         dtype (str/type):
             data type of base images
         extraction (str):
-            extraction function used to compute marker counts. default is 'total_intensity'
+            extraction function used to compute marker counts.
         **kwargs:
             arbitrary keyword arguments for signal extraction
 
@@ -315,7 +315,7 @@ def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
     fovs = io_utils.remove_file_extensions(fovs)
 
     misc_utils.verify_in_list(
-        extraction=[extraction],
+        extraction=extraction,
         extraction_options=list(extraction_function.keys())
     )
 

--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -8,13 +8,14 @@ import xarray as xr
 from skimage.measure import regionprops_table
 
 from ark.utils import io_utils, load_utils, misc_utils, segmentation_utils
-from ark.segmentation import signal_extraction
+from ark.segmentation.signal_extraction import extraction_function
 
 import ark.settings as settings
 
 
 def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=False,
-                          regionprops_features=None, split_large_nuclei=False):
+                          regionprops_features=None, split_large_nuclei=False,
+                          extraction='default', **kwargs):
     """Extract single cell protein expression data from channel TIFs for a single fov
     Args:
         input_images (xarray.DataArray):
@@ -27,6 +28,10 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
             morphology features for regionprops to extract for each cell
         split_large_nuclei (bool):
             controls whether nuclei which have portions outside of the cell will get relabeled
+        extraction (str):
+            extraction function used to compute marker counts. default is 'default'
+        kwargs:
+            arbitrary keyword arguments
     Returns:
         xarray.DataArray:
             xarray containing segmented data of cells x markers
@@ -42,6 +47,10 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
     # labels are required
     if 'label' not in regionprops_features:
         regionprops_features.append('label')
+
+    # centroid is required
+    if 'centroid-0' not in regionprops_features and 'centroid' not in regionprops_features:
+        regionprops_features.append('centroid')
 
     # enforce post channel column is present and first
     if regionprops_features[0] != settings.POST_CHANNEL_COL:
@@ -97,8 +106,14 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
         # get coords corresponding to current cell.
         cell_coords = cell_props.loc[cell_props['label'] == cell_id, 'coords'].values[0]
 
+        # get centroid corresponding to current cell
+        kwargs['centroid'] = (
+            cell_props.loc[cell_props['label'] == cell_id, 'centroid-0'],
+            cell_props.loc[cell_props['label'] == cell_id, 'centroid-1']
+        )
+
         # calculate the total signal intensity within cell
-        cell_counts = signal_extraction.default_extraction(cell_coords, input_images)
+        cell_counts = extraction_function[extraction](cell_coords, input_images, **kwargs)
 
         # get morphology metrics
         current_cell_props = cell_props.loc[cell_props['label'] == cell_id, regionprops_names]
@@ -121,8 +136,14 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
                 # get coordinates of corresponding nucleus
                 nuc_coords = nuc_props.loc[nuc_props['label'] == nuc_id, 'coords'].values[0]
 
+                # get nuclear coordinates
+                kwargs['centroid'] = (
+                    nuc_props.loc[nuc_props['label'] == nuc_id, 'centroid-0'],
+                    nuc_props.loc[nuc_props['label'] == nuc_id, 'centroid-1']
+                )
+
                 # extract nuclear signal
-                nuc_counts = signal_extraction.default_extraction(nuc_coords, input_images)
+                nuc_counts = extraction_function[extraction](nuc_coords, input_images, **kwargs)
 
                 # get morphology metrics
                 current_nuc_props = nuc_props.loc[
@@ -142,7 +163,7 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
 
 
 def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts=False,
-                                 split_large_nuclei=False):
+                                 split_large_nuclei=False, extraction='default', **kwargs):
     """Create a matrix of cells by channels with the total counts of each marker in each cell.
 
     Args:
@@ -157,6 +178,10 @@ def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts
         split_large_nuclei (bool):
             boolean flag to determine whether nuclei which are larger than their assigned cell
             will get split into two different nuclear objects
+        extraction (str):
+            extraction function used to compute marker counts. default is 'default'
+        kwargs:
+            arbitrary keyword args
 
     Returns:
         tuple (pandas.DataFrame, pandas.DataFrame):
@@ -193,7 +218,8 @@ def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts
         # extract the counts per cell for each marker
         marker_counts = compute_marker_counts(image_data.loc[fov, :, :, :], segmentation_label,
                                               nuclear_counts=nuclear_counts,
-                                              split_large_nuclei=split_large_nuclei)
+                                              split_large_nuclei=split_large_nuclei,
+                                              extraction=extraction, **kwargs)
 
         # normalize counts by cell size
         marker_counts_norm = segmentation_utils.transform_expression_matrix(marker_counts,
@@ -235,7 +261,8 @@ def create_marker_count_matrices(segmentation_labels, image_data, nuclear_counts
 
 
 def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
-                        is_mibitiff=False, fovs=None, batch_size=5, dtype="int16"):
+                        is_mibitiff=False, fovs=None, batch_size=5, dtype="int16",
+                        extraction='default', **kwargs):
     """This function takes the segmented data and computes the expression matrices batch-wise
     while also validating inputs
 
@@ -255,6 +282,10 @@ def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
             necessary for speed and memory considerations
         dtype (str/type):
             data type of base images
+        extraction (str):
+            extraction function used to compute marker counts. default is 'default'
+        kwargs:
+            arbitrary keyword arguments
 
     Returns:
         tuple (pandas.DataFrame, pandas.DataFrame):å
@@ -312,7 +343,9 @@ def generate_cell_table(segmentation_labels, tiff_dir, img_sub_folder,
         # segment the imaging data
         cell_table_size_normalized, cell_table_arcsinh_transformed = create_marker_count_matrices(
             segmentation_labels=current_labels,
-            image_data=image_data
+            image_data=image_data,
+            extraction=extraction,
+            **kwargs
         )
 
         # now append to the final dfs to return

--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -107,10 +107,10 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
         cell_coords = cell_props.loc[cell_props['label'] == cell_id, 'coords'].values[0]
 
         # get centroid corresponding to current cell
-        kwargs['centroid'] = (
-            cell_props.loc[cell_props['label'] == cell_id, 'centroid-0'],
-            cell_props.loc[cell_props['label'] == cell_id, 'centroid-1']
-        )
+        kwargs['centroid'] = np.array((
+            cell_props.loc[cell_props['label'] == cell_id, 'centroid-0'].values,
+            cell_props.loc[cell_props['label'] == cell_id, 'centroid-1'].values
+        )).T
 
         # calculate the total signal intensity within cell
         cell_counts = extraction_function[extraction](cell_coords, input_images, **kwargs)
@@ -136,11 +136,11 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
                 # get coordinates of corresponding nucleus
                 nuc_coords = nuc_props.loc[nuc_props['label'] == nuc_id, 'coords'].values[0]
 
-                # get nuclear coordinates
-                kwargs['centroid'] = (
-                    nuc_props.loc[nuc_props['label'] == nuc_id, 'centroid-0'],
-                    nuc_props.loc[nuc_props['label'] == nuc_id, 'centroid-1']
-                )
+                # get nuclear centroid
+                kwargs['centroid'] = np.array((
+                    nuc_props.loc[nuc_props['label'] == nuc_id, 'centroid-0'].values,
+                    nuc_props.loc[nuc_props['label'] == nuc_id, 'centroid-1'].values
+                )).T
 
                 # extract nuclear signal
                 nuc_counts = extraction_function[extraction](nuc_coords, input_images, **kwargs)

--- a/ark/segmentation/marker_quantification_test.py
+++ b/ark/segmentation/marker_quantification_test.py
@@ -56,7 +56,16 @@ def test_compute_marker_counts_base():
     assert np.array_equal(segmentation_output.loc['whole_cell', :, settings.CELL_SIZE],
                           segmentation_output.loc['whole_cell', :, 'area'])
 
-    # TODO: add test to validate different extraction
+    # test different extraction selection
+    center_extraction = \
+        marker_quantification.compute_marker_counts(input_images=input_images,
+                                                    segmentation_labels=segmentation_labels,
+                                                    extraction='center_weighting')
+
+    assert np.all(
+        segmentation_output.loc['whole_cell', :, 'chan0'].values
+        > center_extraction.loc['whole_cell', :, 'chan0'].values
+    )
 
 
 def test_compute_marker_counts_equal_masks():

--- a/ark/segmentation/marker_quantification_test.py
+++ b/ark/segmentation/marker_quantification_test.py
@@ -56,6 +56,8 @@ def test_compute_marker_counts_base():
     assert np.array_equal(segmentation_output.loc['whole_cell', :, settings.CELL_SIZE],
                           segmentation_output.loc['whole_cell', :, 'area'])
 
+    # TODO: add test to validate different extraction
+
 
 def test_compute_marker_counts_equal_masks():
     cell_mask, channel_data = test_utils.create_test_extraction_data()

--- a/ark/segmentation/signal_extraction.py
+++ b/ark/segmentation/signal_extraction.py
@@ -47,10 +47,6 @@ def center_weighting_extraction(cell_coords, image_data, **kwargs):
             Sums of counts for each channel
     """
 
-    # check for centroid in kwargs
-    if 'centroid' not in kwargs.keys():
-        raise TypeError("center_weighting_extraction() missing keyowrd-only argument: 'centroid'")
-
     # compute the distance box-level from the center outward
     weights = np.linalg.norm(cell_coords - kwargs['centroid'], ord=np.inf, axis=1)
 
@@ -92,5 +88,5 @@ def default_extraction(cell_coords, image_data, **kwargs):
 extraction_function = {
     'positive_pixel': positive_pixels_extraction,
     'center_weighting': center_weighting_extraction,
-    'default': default_extraction,
+    'total_intensity': default_extraction,
 }

--- a/ark/segmentation/signal_extraction.py
+++ b/ark/segmentation/signal_extraction.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def positive_pixels_extraction(cell_coords, image_data, threshold=0):
+def positive_pixels_extraction(cell_coords, image_data, **kwargs):
     """Extract channel counts by summing over the number of non-zero pixels in the cell.
 
     Improves on default_extraction by not distinguishing between pixel expression values
@@ -9,23 +9,26 @@ def positive_pixels_extraction(cell_coords, image_data, threshold=0):
     Args:
         cell_coords (numpy.ndarray): values representing pixels within one cell
         image_data (xarray.DataArray): array containing channel counts
-        threshold (int): where we want to set the cutoff for a positive pixel, default 0
+        kwargs: arbitrary keyword arguments
 
     Returns:
         numpy.ndarray:
             Sums of counts for each channel
     """
 
+    if 'threshold' not in kwargs.keys():
+        kwargs['threshold'] = 0
+
     # index into image_data
     channel_values = image_data.values[tuple(cell_coords.T)]
 
     # create binary mask based on threshold
-    channel_counts = np.sum(channel_values > threshold, axis=0)
+    channel_counts = np.sum(channel_values > kwargs['threshold'], axis=0)
 
     return channel_counts
 
 
-def center_weighting_extraction(cell_coords, image_data, centroid):
+def center_weighting_extraction(cell_coords, image_data, **kwargs):
     """Extract channel counts by summing over weighted expression values based on distance from
     center.
 
@@ -36,16 +39,20 @@ def center_weighting_extraction(cell_coords, image_data, centroid):
             values representing pixels within one cell
         image_data (xarray.DataArray):
             array containing channel counts
-        centroid (tuple):
-            the centroid of the region in question
+        **kwargs:
+            arbitrary keyword arguments
 
     Returns:
         numpy.ndarray:
             Sums of counts for each channel
     """
 
+    # check for centroid in kwargs
+    if 'centroid' not in kwargs.keys():
+        raise TypeError("center_weighting_extraction() missing keyowrd-only argument: 'centroid'")
+
     # compute the distance box-level from the center outward
-    weights = np.linalg.norm(cell_coords - centroid, ord=np.inf, axis=1)
+    weights = np.linalg.norm(cell_coords - kwargs['centroid'], ord=np.inf, axis=1)
 
     # center the weights around the middle value
     weights = 1 - (weights / (np.max(weights) + 1))
@@ -57,7 +64,7 @@ def center_weighting_extraction(cell_coords, image_data, centroid):
     return channel_counts
 
 
-def default_extraction(cell_coords, image_data):
+def default_extraction(cell_coords, image_data, **kwargs):
     """ Extract channel counts for an individual cell via basic summation for each channel
 
     Args:
@@ -65,6 +72,8 @@ def default_extraction(cell_coords, image_data):
             values representing pixels within one cell
         image_data (xarray.DataArray):
             array containing channel counts
+        kwargs:
+            arbitrary keyword arguments
 
     Returns:
         numpy.ndarray:
@@ -78,3 +87,10 @@ def default_extraction(cell_coords, image_data):
     channel_counts = np.sum(channel_values, axis=0)
 
     return channel_counts
+
+
+extraction_function = {
+    'positive_pixel': positive_pixels_extraction,
+    'center_weighting': center_weighting_extraction,
+    'default': default_extraction,
+}

--- a/ark/segmentation/signal_extraction.py
+++ b/ark/segmentation/signal_extraction.py
@@ -9,7 +9,7 @@ def positive_pixels_extraction(cell_coords, image_data, **kwargs):
     Args:
         cell_coords (numpy.ndarray): values representing pixels within one cell
         image_data (xarray.DataArray): array containing channel counts
-        kwargs: arbitrary keyword arguments
+        **kwargs: arbitrary keyword arguments
 
     Returns:
         numpy.ndarray:
@@ -72,7 +72,7 @@ def default_extraction(cell_coords, image_data, **kwargs):
             values representing pixels within one cell
         image_data (xarray.DataArray):
             array containing channel counts
-        kwargs:
+        **kwargs:
             arbitrary keyword arguments
 
     Returns:

--- a/ark/segmentation/signal_extraction.py
+++ b/ark/segmentation/signal_extraction.py
@@ -4,8 +4,6 @@ import numpy as np
 def positive_pixels_extraction(cell_coords, image_data, **kwargs):
     """Extract channel counts by summing over the number of non-zero pixels in the cell.
 
-    Improves on total_intensity_extraction by not distinguishing between pixel expression values
-
     Args:
         cell_coords (numpy.ndarray): values representing pixels within one cell
         image_data (xarray.DataArray): array containing channel counts
@@ -28,8 +26,6 @@ def positive_pixels_extraction(cell_coords, image_data, **kwargs):
 def center_weighting_extraction(cell_coords, image_data, **kwargs):
     """Extract channel counts by summing over weighted expression values based on distance from
     center.
-
-    Improves upon default extraction by including a level of certainty/uncertainty.
 
     Args:
         cell_coords (numpy.ndarray):

--- a/ark/segmentation/signal_extraction.py
+++ b/ark/segmentation/signal_extraction.py
@@ -4,7 +4,7 @@ import numpy as np
 def positive_pixels_extraction(cell_coords, image_data, **kwargs):
     """Extract channel counts by summing over the number of non-zero pixels in the cell.
 
-    Improves on default_extraction by not distinguishing between pixel expression values
+    Improves on total_intensity_extraction by not distinguishing between pixel expression values
 
     Args:
         cell_coords (numpy.ndarray): values representing pixels within one cell
@@ -16,14 +16,11 @@ def positive_pixels_extraction(cell_coords, image_data, **kwargs):
             Sums of counts for each channel
     """
 
-    if 'threshold' not in kwargs.keys():
-        kwargs['threshold'] = 0
-
     # index into image_data
     channel_values = image_data.values[tuple(cell_coords.T)]
 
     # create binary mask based on threshold
-    channel_counts = np.sum(channel_values > kwargs['threshold'], axis=0)
+    channel_counts = np.sum(channel_values > kwargs.get('threshold', 0), axis=0)
 
     return channel_counts
 
@@ -48,7 +45,7 @@ def center_weighting_extraction(cell_coords, image_data, **kwargs):
     """
 
     # compute the distance box-level from the center outward
-    weights = np.linalg.norm(cell_coords - kwargs['centroid'], ord=np.inf, axis=1)
+    weights = np.linalg.norm(cell_coords - kwargs.get('centroid'), ord=np.inf, axis=1)
 
     # center the weights around the middle value
     weights = 1 - (weights / (np.max(weights) + 1))
@@ -60,7 +57,7 @@ def center_weighting_extraction(cell_coords, image_data, **kwargs):
     return channel_counts
 
 
-def default_extraction(cell_coords, image_data, **kwargs):
+def total_intensity_extraction(cell_coords, image_data, **kwargs):
     """ Extract channel counts for an individual cell via basic summation for each channel
 
     Args:
@@ -88,5 +85,5 @@ def default_extraction(cell_coords, image_data, **kwargs):
 extraction_function = {
     'positive_pixel': positive_pixels_extraction,
     'center_weighting': center_weighting_extraction,
-    'total_intensity': default_extraction,
+    'total_intensity': total_intensity_extraction,
 }

--- a/ark/segmentation/signal_extraction_test.py
+++ b/ark/segmentation/signal_extraction_test.py
@@ -156,7 +156,7 @@ def test_center_weighting_extraction():
 
     # catch no centroid error
     with pytest.raises(TypeError):
-        signal_extraction.center_weighting_extraction(
+        _ = signal_extraction.center_weighting_extraction(
             cell_coords=coords_1,
             image_data=xr.DataArray(sample_channel_data)
         )

--- a/ark/segmentation/signal_extraction_test.py
+++ b/ark/segmentation/signal_extraction_test.py
@@ -6,6 +6,8 @@ from ark.utils import synthetic_spatial_datagen
 
 from skimage.measure import regionprops
 
+import pytest
+
 
 def test_positive_pixels_extraction():
     # sample params
@@ -51,21 +53,39 @@ def test_positive_pixels_extraction():
     assert np.all(channel_counts_2 == [0, 236])
 
     # test with new threshold == 10
-    test_threshold = 10
+    kwargs = {'threshold': 10}
 
     channel_counts_1 = signal_extraction.positive_pixels_extraction(
         cell_coords=coords_1,
         image_data=xr.DataArray(sample_channel_data),
-        threshold=test_threshold
+        **kwargs
     )
 
     channel_counts_2 = signal_extraction.positive_pixels_extraction(
         cell_coords=coords_2,
         image_data=xr.DataArray(sample_channel_data),
-        threshold=test_threshold
+        **kwargs
     )
 
     assert np.all(channel_counts_1 == [0, 0])
+    assert np.all(channel_counts_2 == [0, 236])
+
+    # test for multichannel thresholds
+    kwargs = {'threshold': np.array([0, 10])}
+
+    channel_counts_1 = signal_extraction.positive_pixels_extraction(
+        cell_coords=coords_1,
+        image_data=xr.DataArray(sample_channel_data),
+        **kwargs
+    )
+
+    channel_counts_2 = signal_extraction.positive_pixels_extraction(
+        cell_coords=coords_2,
+        image_data=xr.DataArray(sample_channel_data),
+        **kwargs
+    )
+
+    assert np.all(channel_counts_1 == [25, 0])
     assert np.all(channel_counts_2 == [0, 236])
 
 
@@ -99,8 +119,8 @@ def test_center_weighting_extraction():
 
     # extract the centroids and coords
     region_info = regionprops(sample_segmentation_mask.astype(np.int16))
-    centroid_1 = region_info[0].centroid
-    centroid_2 = region_info[1].centroid
+    kwarg_1 = {'centroid': region_info[0].centroid}
+    kwarg_2 = {'centroid': region_info[1].centroid}
 
     coords_1 = region_info[0].coords
     coords_2 = region_info[1].coords
@@ -108,13 +128,13 @@ def test_center_weighting_extraction():
     channel_counts_1_center_weight = signal_extraction.center_weighting_extraction(
         cell_coords=coords_1,
         image_data=xr.DataArray(sample_channel_data),
-        centroid=centroid_1
+        **kwarg_1
     )
 
     channel_counts_2_center_weight = signal_extraction.center_weighting_extraction(
         cell_coords=coords_2,
         image_data=xr.DataArray(sample_channel_data),
-        centroid=centroid_2
+        **kwarg_2
     )
 
     channel_counts_1_base_weight = signal_extraction.default_extraction(
@@ -133,6 +153,13 @@ def test_center_weighting_extraction():
 
     # assert effect of "bleeding" membrane signal is less with weighted than default
     assert channel_counts_1_center_weight[1] < channel_counts_1_base_weight[1]
+
+    # catch no centroid error
+    with pytest.raises(TypeError):
+        signal_extraction.center_weighting_extraction(
+            cell_coords=coords_1,
+            image_data=xr.DataArray(sample_channel_data)
+        )
 
 
 def test_default_extraction():

--- a/ark/segmentation/signal_extraction_test.py
+++ b/ark/segmentation/signal_extraction_test.py
@@ -6,8 +6,6 @@ from ark.utils import synthetic_spatial_datagen
 
 from skimage.measure import regionprops
 
-import pytest
-
 
 def test_positive_pixels_extraction():
     # sample params
@@ -153,13 +151,6 @@ def test_center_weighting_extraction():
 
     # assert effect of "bleeding" membrane signal is less with weighted than default
     assert channel_counts_1_center_weight[1] < channel_counts_1_base_weight[1]
-
-    # catch no centroid error
-    with pytest.raises(TypeError):
-        _ = signal_extraction.center_weighting_extraction(
-            cell_coords=coords_1,
-            image_data=xr.DataArray(sample_channel_data)
-        )
 
 
 def test_default_extraction():

--- a/ark/segmentation/signal_extraction_test.py
+++ b/ark/segmentation/signal_extraction_test.py
@@ -135,12 +135,12 @@ def test_center_weighting_extraction():
         **kwarg_2
     )
 
-    channel_counts_1_base_weight = signal_extraction.default_extraction(
+    channel_counts_1_base_weight = signal_extraction.total_intensity_extraction(
         cell_coords=coords_1,
         image_data=xr.DataArray(sample_channel_data)
     )
 
-    channel_counts_2_base_weight = signal_extraction.default_extraction(
+    channel_counts_2_base_weight = signal_extraction.total_intensity_extraction(
         cell_coords=coords_2,
         image_data=xr.DataArray(sample_channel_data)
     )
@@ -153,7 +153,7 @@ def test_center_weighting_extraction():
     assert channel_counts_1_center_weight[1] < channel_counts_1_base_weight[1]
 
 
-def test_default_extraction():
+def test_total_intensity_extraction():
     # sample params
     size_img = (1024, 1024)
     cell_radius = 10
@@ -181,12 +181,12 @@ def test_default_extraction():
     coords_1 = np.argwhere(sample_segmentation_mask == 1)
     coords_2 = np.argwhere(sample_segmentation_mask == 2)
 
-    channel_counts_1 = signal_extraction.default_extraction(
+    channel_counts_1 = signal_extraction.total_intensity_extraction(
         cell_coords=coords_1,
         image_data=xr.DataArray(sample_channel_data)
     )
 
-    channel_counts_2 = signal_extraction.default_extraction(
+    channel_counts_2 = signal_extraction.total_intensity_extraction(
         cell_coords=coords_2,
         image_data=xr.DataArray(sample_channel_data)
     )

--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -358,7 +358,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Afterwards, we can generate expression matrices from the labeling + imaging data"
+    "### Afterwards, we can generate expression matrices from the labeling + imaging data\n",
+    "\n",
+    "There are mutliple different extraction/marker counting options, which can be passsed via the 'extraction argument':\n",
+    " - `'default'`: sum total marker intensity over all pixels within cell\n",
+    " - `'positive_pixel'`: count number of pixels above global (or marker specific) threshold(s).  A value or array containing these thresholds can be passed as a part of `extraction_kwargs`.  If no thresholds are given, all non-zero pixels are counted\n",
+    " - `'center_weighted'`: same as default, but pixel intensities farther from the cell centroid are diminished"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#set specific marker thresholds from csv\n",
+    "set_thresholds = False\n",
+    "\n",
+    "extraction_kwargs = {}\n",
+    "if set_thresholds:\n",
+    "    # GLOBAL THRESHOLD EXAMPLE\n",
+    "    thresholds = 0\n",
+    "\n",
+    "    extraction_kwargs['threshold'] = thresholds"
    ]
   },
   {
@@ -383,7 +405,9 @@
     "                                              img_sub_folder=\"TIFs\",\n",
     "                                              is_mibitiff=MIBItiff,\n",
     "                                              fovs=fovs,\n",
-    "                                              batch_size=5)"
+    "                                              batch_size=5,\n",
+    "                                              extraction='positive_pixel',\n",
+    "                                              **extraction_kwargs)"
    ]
   },
   {

--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -358,29 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Afterwards, we can generate expression matrices from the labeling + imaging data\n",
-    "\n",
-    "There are mutliple different extraction/marker counting options, which can be passsed via the 'extraction argument':\n",
-    " - `'default'`: sum total marker intensity over all pixels within cell\n",
-    " - `'positive_pixel'`: count number of pixels above global (or marker specific) threshold(s).  A value or array containing these thresholds can be passed as a part of `extraction_kwargs`.  If no thresholds are given, all non-zero pixels are counted\n",
-    " - `'center_weighted'`: same as default, but pixel intensities farther from the cell centroid are diminished"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#set specific marker thresholds from csv\n",
-    "set_thresholds = False\n",
-    "\n",
-    "extraction_kwargs = {}\n",
-    "if set_thresholds:\n",
-    "    # GLOBAL THRESHOLD EXAMPLE\n",
-    "    thresholds = 0\n",
-    "\n",
-    "    extraction_kwargs['threshold'] = thresholds"
+    "### Afterwards, we can generate expression matrices from the labeling + imaging data"
    ]
   },
   {
@@ -405,9 +383,7 @@
     "                                              img_sub_folder=\"TIFs\",\n",
     "                                              is_mibitiff=MIBItiff,\n",
     "                                              fovs=fovs,\n",
-    "                                              batch_size=5,\n",
-    "                                              extraction='positive_pixel',\n",
-    "                                              **extraction_kwargs)"
+    "                                              batch_size=5)"
    ]
   },
   {


### PR DESCRIPTION
## **Purpose**

Allows different extraction functions to be called from the notebooks.  Functions were already written, but couldn't be accessed by users.  Closes #157 

## **Implementation**

Users can pass a string denoting the type of extraction they want to use.  Additionally, for extractions which require additional arguments/parameters, kwargs have been added to facilitate generalized 'passing down' of these additional arguments.  The arguments of the extraction functions were made identical to facilitate general callability via dictionary in `signal_extraction`

## **Remaining issues**

Some more test functions could be added, along with an example in the segmentation notebook.  Lmk what your thoughts are on that front.
