### PR TITLE
Removes mibilib dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ python:
 # We add python path to enable testing jupyter notebooks
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install --no-deps -r requirements-nodeps.txt
   - travis_retry pip install -r requirements-test.txt
   - travis_retry export PYTHONPATH=$PWD
   # this is needed to install the requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,8 @@ RUN apt-get update && apt-get install -y gcc
 WORKDIR /scripts
 
 # copy over the requirements.txt, install dependencies, and README
-COPY setup.py requirements.txt requirements-nodeps.txt README.md /opt/ark-analysis/
+COPY setup.py requirements.txt README.md /opt/ark-analysis/
 RUN pip install -r /opt/ark-analysis/requirements.txt
-
-# install mibilib separately, with no dependencies, to avoid irrelevant dependency conflicts
-RUN pip install --no-deps -r /opt/ark-analysis/requirements-nodeps.txt
 
 # copy the scripts over
 COPY ark /opt/ark-analysis/ark

--- a/ark/utils/load_utils.py
+++ b/ark/utils/load_utils.py
@@ -4,8 +4,8 @@ import warnings
 import skimage.io as io
 import numpy as np
 import xarray as xr
-from mibidata import tiff
 
+from ark.utils.tiff_utils import read_mibitiff
 from ark.utils import io_utils as iou
 
 
@@ -63,7 +63,7 @@ def load_imgs_from_mibitiff(data_dir, mibitiff_files=None, channels=None, delimi
 
     # if no channels specified, get them from first MIBItiff file
     if channels is None:
-        channel_tuples = tiff.read(mibitiff_files[0]).channels
+        _, channel_tuples = read_mibitiff(mibitiff_files[0])
         channels = [channel_tuple[1] for channel_tuple in channel_tuples]
 
     if len(channels) == 0:
@@ -72,7 +72,7 @@ def load_imgs_from_mibitiff(data_dir, mibitiff_files=None, channels=None, delimi
     # extract images from MIBItiff file
     img_data = []
     for mibitiff_file in mibitiff_files:
-        img_data.append(tiff.read(mibitiff_file)[channels])
+        img_data.append(read_mibitiff(mibitiff_file, channels)[0])
     img_data = np.stack(img_data, axis=0)
     img_data = img_data.astype(dtype)
 

--- a/ark/utils/plot_utils.py
+++ b/ark/utils/plot_utils.py
@@ -1,10 +1,4 @@
-import os
-import copy
-
 import numpy as np
-import pandas as pd
-import skimage.io as io
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 

--- a/ark/utils/test_utils.py
+++ b/ark/utils/test_utils.py
@@ -7,10 +7,9 @@ import pandas as pd
 import xarray as xr
 import skimage.io as io
 
-from mibidata import mibi_image as mi, tiff
-
 import ark.settings as settings
 from ark.utils import synthetic_spatial_datagen
+from ark.utils.tiff_utils import write_mibitiff
 
 
 def gen_fov_chan_names(num_fovs, num_chans, return_imgs=False, use_delimiter=False):
@@ -261,12 +260,8 @@ def _write_mibitiff(base_dir, fov_names, channel_names, shape, sub_dir, fills, d
     mass_map = tuple(enumerate(channel_names, 1))
 
     for i, fov in enumerate(fov_names):
-        tif_obj = mi.MibiImage(tif_data[i, :, :, :],
-                               mass_map,
-                               **MIBITIFF_METADATA)
-
         tiffpath = os.path.join(base_dir, f'{fov}.tiff')
-        tiff.write(tiffpath, tif_obj, dtype=dtype)
+        write_mibitiff(tiffpath, tif_data[i, :, :, :], mass_map, MIBITIFF_METADATA)
         filelocs[fov] = tiffpath
 
     return filelocs, tif_data

--- a/ark/utils/tiff_utils.py
+++ b/ark/utils/tiff_utils.py
@@ -1,0 +1,144 @@
+from fractions import Fraction
+import numpy as np
+from skimage.external.tifffile import TiffFile, TiffWriter
+import json
+import datetime
+
+
+def read_mibitiff(file, channels=None):
+    """ Reads MIBI data from an IonpathMIBI TIFF file.
+
+    Currently, only SIMS data is supported
+
+    Args:
+        file (str): The string path or an open file object to a MIBItiff file.
+        channels (list): Targets to load. If None, all targets/channels are loaded
+
+    Returns:
+        tuple (np.ndarray, list[tuple]):
+        - image data
+        - channel data
+    """
+    return_channels = []
+    img_data = []
+    with TiffFile(file) as tif:
+
+        # make sure it's a mibitiff
+        _check_version(tif)
+
+        for page in tif.pages:
+
+            # get tags as json
+            description = json.loads(
+                page.tags['image_description'].value.decode('utf-8')
+            )
+
+            # only load supplied channels
+            if channels is not None and description['channel.target'] not in channels:
+                continue
+
+            # read channel data
+            return_channels.append((
+                description['channel.mass'],
+                description['channel.target']
+            ))
+
+            # read image data
+            img_data.append(page.asarray())
+
+    return np.stack(img_data, axis=2), return_channels
+
+
+def _check_version(file):
+    """ Checks that file is MIBItiff
+
+    Args:
+        file (TiffFile): opened tiff file
+
+    Raises:
+        ValueError
+    """
+    filetype = file.pages[0].tags.get('software')
+    if not (filetype and filetype.value.decode('utf-8').startswith('IonpathMIBI')):
+        raise ValueError('File is not of type IonpathMIBI...')
+
+
+_PREFIXED_METADATA_ATTRIBUTES = ('run', 'coordinates', 'size', 'slide',
+                                 'fov_id', 'fov_name', 'folder', 'dwell',
+                                 'scans', 'aperture', 'instrument', 'tissue',
+                                 'panel', 'mass_offset', 'mass_gain',
+                                 'time_resolution', 'miscalibrated',
+                                 'check_reg', 'filename', 'description',
+                                 'version')
+
+
+def write_mibitiff(filepath, img_data, channel_tuples, metadata):
+    """ Writes MIBI data to a multipage TIFF.
+
+    Args:
+        filepath (str):
+            The path to the target file
+        img_data (np.ndarray):
+            Image data
+        channel_tuples (iterable):
+            Iterable of tuples corresponding to image channel massess and target names
+        metadata (dict):
+            MIBItiff specific metadata
+    """
+
+    # set up mibitiff metadata
+    ranges = [(0, m) for m in img_data.max(axis=(0, 1))]
+
+    range_dtype = _range_dtype_map(img_data.dtype)
+
+    coordinates = [
+        (286, '2i', 1, _micron_to_cm(metadata['coordinates'][0])),
+        (287, '2i', 1, _micron_to_cm(metadata['coordinates'][1]))
+    ]
+    resolution = (img_data.shape[0] * 1e4 / float(metadata['size']),
+                  img_data.shape[1] * 1e4 / float(metadata['size']),
+                  'cm')
+
+    description = {}
+    for key, value in metadata.items():
+        if key in _PREFIXED_METADATA_ATTRIBUTES:
+            description[f'mibi.{key}'] = value
+        elif key != "date":
+            description[key] = value
+
+    with TiffWriter(filepath, software="IonpathMIBIv1.0") as infile:
+        for index, channel_tuple in enumerate(channel_tuples):
+            mass, target = channel_tuple
+            _metadata = description.copy()
+            _metadata.update({
+                'image.type': 'SIMS',
+                'channel.mass': int(mass),
+                'channel.target': target,
+            })
+            page_name = (
+                285, 's', 0, '{} ({})'.format(target,
+                                              mass)
+            )
+            min_value = (340, range_dtype, 1, ranges[index][0])
+            max_value = (341, range_dtype, 1, ranges[index][1])
+            page_tags = coordinates + [page_name, min_value, max_value]
+
+            infile.save(
+                img_data[:, :, index], compress=6, resolution=resolution,
+                extratags=page_tags, metadata=_metadata,
+                datetime=datetime.datetime.strptime(metadata['date'], '%Y-%m-%dT%H:%M:%S')
+            )
+
+
+def _micron_to_cm(um):
+    """ Converts microns to a fraction tuple in cm
+    """
+    frac = Fraction(float(um) / 10000).limit_denominator(1000000)
+    return frac.numerator, frac.denominator
+
+
+def _range_dtype_map(dtype):
+    if dtype == np.float32 or np.issubdtype(dtype, np.floating):
+        return 'd'
+    else:
+        return 'I'

--- a/ark/utils/tiff_utils.py
+++ b/ark/utils/tiff_utils.py
@@ -103,8 +103,6 @@ def write_mibitiff(filepath, img_data, channel_tuples, metadata):
     for key, value in metadata.items():
         if key in _PREFIXED_METADATA_ATTRIBUTES:
             description[f'mibi.{key}'] = value
-        elif key != "date":
-            description[key] = value
 
     with TiffWriter(filepath, software="IonpathMIBIv1.0") as infile:
         for index, channel_tuple in enumerate(channel_tuples):

--- a/ark/utils/tiff_utils_test.py
+++ b/ark/utils/tiff_utils_test.py
@@ -31,10 +31,10 @@ def test_read_mibitiff():
     # should throw error on standard tif load
     with pytest.raises(ValueError):
         with tempfile.TemporaryDirectory() as temp_dir:
-            paths, _ = test_utils.create_paired_xarray_fovs(temp_dir, ['test_fov'], ['chan0'])
+            filepaths, _ = test_utils.create_paired_xarray_fovs(temp_dir, ['test_fov'], ['chan0'])
 
             # should raise value error
-            img_data, all_channels = tiff_utils.read_mibitiff(paths['test_fov'])
+            img_data, all_channels = tiff_utils.read_mibitiff(filepaths['test_fov'][0] + '.tiff')
 
 
 # test write_mibitiff and verify with read_mibitiff
@@ -43,11 +43,11 @@ def test_write_mibitiff():
     fovs, chans = test_utils.gen_fov_chan_names(1, 10)
     with tempfile.TemporaryDirectory() as temp_dir:
         # this uses write_mibitiff
-        paths, true_data = test_utils.create_paired_xarray_fovs(temp_dir, fov_names=fovs,
-                                                                channel_names=chans,
-                                                                mode='mibitiff', fills=True)
+        filepaths, true_data = test_utils.create_paired_xarray_fovs(temp_dir, fov_names=fovs,
+                                                                    channel_names=chans,
+                                                                    mode='mibitiff', fills=True)
 
         # validate correct tiff writeout via read_mibitiff
-        load_data, chan_tups = tiff_utils.read_mibitiff(paths[fovs[0]])
+        load_data, chan_tups = tiff_utils.read_mibitiff(filepaths[fovs[0]])
 
         assert(np.all(true_data[0, :, :, :].values == load_data))

--- a/ark/utils/tiff_utils_test.py
+++ b/ark/utils/tiff_utils_test.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 import tempfile
+import pytest
 
 from ark.utils import tiff_utils, test_utils
 
@@ -26,6 +27,14 @@ def test_read_mibitiff():
     assert(subset_chan == all_channels[:3])
 
     assert(np.all(img_data[:, :, :3] == subset_imgdata))
+
+    # should throw error on standard tif load
+    with pytest.raises(ValueError):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            paths, _ = test_utils.create_paired_xarray_fovs(temp_dir, ['test_fov'], ['chan0'])
+
+            # should raise value error
+            img_data, all_channels = tiff_utils.read_mibitiff(paths['test_fov'])
 
 
 # test write_mibitiff and verify with read_mibitiff

--- a/ark/utils/tiff_utils_test.py
+++ b/ark/utils/tiff_utils_test.py
@@ -1,0 +1,44 @@
+import os
+import numpy as np
+import tempfile
+
+from ark.utils import tiff_utils, test_utils
+
+EXAMPLE_MIBITIFF_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), '..', '..',
+    'data/example_dataset/input_data/mibitiff_inputs',
+    'fov8_RowNumber0_Depth_Profile0-MassCorrected-Filtered.tiff'
+)
+
+
+# test read_mibitiff on static tiff file
+# shouldn't use test_utils here since it uses write_mibitiff
+def test_read_mibitiff():
+    img_data, all_channels = tiff_utils.read_mibitiff(EXAMPLE_MIBITIFF_PATH)
+
+    assert(img_data.shape == (1024, 1024, len(all_channels)))
+
+    channel_names = [chan_tup[1] for chan_tup in all_channels]
+
+    subset_imgdata, subset_chan = tiff_utils.read_mibitiff(EXAMPLE_MIBITIFF_PATH,
+                                                           channels=channel_names[:3])
+
+    assert(subset_chan == all_channels[:3])
+
+    assert(np.all(img_data[:, :, :3] == subset_imgdata))
+
+
+# test write_mibitiff and verify with read_mibitiff
+# test utils uses write_mibitiff so we can just use that to test it
+def test_write_mibitiff():
+    fovs, chans = test_utils.gen_fov_chan_names(1, 10)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # this uses write_mibitiff
+        paths, true_data = test_utils.create_paired_xarray_fovs(temp_dir, fov_names=fovs,
+                                                                channel_names=chans,
+                                                                mode='mibitiff', fills=True)
+
+        # validate correct tiff writeout via read_mibitiff
+        load_data, chan_tups = tiff_utils.read_mibitiff(paths[fovs[0]])
+
+        assert(np.all(true_data[0, :, :, :].values == load_data))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,9 +63,7 @@ napoleon_google_docstring = True
 
 # contains list of modules to be marked up
 # will ensure 'clean' imports of all the following libraries
-# I imagine mibidata will be a problem we'll have to address in the future...
-autodoc_mock_imports = ['h5py'
-                        'mibidata',
+autodoc_mock_imports = ['h5py',
                         'numpy',
                         'matplotlib',
                         'pandas',
@@ -80,9 +78,6 @@ autodoc_mock_imports = ['h5py'
                         'twisted',
                         'kiosk_client',
                         'mpl_toolkits']
-
-# explicitly mock mibidata
-sys.modules['mibidata'] = mock.Mock()
 
 # prefix each section label with the name of the document it is in, followed by a colon
 # autosection_label_prefix_document = True

--- a/requirements-nodeps.txt
+++ b/requirements-nodeps.txt
@@ -1,1 +1,0 @@
-git+git://github.com/ionpath/mibilib@v1.3.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from distutils.command.build_ext import build_ext as DistUtilsBuildExt
 from setuptools import setup, find_packages
 
 VERSION = '0.2.8'
-VERSION_MIBILIB = '1.3.0'
 
 
 # set a long description which is basically the README
@@ -40,8 +39,6 @@ setup(
                   'pytest-pycodestyle',
                   'testbook']
     },
-    dependency_links=['https://github.com/ionpath/mibilib/archive/v{}.tar.gz#egg=python-s3-{}'
-                      .format(VERSION_MIBILIB, VERSION_MIBILIB.replace('.', '-'))],
     long_description=long_description,
     long_description_content_type='text/markdown',
     classifiers=['License :: OSI Approved :: Apache Software License',

--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -371,7 +371,7 @@
     "overlay_channels = data_xr_summed.channels.values\n",
     "warnings.simplefilter(\"ignore\")\n",
     "\n",
-    "fov_to_display = io_utils.remove_file_extensions(fovs[0])\n",
+    "fov_to_display = io_utils.remove_file_extensions([fovs[0]])[0]\n",
     "\n",
     "fov_overlay = plot_utils.create_overlay(\n",
     "    segmentation_labels.loc[fov_to_display, :, :, 'whole_cell'].values,\n",

--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "slideshow": {
      "slide_type": "slide"
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "tags": [
      "file_path"
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "tags": [
      "create_dirs"
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "tags": [
      "validate_path"
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "tags": [
      "mibitiff_set"
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "tags": [
      "load_fovs"
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "tags": [
      "nuc_mem_set"
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "scrolled": true,
     "tags": [
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "tags": [
      "load_data_xr"
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "tags": [
      "gen_input"
@@ -234,13 +234,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "tags": [
      "create_output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Zipping preprocessed tif files.\n",
+      "Uploading files to DeepCell server.\n",
+      "100%|██████████| 100/100 [00:16<00:00,  6.19it/s]\n",
+      "Extracting tif files from DeepCell response.\n"
+     ]
+    }
+   ],
    "source": [
     "deepcell_service_utils.create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=fovs)"
    ]
@@ -347,6 +358,9 @@
       ]
      },
      "metadata": {
+      "tags": [
+       "display_example"
+      ],
       "needs_background": "light"
      },
      "output_type": "display_data"
@@ -357,7 +371,7 @@
     "overlay_channels = data_xr_summed.channels.values\n",
     "warnings.simplefilter(\"ignore\")\n",
     "\n",
-    "fov_to_display = 'fov8'\n",
+    "fov_to_display = fovs[0]\n",
     "\n",
     "fov_overlay = plot_utils.create_overlay(\n",
     "    segmentation_labels.loc[fov_to_display, :, :, 'whole_cell'].values,\n",
@@ -451,7 +465,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.6.12-final"
   }
  },
  "nbformat": 4,

--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -371,7 +371,7 @@
     "overlay_channels = data_xr_summed.channels.values\n",
     "warnings.simplefilter(\"ignore\")\n",
     "\n",
-    "fov_to_display = fovs[0]\n",
+    "fov_to_display = io_utils.remove_file_extensions(fovs[0])\n",
     "\n",
     "fov_overlay = plot_utils.create_overlay(\n",
     "    segmentation_labels.loc[fov_to_display, :, :, 'whole_cell'].values,\n",


### PR DESCRIPTION
## **What is the purpose of this PR?**

Some users have had trouble building the docker due to mibilib's strict library dependencies.  We've attempted to address this before, but problems persist.  This PR removes the mibilib dependency, while preserving basic mibitiff support.

## **How did you implement your changes**

Calls to `mibilib.tiff` are no longer used; `tiff_utils.read_mibitiff` and `tiff_utils.write_mibitiff` replace its usages.

## **Remaining issues**

Only a limited subset of mibitiff is supported, not the entire specification.  All that's been implemented is the basic functionality required to read/write channel data from/to mibitiffs.
