### PR TITLE
Add option to change scale factor for cell segmentation

### DIFF
--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -213,7 +213,7 @@
    },
    "outputs": [],
    "source": [
-    "# override default value to increase size of image by a factor of the value of rescale_factor\n",
+    "# Mesmer was trained on data acquired at 20X resolution. If your image data was acquired at a different resolution, you will get the best performance by rescaling. The rescale factor will increase or decrease the image resolution by the value you provide. For example, if you data was acquired at 10X, use a `rescale_factor` of 2. If your data was acquired at 60X resolution, use a `rescale_factor` of 0.33.\n",
     "rescale_factor = 1.0"
    ]
   },

--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -205,6 +205,20 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "seg_scale_set"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# override default value to increase size of image by a factor of the value of rescale_factor\n",
+    "rescale_factor = 1.0"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 11,
    "metadata": {
     "tags": [
@@ -224,7 +238,7 @@
     }
    ],
    "source": [
-    "deepcell_service_utils.create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=fovs)"
+    "deepcell_service_utils.create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=fovs, scale=rescale_factor)"
    ]
   },
   {


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #423. `Segment_Image_Data.ipynb` does not make it obvious that the image scaling factor can be adjusted. We add an option to allow the user to easily override the default value of 1.0.

**How did you implement your changes**

Add a cell before the call to `create_deepcell_output` to allow the user to set the `scale` argument.
