### PR TITLE
Automatically rebuild Docker if requirements.txt modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,6 @@ First, get the latest version of the code
 git pull
 ```
 
-Because `requirements.txt` may have changed, rebuild the Docker using
-```
-docker build -t ark-analysis .
-```
-
 Then, run the command below to update the jupyter notebooks to the latest version
 ```
 bash start_docker.sh --update
@@ -86,6 +81,8 @@ or
 ```
 bash start_docker.sh -u
 ```
+
+If the requirements.txt has changed, Docker will rebuild with the new dependencies first.
 
 ### WARNING
 

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -3,6 +3,7 @@
 # if requirements.txt has been changed in the last day, automatically rebuild Docker first
 if [[ $(find . -mmin -1440 -type f -print | grep requirements.txt | wc -l) -eq 1 ]]
   then
+    echo "New requirements.txt file detected, rebuilding Docker"
     docker build -t ark-analysis .
 fi
 

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# if requirements.txt has been changed in the last day, automatically rebuild Docker first
+if [[ $(find . -mmin -1440 -type f -print | grep requirements.txt | wc -l) -eq 1 ]]
+  then
+    docker build -t ark-analysis .
+fi
+
 # catch and pass update flag to notebook update routine
 bash update_notebooks.sh "$@"
 
@@ -12,10 +18,10 @@ until [[ $(lsof -i -P -n | grep 127.0.0.1:$PORT | wc -l) -eq 0 ]]
 done
 
 if [ $PORT -ne 8888 ]
-then
-  echo "WARNING: another Jupyter server on port 8888 running"
-  echo "Enter this URL instead to access the notebooks: http://127.0.0.1:$PORT/"
-  echo "In the URLs below, copy the token after \"token=\", paste that into the password prompt, and log in"
+  then
+    echo "WARNING: another Jupyter server on port 8888 running"
+    echo "Enter this URL instead to access the notebooks: http://127.0.0.1:$PORT/"
+    echo "In the URLs below, copy the token after \"token=\", paste that into the password prompt, and log in"
 fi
 
 docker run -it \


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #391. If the `requirements.txt` file is changed, Docker will need to be rebuilt. However, many users won't know to do this. To prevent confusion, we should automatically rebuild Docker for them if `requirements.txt` has been changed.

**How did you implement your changes**

We update `start_docker.sh` to run the `docker build` command automatically if the file has been changed within the last day. Tough luck if the user misses the deadline, but I think it's a generous one (the user is likely going to immediately start Docker after a new pull anyways).