### PR TITLE
Modify validate_paths to work outside docker

### DIFF
--- a/ark/utils/io_utils.py
+++ b/ark/utils/io_utils.py
@@ -32,10 +32,10 @@ def validate_paths(paths, data_prefix=True):
                 raise ValueError(
                     f'The file/path, {pathlib.Path(path).name}, could not be found...')
             else:
-                    raise ValueError(
-                        f'The path, {path}, is not prefixed with \'../data\'.\n'
-                        f'Be sure to add all images/files/data to the \'data\' folder, '
-                        f'and to reference as \'../data/path_to_data/myfile.tif\'')
+                raise ValueError(
+                    f'The path, {path}, is not prefixed with \'../data\'.\n'
+                    f'Be sure to add all images/files/data to the \'data\' folder, '
+                    f'and to reference as \'../data/path_to_data/myfile.tif\'')
 
 
 def list_files(dir_name, substrs=None, exact_match=False):

--- a/ark/utils/io_utils.py
+++ b/ark/utils/io_utils.py
@@ -3,12 +3,14 @@ import pathlib
 import warnings
 
 
-def validate_paths(paths):
+def validate_paths(paths, data_prefix=True):
     """Verifys that paths exist and don't leave Docker's scope
 
     Args:
         paths (str or list):
             paths to verify.
+        data_prefix (bool):
+            if True, checks that directory starts with /data, necessary when inside the docker
 
     Raises:
         ValueError:
@@ -21,7 +23,7 @@ def validate_paths(paths):
 
     for path in paths:
         if not os.path.exists(path):
-            if str(path).startswith('../data'):
+            if str(path).startswith('../data') or not data_prefix:
                 for parent in reversed(pathlib.Path(path).parents):
                     if not os.path.exists(parent):
                         raise ValueError(
@@ -30,10 +32,10 @@ def validate_paths(paths):
                 raise ValueError(
                     f'The file/path, {pathlib.Path(path).name}, could not be found...')
             else:
-                raise ValueError(
-                    f'The path, {path}, is not prefixed with \'../data\'.\n'
-                    f'Be sure to add all images/files/data to the \'data\' folder, '
-                    f'and to reference as \'../data/path_to_data/myfile.tif\'')
+                    raise ValueError(
+                        f'The path, {path}, is not prefixed with \'../data\'.\n'
+                        f'Be sure to add all images/files/data to the \'data\' folder, '
+                        f'and to reference as \'../data/path_to_data/myfile.tif\'')
 
 
 def list_files(dir_name, substrs=None, exact_match=False):

--- a/ark/utils/io_utils_test.py
+++ b/ark/utils/io_utils_test.py
@@ -52,6 +52,23 @@ def test_validate_paths():
         with pytest.raises(ValueError, match=r".*The file/path.*not_a_real_file.*"):
             iou.validate_paths(wrong_file)
 
+    # make tempdir for testing outside of docker
+    with tempfile.TemporaryDirectory() as valid_path:
+
+        # make valid subdirectory
+        valid_parts = [p for p in pathlib.Path(valid_path).parts]
+        valid_parts[0] = 'not_a_real_directory'
+
+        # test no '../data' prefix
+        starts_out_of_scope = os.path.join(*valid_parts)
+
+        # test out of scope when specifying out of scope
+        with pytest.raises(ValueError, match=r".*not_a_real_directory*"):
+            iou.validate_paths(starts_out_of_scope, data_prefix=False)
+
+        with pytest.raises(ValueError, match=r".*is not prefixed with.*"):
+            iou.validate_paths(starts_out_of_scope, data_prefix=True)
+
     # reset cwd after testing
     os.chdir('../')
 

--- a/ark/utils/load_utils.py
+++ b/ark/utils/load_utils.py
@@ -35,7 +35,7 @@ def load_imgs_from_mibitiff(data_dir, mibitiff_files=None, channels=None, delimi
             xarray with shape [fovs, x_dim, y_dim, channels]
     """
 
-    iou.validate_paths(data_dir)
+    iou.validate_paths(data_dir, data_prefix=False)
 
     if not mibitiff_files:
         mibitiff_files = iou.list_files(data_dir, substrs=['.tif'])
@@ -108,7 +108,7 @@ def load_imgs_from_tree(data_dir, img_sub_folder=None, fovs=None, channels=None,
             xarray with shape [fovs, x_dim, y_dim, tifs]
     """
 
-    iou.validate_paths(data_dir)
+    iou.validate_paths(data_dir, data_prefix=False)
 
     if fovs is None:
         # get all fovs
@@ -237,7 +237,7 @@ def load_imgs_from_dir(data_dir, files=None, delimiter=None, xr_dim_name='compar
               of channels in the input.
     """
 
-    iou.validate_paths(data_dir)
+    iou.validate_paths(data_dir, data_prefix=False)
 
     if files is None:
         imgs = iou.list_files(data_dir, substrs=['.tif', '.jpg', '.png'])

--- a/ark/utils/spatial_analysis_utils.py
+++ b/ark/utils/spatial_analysis_utils.py
@@ -31,7 +31,7 @@ def calc_dist_matrix(label_maps, save_path=None):
     # Check that file path exists, if given
 
     if save_path is not None:
-        io_utils.validate_paths(save_path)
+        io_utils.validate_paths(save_path, data_prefix=False)
 
     dist_mats_list = []
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

The current validate_paths function assumes that the user is within the docker and all paths are prefixed with /data. However, as we start to use these functions elsewhere and pip install the library, we don't want this assumption to necessarily be true. 

**How did you implement your changes**
I've modified this function to give the option of dropping the /data prefix requirement, and updated all calls to validate_paths which are outside of a jupyter notebook to use this new logic. 