### PR TITLE
Fix single compartment indexing for morphology computations

### DIFF
--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -216,9 +216,6 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
     # add the single compartment features to regionprops_names
     regionprops_names.extend(regionprops_single_comp)
 
-    # add the multi compartment features to regionprops_names
-    regionprops_names.extend(regionprops_multi_comp)
-
     # get all the cell ids
     unique_cell_ids = np.unique(segmentation_labels[..., 0].values)
     unique_cell_ids = unique_cell_ids[np.nonzero(unique_cell_ids)]

--- a/ark/segmentation/marker_quantification_test.py
+++ b/ark/segmentation/marker_quantification_test.py
@@ -133,8 +133,8 @@ def test_assign_multi_compartment_features():
         compartment_names=['whole_cell', 'nuclear']
     )
 
-    # create a sample marker count matrix with 2 compartments, 3 cell ids, and 3 features
-    sample_marker_counts = np.zeros((2, 3, 3))
+    # create a sample marker count matrix with 2 compartments, 3 cell ids, and 2 features
+    sample_marker_counts = np.zeros((2, 3, 2))
 
     # cell 0: no nucleus
     sample_marker_counts[0, 0, 1] = 5
@@ -151,7 +151,7 @@ def test_assign_multi_compartment_features():
     sample_marker_counts = xr.DataArray(copy.copy(sample_marker_counts),
                                         coords=[['whole_cell', 'nuclear'],
                                                 [0, 1, 2],
-                                                ['feat_1', 'area', 'nc_ratio']],
+                                                ['feat_1', 'area']],
                                         dims=['compartments', 'cell_id', 'features'])
 
     # define the nuclear properties
@@ -160,6 +160,9 @@ def test_assign_multi_compartment_features():
     sample_marker_counts = marker_quantification.assign_multi_compartment_features(
         sample_marker_counts, regionprops_multi_comp
     )
+
+    # assert we added nc_ratio as a features key
+    assert 'nc_ratio' in sample_marker_counts.features.values
 
     # testing cell 0
     assert sample_marker_counts.loc['whole_cell', 0, 'nc_ratio'] == 0


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #401. Currently, we index the cell table when computing single compartment features with all the features (including multi compartment features), which throws a warning. This warning likely will become an error in the future, so best to patch this up now.

**How did you implement your changes**

We don't append `regionprops_multi_comp` to `regionprops_names` until we actually need to compute multi compartment features. This means that we also need to explicitly append multi comp features to `marker_counts` prior to computing them.