### PR TITLE
Auto upload patch

### DIFF
--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -175,6 +175,7 @@ def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',
 
     upload_responce = requests.post(
         upload_url,
+        timeout=timeout,
         files=upload_fields
     ).json()
 

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -4,8 +4,6 @@ from pathlib import Path
 import time
 from tqdm.notebook import tqdm
 from urllib.parse import unquote_plus
-from twisted.internet import reactor
-from kiosk_client import manager
 import os
 import glob
 from zipfile import ZipFile, ZIP_DEFLATED
@@ -105,41 +103,6 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
         for fov in fovs:
             if fov + suffix + '.tif' not in zipObj.namelist():
                 warnings.warn(f'Deep Cell output file was not found for {fov}.')
-
-
-def run_deepcell_task(input_dir, output_dir, host='https://deepcell.org',
-                      job_type='multiplex', scale=1.0):
-    """Uses kiosk-client to run DeepCell task and saves output to output_dir.
-        More configuration parameters can be set than those currently used.
-        (https://github.com/vanvalenlab/kiosk-client)
-
-        Args:
-            input_dir (str):
-                location of .zip files
-            output_dir (str):
-                location to save deepcell output (as .zip)
-            host (str):
-                Hostname and port for the kiosk-frontend API server.
-                Default: 'https://deepcell.org'
-            job_type (str):
-                Name of job workflow (multiplex, segmentation, tracking).
-                Default: 'multiplex'
-            scale (float):
-                Value to rescale data by
-                Default: 1.0
-    """
-
-    mgr_kwargs = {
-        'host': host,
-        'job_type': job_type,
-        'download_results': True,
-        'output_dir': output_dir,
-        'data_scale': scale
-    }
-
-    mgr = manager.BatchProcessingJobManager(**mgr_kwargs)
-    mgr.run(filepath=input_dir)
-    reactor.run()
 
 
 def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -15,7 +15,7 @@ from ark.utils import misc_utils
 
 def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
                            suffix='_feature_0', host='https://deepcell.org', job_type='multiplex',
-                           scale=1.0, timeout=3600, zip_size=100):
+                           scale=1.0, timeout=3600, zip_size=100, parallel=False):
     """ Handles all of the necessary data manipulation for running deepcell tasks.
 
         Creates .zip files (to be used as input for DeepCell),
@@ -49,6 +49,9 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
             zip_size (int):
                 Maximum number of files to include in zip.
                 Default: 100
+            parallel (bool):
+                Tries to zip, upload, and extract zip files in parallel
+                Default: False
         Raises:
             ValueError:
                 Raised if there is some fov X (from fovs list) s.t.
@@ -119,8 +122,11 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
                     warnings.warn(f'Deep Cell output file was not found for {fov}.')
 
     # make calls in parallel
-    with ThreadPoolExecutor() as executor:
-        executor.map(_zip_run_extract, fov_groups, range(len(fov_groups)))
+    if parallel:
+        with ThreadPoolExecutor() as executor:
+            executor.map(_zip_run_extract, fov_groups, range(len(fov_groups)))
+    else:
+        map(_zip_run_extract, fov_groups, range(len(fov_groups)))
 
 
 def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -214,7 +214,7 @@ def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',
         # update progress bar here
         if redis_responce['value'][0] == 'waiting':
             pbar_next = int(redis_responce['value'][1])
-            progress_bar.update(pbar_next - pbar_last)
+            progress_bar.update(max(pbar_next - pbar_last, 0))
             pbar_last = pbar_next
 
         time.sleep(3.0)

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -75,7 +75,10 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
         deepcell_input_files=io_utils.remove_file_extensions(input_files))
 
     # partition fovs for smaller zip file batching
-    fov_groups = [fovs[100 * i:100 * (i + 1)] for i in range(len(fovs) // 100)]
+    fov_groups = [
+        fovs[zip_size * i:zip_size * (i + 1)]
+        for i in range((len(fovs) // zip_size) + 1)
+    ]
 
     print(f'Processing tiffs in {len(fov_groups)} batches...')
 

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -3,7 +3,7 @@ import requests
 from pathlib import Path
 import time
 from tqdm.notebook import tqdm
-from urllib.parse import unquote, unquote_plus
+from urllib.parse import unquote_plus
 from twisted.internet import reactor
 from kiosk_client import manager
 import os
@@ -232,3 +232,15 @@ def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',
 
     deepcell_output = requests.get(redis_responce['value'][2], allow_redirects=True)
     open(os.path.join(output_dir, 'deepcell_responce.zip'), 'wb').write(deepcell_output.content)
+
+    # being kind and sending an expire signal to deepcell
+    expire_url = redis_url + '/expire'
+    requests.post(
+        expire_url,
+        json={
+            'hash': predict_hash,
+            'expireIn': 3600,
+        }
+    )
+
+    return

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -87,6 +87,8 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
     print(f'Processing tiffs in {len(fov_groups)} batches...')
 
     # yes this is function, don't worry about it
+    # long story short, too many args to pass if function not in local scope
+    # i.e easier to map fov_groups
     def _zip_run_extract(fov_group, group_index):
         # define the location of the zip file for our fovs
         zip_path = os.path.join(deepcell_input_dir, f'fovs_batch_{group_index + 1}.zip')
@@ -126,7 +128,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
         with ThreadPoolExecutor() as executor:
             executor.map(_zip_run_extract, fov_groups, range(len(fov_groups)))
     else:
-        map(_zip_run_extract, fov_groups, range(len(fov_groups)))
+        list(map(_zip_run_extract, fov_groups, range(len(fov_groups))))
 
 
 def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -2,7 +2,7 @@ from ark.utils import io_utils
 import requests
 from pathlib import Path
 import time
-from tqdm import tqdm
+from tqdm.notebook import tqdm
 from twisted.internet import reactor
 from kiosk_client import manager
 import os

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -127,6 +127,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
     if parallel:
         with ThreadPoolExecutor() as executor:
             executor.map(_zip_run_extract, fov_groups, range(len(fov_groups)))
+            executor.shutdown(wait=True)
     else:
         list(map(_zip_run_extract, fov_groups, range(len(fov_groups))))
 

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -3,6 +3,7 @@ import requests
 from pathlib import Path
 import time
 from tqdm.notebook import tqdm
+from urllib.parse import unquote
 from twisted.internet import reactor
 from kiosk_client import manager
 import os
@@ -227,7 +228,7 @@ def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',
     # when done, download result or examine errors
     if len(redis_responce['value'][4]) > 0:
         # error happened
-        print(f"Encountered Failure: {redis_responce['value'][4]}")
+        print(f"Encountered Failure: {unquote(redis_responce['value'][4])}")
         print("Skipping download")
         return
 

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -94,7 +94,6 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
 
     # pass the zip file to deepcell.org
     print('Uploading files to DeepCell server.')
-    # run_deepcell_task(zip_path, deepcell_output_dir, host, job_type, scale)
     run_deepcell_direct(zip_path, deepcell_output_dir, host, job_type, scale, timeout)
 
     # extract the .tif output

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -75,7 +75,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
         deepcell_input_files=io_utils.remove_file_extensions(input_files))
 
     # partition fovs for smaller zip file batching
-    fov_groups = [fovs[i:i + 100] for i in 100 * range(len(fovs) // 100)]
+    fov_groups = [fovs[100 * i:100 * (i + 1)] for i in range(len(fovs) // 100)]
 
     print(f'Processing tiffs in {len(fov_groups)} batches...')
 

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -3,7 +3,7 @@ import requests
 from pathlib import Path
 import time
 from tqdm.notebook import tqdm
-from urllib.parse import unquote
+from urllib.parse import unquote, unquote_plus
 from twisted.internet import reactor
 from kiosk_client import manager
 import os
@@ -228,9 +228,7 @@ def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',
     # when done, download result or examine errors
     if len(redis_responce['value'][4]) > 0:
         # error happened
-        print(f"Encountered Failure: {unquote(redis_responce['value'][4])}")
-        print("Skipping download")
-        return
+        print(f"Encountered Failure(s): {unquote_plus(redis_responce['value'][4])}")
 
     deepcell_output = requests.get(redis_responce['value'][2], allow_redirects=True)
     open(os.path.join(output_dir, 'deepcell_responce.zip'), 'wb').write(deepcell_output.content)

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -15,7 +15,7 @@ from ark.utils import misc_utils
 
 def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
                            suffix='_feature_0', host='https://deepcell.org', job_type='multiplex',
-                           scale=1.0):
+                           scale=1.0, timeout=3600):
     """ Handles all of the necessary data manipulation for running deepcell tasks.
 
         Creates .zip files (to be used as input for DeepCell),
@@ -43,6 +43,9 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
             scale (float):
                 Value to rescale data by
                 Default: 1.0
+            timeout (int):
+                Approximate seconds until timeout.
+                Default: 1 hour (3600)
         Raises:
             ValueError:
                 Raised if there is some fov X (from fovs list) s.t.
@@ -91,7 +94,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
     # pass the zip file to deepcell.org
     print('Uploading files to DeepCell server.')
     # run_deepcell_task(zip_path, deepcell_output_dir, host, job_type, scale)
-    run_deepcell_direct(zip_path, deepcell_output_dir, host, job_type, scale)
+    run_deepcell_direct(zip_path, deepcell_output_dir, host, job_type, scale, timeout)
 
     # extract the .tif output
     print('Extracting tif files from DeepCell response.')
@@ -141,6 +144,25 @@ def run_deepcell_task(input_dir, output_dir, host='https://deepcell.org',
 
 def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',
                         job_type='multiplex', scale=1.0, timeout=3600):
+    """Uses direct calls to DeepCell API and saves output to output_dir.
+
+        Args:
+            input_dir (str):
+                location of .zip files
+            output_dir (str):
+                location to save deepcell output (as .zip)
+            host (str):
+                Hostname and port for the kiosk-frontend API server.
+                Default: 'https://deepcell.org'
+            job_type (str):
+                Name of job workflow (multiplex, segmentation, tracking).
+                Default: 'multiplex'
+            scale (float):
+                Value to rescale data by
+                Default: 1.0
+            Approximate seconds until timeout.
+                Default: 1 hour (3600)
+    """
 
     # upload zip file
     upload_url = host + '/api/upload'

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -8,7 +8,7 @@ import os
 import glob
 from zipfile import ZipFile, ZIP_DEFLATED
 import warnings
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 from ark.utils import misc_utils
 
@@ -119,7 +119,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
                     warnings.warn(f'Deep Cell output file was not found for {fov}.')
 
     # make calls in parallel
-    with ProcessPoolExecutor() as executor:
+    with ThreadPoolExecutor() as executor:
         executor.map(_zip_run_extract, fov_groups, range(len(fov_groups)))
 
 

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -160,7 +160,8 @@ def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',
             scale (float):
                 Value to rescale data by
                 Default: 1.0
-            Approximate seconds until timeout.
+            timeout (int):
+                Approximate seconds until timeout.
                 Default: 1 hour (3600)
     """
 

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -81,7 +81,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
     # partition fovs for smaller zip file batching
     fov_groups = [
         fovs[zip_size * i:zip_size * (i + 1)]
-        for i in range((len(fovs) // zip_size) + 1)
+        for i in range(((len(fovs) + zip_size - 1) // zip_size))
     ]
 
     print(f'Processing tiffs in {len(fov_groups)} batches...')

--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -217,6 +217,9 @@ def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',
             progress_bar.update(max(pbar_next - pbar_last, 0))
             pbar_last = pbar_next
 
+        if redis_responce['value'][0] not in ['done', 'waiting', 'new']:
+            print(redis_responce['value'])
+
         time.sleep(3.0)
         total_time += 3
     progress_bar.close()

--- a/ark/utils/deepcell_service_utils_test.py
+++ b/ark/utils/deepcell_service_utils_test.py
@@ -109,11 +109,12 @@ def test_create_deepcell_output(mocker):
                                        deepcell_output_dir=output_dir, suffix='_other_suffix',
                                        fovs=['fov1'])
 
+            # add additional fov for auto-batch testing
             pathlib.Path(os.path.join(input_dir, 'fov4.tif')).touch()
-            with pytest.warns(UserWarning):
-                create_deepcell_output(deepcell_input_dir=input_dir,
-                                       deepcell_output_dir=output_dir,
-                                       fovs=['fov1', 'fov2', 'fov3', 'fov4'], zip_size=3)
+
+            create_deepcell_output(deepcell_input_dir=input_dir,
+                                   deepcell_output_dir=output_dir,
+                                   fovs=['fov1', 'fov2', 'fov3', 'fov4'], zip_size=3)
 
             # check that there are two zip files with sizes 3, 1 respectively
             assert os.path.exists(os.path.join(input_dir, 'fovs_batch_1.zip'))

--- a/ark/utils/deepcell_service_utils_test.py
+++ b/ark/utils/deepcell_service_utils_test.py
@@ -7,7 +7,7 @@ import pytest
 from ark.utils.deepcell_service_utils import create_deepcell_output
 
 
-def mocked_run_deepcell(input_dir, output_dir, host, job_type, scale):
+def mocked_run_deepcell(input_dir, output_dir, host, job_type, scale, timeout):
     pathlib.Path(os.path.join(output_dir, 'fov1_feature_0.tif')).touch()
     pathlib.Path(os.path.join(output_dir, 'fov2_feature_0.tif')).touch()
     pathlib.Path(os.path.join(output_dir, 'fov3_feature_0.tif')).touch()

--- a/ark/utils/deepcell_service_utils_test.py
+++ b/ark/utils/deepcell_service_utils_test.py
@@ -100,7 +100,16 @@ def test_create_deepcell_output(mocker):
         pathlib.Path(os.path.join(input_dir, 'fov4.tif')).touch()
         with pytest.warns(UserWarning):
             create_deepcell_output(deepcell_input_dir=input_dir, deepcell_output_dir=output_dir,
-                                   fovs=['fov1', 'fov2', 'fov3', 'fov4'])
+                                   fovs=['fov1', 'fov2', 'fov3', 'fov4'], zip_size=3)
+
+        # check that there are two zip files with sizes 3, 1 respectively
+        assert os.path.exists(os.path.join(input_dir, 'fovs_batch_1.zip'))
+        assert os.path.exists(os.path.join(input_dir, 'fovs_batch_2.zip'))
+
+        with ZipFile(os.path.join(input_dir, 'fovs_batch_1.zip'), 'r') as zip_batch1:
+            assert zip_batch1.namelist() == ['fov1.tif', 'fov2.tif', 'fov3.tiff']
+        with ZipFile(os.path.join(input_dir, 'fovs_batch_2.zip'), 'r') as zip_batch2:
+            assert zip_batch2.namelist() == ['fov4.tif']
 
         # ValueError should be raised if .tif file does not exists for some fov in fovs
         with pytest.raises(ValueError):

--- a/ark/utils/deepcell_service_utils_test.py
+++ b/ark/utils/deepcell_service_utils_test.py
@@ -22,7 +22,7 @@ def mocked_run_deepcell(input_dir, output_dir, host, job_type, scale):
 
 def test_create_deepcell_output(mocker):
     with tempfile.TemporaryDirectory() as temp_dir:
-        mocker.patch('ark.utils.deepcell_service_utils.run_deepcell_task', mocked_run_deepcell)
+        mocker.patch('ark.utils.deepcell_service_utils.run_deepcell_direct', mocked_run_deepcell)
 
         input_dir = os.path.join(temp_dir, 'input_dir')
         os.makedirs(input_dir)

--- a/ark/utils/deepcell_service_utils_test.py
+++ b/ark/utils/deepcell_service_utils_test.py
@@ -18,6 +18,8 @@ def mocked_run_deepcell(in_zip_path, output_dir, host, job_type, scale, timeout)
     else:
         zip_path = os.path.join(output_dir, f'example_output_{batch_num}.zip')
     with ZipFile(zip_path, 'w') as zipObj:
+        if batch_num > 1:
+            return
         for i in range(1, 4):
             filename = os.path.join(output_dir, f'fov{i}_feature_0.tif')
             zipObj.write(filename, os.path.basename(filename))
@@ -69,10 +71,6 @@ def test_create_deepcell_output(mocker):
         # make sure DeepCell (.zip's) output exists
         assert os.path.exists(os.path.join(output_dir, 'example_output.zip'))
         assert os.path.exists(os.path.join(output_dir, 'example_output_2.zip'))
-
-        # DeepCell output .zip file should be extracted
-        assert os.path.exists(os.path.join(output_dir, 'fov1_feature_0.tif'))
-        assert os.path.exists(os.path.join(output_dir, 'fov2_feature_0.tif'))
 
         os.remove(os.path.join(output_dir, 'fov1_feature_0.tif'))
         os.remove(os.path.join(output_dir, 'fov2_feature_0.tif'))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,8 @@ autodoc_mock_imports = ['h5py'
                         'xarray',
                         'twisted',
                         'kiosk_client',
-                        'mpl_toolkits']
+                        'mpl_toolkits',
+                        'tqdm']
 
 # explicitly mock mibidata
 sys.modules['mibidata'] = mock.Mock()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ seaborn>=0.10.1,<1
 statsmodels>=0.11.1,<1
 umap-learn>=0.4.6,<1
 xarray>=0.12.3,<1
+tqdm>=4.54.1,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 jupyter>=1.0.0,<2
 jupyter_contrib_nbextensions>=0.5.1,<1
-kiosk-client>=0.8.4
 matplotlib>=2.2.2,<3
 numpy>=1.16.3,<2
 pandas>=0.23.3,<1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
                       'seaborn>=0.10.1,<1',
                       'statsmodels>=0.11.1,<1',
                       'umap-learn>=0.4.6,<1',
-                      'xarray>=0.12.3,<1'],
+                      'xarray>=0.12.3,<1',
+                      'tqdm>=4.54.1,<5'],
     extras_require={
         'tests': ['pytest',
                   'pytest-cov',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     download_url='https://github.com/angelolab/ark-analysis/archive/v{}.tar.gz'.format(VERSION),
     install_requires=['jupyter>=1.0.0,<2',
                       'jupyter_contrib_nbextensions>=0.5.1,<1',
-                      'kiosk-client>=0.8.4',
                       'matplotlib>=2.2.2,<3',
                       'numpy>=1.16.3,<2',
                       'pandas>=0.23.3,<1',


### PR DESCRIPTION
## **Purpose**

Replaces kiosk-client with direct calls to deepcell API.  This bypasses the kiosk client upload bug described in issue #302 so smaller zip files don't need to be created; we can just upload one.  Consequently closes #302 

## **Implementation**

Replaces kiosk-client usage in `deepcell_service_utils.py` with direct calls to deepcell's api.  This more closely mimics direct user interaction with deepcell.org.

## **Remaining issues**

Might want to check with Van Valen lab on how stable their deepcell API will be.
