### PR TITLE
Bump version to 0.2.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os import path
 from distutils.command.build_ext import build_ext as DistUtilsBuildExt
 from setuptools import setup, find_packages
 
-VERSION = '0.2.8'
+VERSION = '0.2.9'
 
 
 # set a long description which is basically the README


### PR DESCRIPTION
Bumps version to 0.2.9. This incorporates the small error checking PRs I added in, and will allow the pip-installable version of the repo to work for generating figures for the Mesmer paper. 