### PR TITLE
Prevent divide by zero

### DIFF
--- a/ark/segmentation/regionprops_extraction.py
+++ b/ark/segmentation/regionprops_extraction.py
@@ -19,8 +19,10 @@ def major_minor_axis_ratio(prop, **kwargs):
         float:
             major axis length / minor axis length
     """
-
-    return prop.major_axis_length / prop.minor_axis_length
+    if prop.minor_axis_length == 0:
+        return np.float('NaN')
+    else:
+        return prop.major_axis_length / prop.minor_axis_length
 
 
 def perim_square_over_area(prop, **kwargs):

--- a/ark/segmentation/regionprops_extraction_test.py
+++ b/ark/segmentation/regionprops_extraction_test.py
@@ -22,6 +22,16 @@ def test_major_minor_axis_ratio():
     major_minor_rat = regionprops_extraction.major_minor_axis_ratio(prop_info)
     assert np.round(major_minor_rat, 4) == 1.1524
 
+    class Regionprop(object):
+        pass
+
+    prop_info = Regionprop()
+    prop_info.major_axis_length = 10
+    prop_info.minor_axis_length = 0
+
+    nan_val = regionprops_extraction.major_minor_axis_ratio(prop_info)
+    assert np.isnan(nan_val)
+
 
 def test_perim_square_over_area():
     sample_arr = np.zeros((50, 50)).astype(int)


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**
The custom regionprops functions don't do any validation of the inputs. In general this is fine, since they come from the base regionprops function. However, minor_axis_length seems to fairly regularly return a value of zero, which causes errors. 

**How did you implement your changes**

Add error checking and return NaN for division by zero, rather than an error. 