### PR TITLE
Fix consensus clustering so it assigns hclust values to each pixel

### DIFF
--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -16,7 +16,7 @@ from ark.utils import misc_utils
 
 def compute_cluster_avg(fovs, channels, base_dir,
                         cluster_dir='pixel_mat_clustered',
-                        cluster_avg_name='pixel_cluster_avg.feather',):
+                        cluster_avg_name='pixel_cluster_avg.feather'):
     """Averages channel values across all fovs in pixel_mat_clustered
 
     Args:

--- a/templates/example_flowsom_clustering.ipynb
+++ b/templates/example_flowsom_clustering.ipynb
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "gen_pixel_mat"
@@ -160,6 +160,7 @@
    },
    "outputs": [],
    "source": [
+    "# use SOM to assign clusters\n",
     "som_utils.cluster_pixels(fovs, base_dir)"
    ]
   },
@@ -180,6 +181,7 @@
    },
    "outputs": [],
    "source": [
+    "# run hierarchical clustering based on SOM cluster assignments\n",
     "som_utils.consensus_cluster(fovs, channels, base_dir)"
    ]
   },


### PR DESCRIPTION
**What is the purpose of this PR?**

Currently, we're only saving the consensus cluster to SOM cluster mapping table. We actually want to use that mapping to assign the consensus clusters to each pixel in our dataset.

**How did you implement your changes**

We pass in more arguments to `consensus_cluster.R` and write the results to a new directory: `pixel_mat_consensus`.
