### PR TITLE
Bump cryptography to 3.4.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=3.4.7,<4
+cryptography>=3.4.8,<4
 google-api-python-client>=2.7.0,<3
 google-auth-httplib2>=0.1.0,<1
 google-auth-oauthlib>=0.4.4,<1


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #448. We need to update the `cryptography` library so that changes in the new version (updated around 10:20 AM on August 24, 2021), which includes the need for an extra dependency, take effect.

**How did you implement your changes**

Change `requirements.txt`.

**Remaining issues**

We may need to explicitly include the `Rust` library if it's not installing correctly.