### PR TITLE
adds missing comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
                       'matplotlib>=2.2.2,<3',
                       'numpy>=1.16.3,<2',
                       'pandas>=0.23.3,<1',
-                      'requests>=2.25.1,<3'
+                      'requests>=2.25.1,<3',
                       'scikit-image>=0.14.3,<=0.16.2',
                       'scikit-learn>=0.19.1,<1',
                       'scipy>=1.1.0,<2',


### PR DESCRIPTION
## **Purpose**

There's a typo in `setup.py` that prevents docker from building.  Travis lets this build since it doesn't rely on setup.py while docker does.

## **How did you implement your changes**

Adds a lonely comma

## **Remaining issues**

mostly some shame tbh.  I suppose we could look into changing our travis testing to necessitate using `setup.py` somehow, but, regardless, it's probably best to just remember to try new setups/requirements related builds locally before hastily submitting pr's @ackagel  (I checked and this one builds fine)