### PR TITLE
adds requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ jupyter_contrib_nbextensions>=0.5.1,<1
 matplotlib>=2.2.2,<3
 numpy>=1.16.3,<2
 pandas>=0.23.3,<1
+requests>=2.25.1,<3
 scikit-image>=0.14.3,<=0.16.2
 scikit-learn>=0.19.1,<1
 scipy>=1.1.0,<2

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
                       'matplotlib>=2.2.2,<3',
                       'numpy>=1.16.3,<2',
                       'pandas>=0.23.3,<1',
+                      'requests>=2.25.1,<3'
                       'scikit-image>=0.14.3,<=0.16.2',
                       'scikit-learn>=0.19.1,<1',
                       'scipy>=1.1.0,<2',


### PR DESCRIPTION
## **Purpose**

I forgot to add the `requests` dependency to `requirements.txt` in PR #369.  Travis passed then only because `requests` is a sub-dependency of one of our `requirements-test.txt` dependencies, meaning it gets installed as if it were a regular requirement.

## **How did you implement your changes**

Adds `requests` as dependency in requirements and setup