### PR TITLE
Add consensus clustering process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN R -e "install.packages('arrow')"
 RUN R -e "install.packages('data.table')"
 RUN R -e "install.packages('BiocManager')"
 RUN R -e "BiocManager::install('FlowSOM')"
+RUN R -e "BiocManager::install('ConsensusClusterPlus')"
 
 # jupyter notebook
 CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--allow-root"]

--- a/ark/phenotyping/consensus_cluster.R
+++ b/ark/phenotyping/consensus_cluster.R
@@ -1,0 +1,53 @@
+# Runs consensus clustering on the pixel data averaged across all channels
+
+# Usage: Rscript {fovs} {channels} {maxK} {cap} {clusterAvgPath} {consensusClusterPath}
+
+# - fovs: list of fovs to cluster
+# - markers: list of channel columns to use
+# - maxK: number of consensus clusters
+# - cap: z-score scaling factor
+# - clusterAvgPath: path to the averaged cluster data
+# - consensusClusterPath: path to file where the consensus cluster results will be written
+
+library(arrow)
+library(data.table)
+library(ConsensusClusterPlus)
+
+# get the command line arguments
+args <- commandArgs(trailingOnly=TRUE)
+
+# create the list of fovs
+fovs <- unlist(strsplit(args[1], split=","))
+
+# create the list of channels
+markers <- unlist(strsplit(args[2], split=","))
+
+# get number of consensus clusters
+maxK <- strtoi(args[3])
+
+# get z-score scaling factor
+cap <- strtoi(args[4])
+
+# get path to the averaged channel data
+clusterAvgPath <- args[5]
+
+# get consensus clustered write path
+consensusClusterPath <- args[6]
+
+# read cluster averaged data
+print("Reading cluster averaged data")
+clusterAvgs <- arrow::read_feather(clusterAvgPath)
+
+# scale and cap the data accordingly
+print("Scaling data")
+clusterAvgsScale <- pmin(scale(clusterAvgs[markers]), cap)
+
+# run the consensus clustering
+print("Running consensus clustering")
+consensusClusterResults <- ConsensusClusterPlus(t(clusterAvgsScale), maxK=maxK)
+hClust <- consensusClusterResults[[maxK]]$consensusClass
+clusterAvgs$hCluster_cap = hClust[clusterAvgs$cluster]
+
+# saving consensus clustering results
+print('Writing consensus clustering results')
+arrow::write_feather(as.data.table(clusterAvgs), consensusClusterPath)

--- a/ark/phenotyping/consensus_cluster.R
+++ b/ark/phenotyping/consensus_cluster.R
@@ -1,8 +1,7 @@
 # Runs consensus clustering on the pixel data averaged across all channels
 
-# Usage: Rscript {fovs} {channels} {maxK} {cap} {clusterAvgPath} {consensusClusterPath}
+# Usage: Rscript {markers} {maxK} {cap} {clusterAvgPath} {consensusClusterPath}
 
-# - fovs: list of fovs to cluster
 # - markers: list of channel columns to use
 # - maxK: number of consensus clusters
 # - cap: z-score scaling factor
@@ -16,23 +15,20 @@ library(ConsensusClusterPlus)
 # get the command line arguments
 args <- commandArgs(trailingOnly=TRUE)
 
-# create the list of fovs
-fovs <- unlist(strsplit(args[1], split=","))
-
 # create the list of channels
-markers <- unlist(strsplit(args[2], split=","))
+markers <- unlist(strsplit(args[1], split=","))
 
 # get number of consensus clusters
-maxK <- strtoi(args[3])
+maxK <- strtoi(args[2])
 
 # get z-score scaling factor
-cap <- strtoi(args[4])
+cap <- strtoi(args[3])
 
 # get path to the averaged channel data
-clusterAvgPath <- args[5]
+clusterAvgPath <- args[4]
 
 # get consensus clustered write path
-consensusClusterPath <- args[6]
+consensusClusterPath <- args[5]
 
 # read cluster averaged data
 print("Reading cluster averaged data")

--- a/ark/phenotyping/run_trained_som.R
+++ b/ark/phenotyping/run_trained_som.R
@@ -56,7 +56,7 @@ for (i in 1:length(fovs)) {
     clusters <- FlowSOM:::MapDataToCodes(somWeights, fovPixelData)
 
     # assign cluster labels column to pixel data
-    fovPixelData <- as.matrix(cbind(as.matrix(fovPixelData), clusters=clusters[,1]))
+    fovPixelData <- as.matrix(cbind(as.matrix(fovPixelData), cluster=clusters[,1]))
 
     # write to feather
     clusterPath <- paste(pixelClusterDir, fileName, sep="/")

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -13,6 +13,60 @@ from ark.utils import io_utils
 from ark.utils import misc_utils
 
 
+def compute_cluster_avg(fovs, channels, base_dir,
+                        cluster_dir='pixel_mat_clustered',
+                        cluster_avg_name='pixel_cluster_avg.feather'):
+    """Averages channel values across all fovs in pixel_mat_clustered
+
+    Args:
+        fovs (list):
+            The list of fovs to subset on
+        channels (list):
+            The list of channels to subset on
+        base_dir (str):
+            Name of the directory to save the pixel files to
+        cluster_dir (str):
+            Name of the file containing the pixel data with cluster labels
+        cluster_avg_name (str):
+            Name of file to save the averaged results to
+    """
+
+    cluster_avgs = None
+
+    for fov in fovs:
+        # read in the fovs data
+        fov_pixel_data = feather.read_dataframe(
+            os.path.join(base_dir, cluster_dir, fov + '.feather'))
+
+        # aggregate the sums and counts
+        sum_by_cluster = fov_pixel_data.groupby('cluster')[channels].sum()
+        count_by_cluster = fov_pixel_data.groupby('cluster')[channels].size().to_frame('count')
+
+        # concat the results together
+        agg_results = pd.merge(
+            sum_by_cluster, count_by_cluster, left_index=True, right_index=True).reset_index()
+
+        # set to cluster_avgs if not defined, otherwise concat
+        if cluster_avgs is None:
+            cluster_avgs = agg_results
+        else:
+            cluster_avgs = pd.concat([cluster_avgs, agg_results])
+
+    # sum the counts and the channel sums
+    sum_count_totals = cluster_avgs.groupby('cluster')[channels + ['count']].sum().reset_index()
+
+    # now compute the means using the count column
+    sum_count_totals[channels] = sum_count_totals[channels].div(sum_count_totals['count'], axis=0)
+
+    # drop the count column
+    sum_count_totals = sum_count_totals.drop('count', axis=1)
+
+    # save the DataFrame
+    feather.write_dataframe(sum_count_totals,
+                            os.path.join(base_dir, cluster_avg_name),
+                            compression='uncompressed')
+
+
 def create_pixel_matrix(img_xr, seg_labels, base_dir,
                         pre_dir='pixel_mat_preprocessed',
                         sub_dir='pixel_mat_subsetted', fovs=None,
@@ -159,7 +213,7 @@ def train_som(fovs, channels, base_dir,
     misc_utils.verify_in_list(provided_channels=channels,
                               subsetted_channels=sample_sub.columns.values)
 
-    # run som_train.R
+    # run the SOM training process
     process_args = ['Rscript', '/create_som_matrix.R', ','.join(fovs), ','.join(channels),
                     str(num_passes), subsetted_path, weights_path]
     process = subprocess.Popen(process_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -227,8 +281,63 @@ def cluster_pixels(fovs, base_dir, pre_dir='pixel_mat_preprocessed',
     if not os.path.exists(clustered_path):
         os.mkdir(clustered_path)
 
+    # run the trained SOM on the dataset, assigning clusters
     process_args = ['Rscript', '/run_trained_som.R', ','.join(fovs),
                     preprocessed_path, weights_path, clustered_path]
+
+    process = subprocess.Popen(process_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    # continuously poll the process for output/error so it gets displayed in the Jupyter notebook
+    while True:
+        # convert from byte string
+        output = process.stdout.readline().decode('utf-8')
+
+        # if the output is nothing and the process is done, break
+        if process.poll() is not None:
+            break
+        if output:
+            print(output.strip())
+
+
+def consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
+                      cluster_dir='pixel_mat_clustered',
+                      cluster_avg_name='pixel_cluster_avg.feather',
+                      consensus_name='cluster_consensus.feather'):
+    """Run consensus clustering algorithm on summed data across channels
+
+    Args:
+        fovs (list):
+            The list of fovs to subset on
+        channels (list):
+            The list of channels to subset on
+        base_dir (str):
+            Name of the directory to save the pixel files to
+        max_k (int):
+            The number of consensus clusters
+        cap (int):
+            z-score cap to use when hierarchical clustering
+        cluster_dir (str):
+            Name of the file containing the pixel data with cluster labels
+        cluster_avg_name (str):
+            Name of file to save the channel-averaged results to
+        consensus_name (str):
+            Name of file to save the consensus clustered results
+    """
+
+    clustered_path = os.path.join(base_dir, cluster_dir)
+    cluster_avg_path = os.path.join(base_dir, cluster_avg_name)
+    consensus_path = os.path.join(base_dir, consensus_name)
+
+    if not os.path.exists(clustered_path):
+        raise FileNotFoundError('Cluster dir %s does not exist in base_dir %s' %
+                                (base_dir, consensus_path))
+
+    # compute and write the averaged cluster results
+    compute_cluster_avg(fovs, channels, base_dir, cluster_dir)
+
+    # run the consensus clustering process
+    process_args = ['Rscript', '/consensus_cluster.R', ','.join(fovs), ','.join(channels),
+                    str(max_k), str(cap), cluster_avg_path, consensus_path]
 
     process = subprocess.Popen(process_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -31,7 +31,7 @@ def compute_cluster_avg(fovs, channels, base_dir,
             Name of file to save the averaged results to
     """
 
-    cluster_avgs = None
+    cluster_avgs = pd.DataFrame()
 
     for fov in fovs:
         # read in the fovs data
@@ -46,11 +46,7 @@ def compute_cluster_avg(fovs, channels, base_dir,
         agg_results = pd.merge(
             sum_by_cluster, count_by_cluster, left_index=True, right_index=True).reset_index()
 
-        # set to cluster_avgs if not defined, otherwise concat
-        if cluster_avgs is None:
-            cluster_avgs = agg_results
-        else:
-            cluster_avgs = pd.concat([cluster_avgs, agg_results])
+        cluster_avgs = pd.concat([cluster_avgs, agg_results])
 
     # sum the counts and the channel sums
     sum_count_totals = cluster_avgs.groupby('cluster')[channels + ['count']].sum().reset_index()
@@ -336,7 +332,7 @@ def consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
     compute_cluster_avg(fovs, channels, base_dir, cluster_dir)
 
     # run the consensus clustering process
-    process_args = ['Rscript', '/consensus_cluster.R', ','.join(fovs), ','.join(channels),
+    process_args = ['Rscript', '/consensus_cluster.R', ','.join(channels),
                     str(max_k), str(cap), cluster_avg_path, consensus_path]
 
     process = subprocess.Popen(process_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/ark/phenotyping/som_utils_test.py
+++ b/ark/phenotyping/som_utils_test.py
@@ -68,7 +68,7 @@ def mocked_cluster_pixels(fovs, base_dir, pre_dir='pixel_mat_preprocessed',
                                                           fov + '.feather'))
 
 
-def mocked_consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
+def mocked_consensus_cluster(channels, base_dir, max_k=20, cap=3,
                              cluster_avg_name='pixel_cluster_avg.feather',
                              consensus_name='cluster_consensus.feather'):
     # read the cluster average
@@ -363,7 +363,7 @@ def test_consensus_cluster(mocker):
         mocker.patch('ark.phenotyping.som_utils.consensus_cluster', mocked_consensus_cluster)
 
         # run "consensus clustering" using mocked function
-        som_utils.consensus_cluster(fovs=fovs, channels=chans, base_dir=temp_dir)
+        som_utils.consensus_cluster(channels=chans, base_dir=temp_dir)
 
         # assert the final consensus cluster file has been created
         assert os.path.exists(os.path.join(temp_dir, 'cluster_consensus.feather'))

--- a/ark/phenotyping/som_utils_test.py
+++ b/ark/phenotyping/som_utils_test.py
@@ -60,12 +60,80 @@ def mocked_cluster_pixels(fovs, base_dir, pre_dir='pixel_mat_preprocessed',
         cluster_ids = cluster_ids.astype(int)
 
         # now assign the calculated cluster_ids as the cluster assignment
-        fov_mat_pre['clusters'] = cluster_ids
+        fov_mat_pre['cluster'] = cluster_ids
 
-        # write clustered data to HDF5
+        # write clustered data to feather
         feather.write_dataframe(fov_mat_pre, os.path.join(base_dir,
                                                           cluster_dir,
                                                           fov + '.feather'))
+
+
+def mocked_consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
+                             cluster_avg_name='pixel_cluster_avg.feather',
+                             consensus_name='cluster_consensus.feather'):
+    # read the cluster average
+    cluster_avg = feather.read_dataframe(os.path.join(base_dir, cluster_avg_name))
+
+    # dummy scaling using cap
+    cluster_avg_scale = cluster_avg[channels] * (cap - 1) / cap
+
+    # get the mean weight for each channel column
+    cluster_means = cluster_avg_scale.mean(axis=1)
+
+    # multiply by 100 and mod by 20 to get dummy cluster ids for consensus clustering
+    cluster_ids = cluster_means * 100
+    cluster_ids = cluster_ids.astype(int) % 20
+
+    # assign dummy consensus cluster ids
+    cluster_avg['hCluster_cap'] = cluster_ids
+
+    # write consensus cluster results to feather
+    feather.write_dataframe(cluster_avg, os.path.join(base_dir, consensus_name))
+
+
+def test_compute_cluster_avg():
+    # define list of fovs and channels
+    fovs = ['fov0', 'fov1', 'fov2']
+    chans = ['chan0', 'chan1', 'chan2']
+
+    # do not need to test for cluster_dir existence, that happens in consensus_cluster
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # create a dummy clustered matrix
+        os.mkdir(os.path.join(temp_dir, 'pixel_mat_clustered'))
+
+        # write dummy clustered data for each fov
+        for fov in fovs:
+            # create dummy preprocessed data for each fov
+            fov_cluster_matrix = pd.DataFrame(
+                np.repeat(np.array([[0.1, 0.2, 0.3]]), repeats=1000, axis=0),
+                columns=chans
+            )
+
+            # assign dummy cluster labels
+            fov_cluster_matrix['cluster'] = np.repeat(np.arange(100), repeats=10)
+
+            # write the dummy data to pixel_mat_clustered
+            feather.write_dataframe(fov_cluster_matrix, os.path.join(temp_dir,
+                                                                     'pixel_mat_clustered',
+                                                                     fov + '.feather'))
+
+        # compute cluster average matrix
+        som_utils.compute_cluster_avg(fovs, chans, temp_dir)
+
+        # assert that pixel_cluster_avg.feather was actually created
+        assert os.path.exists(os.path.join(temp_dir, 'pixel_cluster_avg.feather'))
+
+        # read the averaged results
+        cluster_avg = feather.read_dataframe(os.path.join(temp_dir, 'pixel_cluster_avg.feather'))
+
+        # verify the provided channels and the channels in cluster_avg are exactly the same
+        misc_utils.verify_same_elements(
+            cluster_avg_chans=cluster_avg[chans].columns.values,
+            provided_chans=chans)
+
+        # assert all rows equal [0.1, 0.2, 0.3], round due to minor float arithmetic inaccuracies
+        result = np.repeat(np.array([[0.1, 0.2, 0.3]]), repeats=100, axis=0)
+        assert np.array_equal(result, np.round(cluster_avg[chans].values, 1))
 
 
 def test_create_pixel_matrix():
@@ -253,5 +321,58 @@ def test_cluster_pixels(mocker):
                                                                    fov + '.feather'))
 
             # assert we didn't assign any cluster 100 or above
-            cluster_ids = fov_cluster_data['clusters']
+            cluster_ids = fov_cluster_data['cluster']
             assert np.all(cluster_ids < 100)
+
+
+def test_consensus_cluster(mocker):
+    # basic error checks: bad path to clustered dir
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with pytest.raises(FileNotFoundError):
+            som_utils.consensus_cluster(fovs=['fov0'], channels=['chan0'],
+                                        base_dir=temp_dir, cluster_dir='bad_path')
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # define fovs and channels
+        fovs = ['fov0', 'fov1', 'fov2']
+        chans = ['Marker1', 'Marker2', 'Marker3', 'Marker4']
+
+        # create a dummy clustered matrix
+        os.mkdir(os.path.join(temp_dir, 'pixel_mat_clustered'))
+
+        # write dummy clustered data for each fov
+        for fov in fovs:
+            # create dummy preprocessed data for each fov
+            fov_cluster_matrix = pd.DataFrame(
+                np.repeat(np.array([[0.1, 0.2, 0.3, 0.4]]), repeats=1000, axis=0),
+                columns=chans
+            )
+
+            # assign dummy cluster labels
+            fov_cluster_matrix['cluster'] = np.repeat(np.arange(100), repeats=10)
+
+            # write the dummy data to pixel_mat_clustered
+            feather.write_dataframe(fov_cluster_matrix, os.path.join(temp_dir,
+                                                                     'pixel_mat_clustered',
+                                                                     fov + '.feather'))
+
+        # compute averages by cluster, this happens before call to R
+        som_utils.compute_cluster_avg(fovs, chans, temp_dir)
+
+        # add mocked function to "consensus cluster" data averaged by cluster
+        mocker.patch('ark.phenotyping.som_utils.consensus_cluster', mocked_consensus_cluster)
+
+        # run "consensus clustering" using mocked function
+        som_utils.consensus_cluster(fovs=fovs, channels=chans, base_dir=temp_dir)
+
+        # assert the final consensus cluster file has been created
+        assert os.path.exists(os.path.join(temp_dir, 'cluster_consensus.feather'))
+
+        # read the dummy consensus cluster results in
+        consensus_cluster_results = feather.read_dataframe(
+            os.path.join(temp_dir, 'cluster_consensus.feather')
+        )
+
+        # assert we didn't assign any cluster 20 or above
+        cluster_ids = consensus_cluster_results['hCluster_cap']
+        assert np.all(cluster_ids < 20)

--- a/ark/utils/notebooks_test_utils.py
+++ b/ark/utils/notebooks_test_utils.py
@@ -242,7 +242,19 @@ def flowsom_run(tb, fovs, channels):
                                                             '%s' + '.feather'))
         """ % (str(channels), fov, fov)
 
-    tb.inject(dummy_cluster_cmd, after='cluster_pixel_mat')
+        tb.inject(dummy_cluster_cmd, after='cluster_pixel_mat')
+
+    # create a dummy consensus clustered data file
+    dummy_consensus = """
+        sample_consensus = pd.DataFrame(np.random.rand(100, len(channels)), columns=channels)
+        sample_consensus['clusters'] = np.arange(100)
+        sample_consensus['hCluster_cap'] = np.repeat(np.arange(20), repeats=5)
+
+        feather.write_dataframe(sample_consensus, os.path.join(base_dir,
+                                                               'cluster_consensus.feather'))
+    """
+
+    tb.inject(dummy_consensus, after='consensus_cluster')
 
 
 def fov_channel_input_set(tb, fovs=None, nucs_list=None, mems_list=None):

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -25,4 +25,5 @@ docker run -it \
   -v "$PWD/data:/data" \
   -v "$PWD/ark/phenotyping/create_som_matrix.R:/create_som_matrix.R" \
   -v "$PWD/ark/phenotyping/run_trained_som.R:/run_trained_som.R" \
+  -v "$PWD/ark/phenotyping/consensus_cluster.R:/consensus_cluster.R" \
   ark-analysis:latest

--- a/templates/example_flowsom_clustering.ipynb
+++ b/templates/example_flowsom_clustering.ipynb
@@ -222,6 +222,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Run consensus clustering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "som_utils.consensus_cluster(fovs, channels, base_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "TODO: add post-processing pixel clustering steps"
    ]
   }
@@ -242,7 +258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/templates/example_flowsom_clustering.ipynb
+++ b/templates/example_flowsom_clustering.ipynb
@@ -228,7 +228,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "consensus_cluster"
+    ]
+   },
    "outputs": [],
    "source": [
     "som_utils.consensus_cluster(fovs, channels, base_dir)"
@@ -258,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses and closes #364. The next step in the clustering pipeline is to add Candace's meta-clustering process, which involves using consensus clustering to analyze the data associated with each SOM cluster assignment.

**How did you implement your changes**

We utilize R's `ConsensusClusterPlus` library and add a new R file `consensus_cluster.R` as a runner. To compute the average channel values across all `fovs`, we add a preprocessing algorithm to `som_utils.py`: `compute_cluster_avg`.
