### PR TITLE
Add option to set nuclear_counts in Segment_Image_Data

### DIFF
--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -320,6 +320,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "nuc_props_set"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# set to True to add nuclear cell properties to the expression matrix\n",
+    "nuclear_counts = False"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -348,7 +362,8 @@
     "                                              img_sub_folder=\"TIFs\",\n",
     "                                              is_mibitiff=MIBItiff,\n",
     "                                              fovs=fovs,\n",
-    "                                              batch_size=5)"
+    "                                              batch_size=5,\n",
+    "                                              nuclear_counts=nuclear_counts)"
    ]
   },
   {


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #387. Now that nuclear property extraction is all up and running, we need to make it easier to users to request nuclear extraction in the notebook.

**How did you implement your changes**

Add a cell that allows users to set `nuclear_counts = True`.
