### PR TITLE
Split nuclei bugfix

### DIFF
--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -255,7 +255,7 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
                                                       nuc_segmentation_labels=nuc_labels,
                                                       cell_ids=unique_cell_ids)
 
-        nuc_props = get_single_compartment_props(segmentation_labels.loc[:, :, 'nuclear'].values,
+        nuc_props = get_single_compartment_props(nuc_labels,
                                                  regionprops_base, regionprops_single_comp,
                                                  **reg_props)
 

--- a/ark/segmentation/marker_quantification_test.py
+++ b/ark/segmentation/marker_quantification_test.py
@@ -315,6 +315,25 @@ def test_compute_marker_counts_nuc_whole_cell_diff():
     assert np.array_equal(segmentation_output_unequal.loc['nuclear', :, 'cell_size'],
                           segmentation_output_unequal.loc['nuclear', :, 'area'])
 
+    # check that splitting large nuclei works as expected
+
+    # swap nuclear and cell masks so that nuc is bigger
+    big_nuc_masks = np.concatenate((nuc_mask, cell_mask), axis=-1)
+    segmentation_labels_big_nuc = test_utils.make_labels_xarray(
+        label_data=big_nuc_masks,
+        compartment_names=['whole_cell', 'nuclear']
+    )
+
+    # test utils output is 4D but tests require 3D
+    segmentation_labels_big_nuc = segmentation_labels_big_nuc[0]
+
+    segmentation_output_big_nuc = \
+        marker_quantification.compute_marker_counts(
+            input_images=input_images,
+            segmentation_labels=segmentation_labels_big_nuc,
+            nuclear_counts=True,
+            split_large_nuclei=True)
+
 
 def test_compute_marker_counts_no_coords():
     cell_mask, channel_data = test_utils.create_test_extraction_data()

--- a/ark/utils/segmentation_utils.py
+++ b/ark/utils/segmentation_utils.py
@@ -39,7 +39,7 @@ def find_nuclear_label_id(nuc_segmentation_labels, cell_coords):
     return nuclear_label_id
 
 
-def split_large_nuclei(cell_segmentation_labels, nuc_segmentation_labels, cell_ids, min_size=5):
+def split_large_nuclei(cell_segmentation_labels, nuc_segmentation_labels, cell_ids, min_size=15):
     """Splits nuclei that are bigger than the corresponding cell into multiple pieces
 
     Args:


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**
The current split_nuclei logic first modifies the nuclear segmentation mask, and then uses that modified mask to extract signal. However, it doesn't provide that modified mask to the regionprops function, which results in a mismatch between the outputs from the two

**How did you implement your changes**
I passed in the modified nuclear segmentations to the regionprops function so that the outputs match up. I also switched the min_size value to match up with the current min_size from Mesmer

**Remaining issues**
We don't pass these modified nuc masks back to the user, but given that this setting is turned off by default I think that's okay for now. 
