### PR TITLE
Close num rand speedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ env
 
 *.c
 *.html
+*.so
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ env
 */_build
 */_markdown
 */visualizations
+
+*.c
+*.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ cache: pip
 
 # command to run tests
 script:
+  - python -m pip install --editable .
   - python -m pytest --cov=ark --pycodestyle ark
 
 jobs:

--- a/ark/utils/_bootstrapping/_close_cell_num_random.pyx
+++ b/ark/utils/_bootstrapping/_close_cell_num_random.pyx
@@ -1,0 +1,84 @@
+from cython cimport cdivision, boundscheck, wraparound
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
+
+from numpy import zeros, uint16
+from numpy cimport uint16_t
+
+from libc.stdlib cimport rand
+
+ctypedef uint16_t DTYPE_t
+
+@cdivision(True) # Ignore modulo/divide by zero warning
+cdef _c_permutation(Py_ssize_t* array, int size):
+    cdef int i, j
+
+    for i in range(size-1, -1, -1):
+        j = rand() % (i + 1)
+        array[i] = j
+        array[j] = i
+
+
+@boundscheck(False)  # Deactivate bounds checking
+@wraparound(False)   # Deactivate negative indexing.
+def compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] marker_nums,
+                           DTYPE_t[:] choice_ar, int bootstrap_num):
+
+    cdef Py_ssize_t num_markers = marker_nums.shape[0]
+    cdef Py_ssize_t num_choices = choice_ar.shape[0]
+
+    # check marker num sizes
+    cdef int mn
+    for mn in range(num_markers):
+        assert num_choices >= marker_nums[mn]
+
+    close_num_rand = zeros((num_markers, num_markers, bootstrap_num), dtype=uint16)
+    cdef DTYPE_t[:, :, :] close_num_rand_view = close_num_rand
+    
+    cdef Py_ssize_t* marker1_labels = <Py_ssize_t*> PyMem_Malloc(num_choices * sizeof(Py_ssize_t))
+    cdef Py_ssize_t* marker2_labels = <Py_ssize_t*> PyMem_Malloc(num_choices * sizeof(Py_ssize_t))
+    if not marker1_labels or not marker2_labels:
+        raise MemoryError()
+
+    cdef int j, k, r, m1n, m2n, label_i, label_j, m1_label, m2_label
+
+    for j in range(num_markers):
+        m1n = marker_nums[j]
+        for k in range(j, num_markers):
+            m2n = marker_nums[k]
+            for r in range(bootstrap_num):
+                _c_permutation(marker1_labels, m1n)
+                _c_permutation(marker2_labels, m2n)
+                #marker1_labels = np.permutation(num_choices)
+                #marker2_labels = np.permutation(num_choices)
+                for label_i in range(m1n):
+                    m1_label = marker1_labels[label_i]
+                    for label_j in range(m2n):
+                        m2_label = marker2_labels[label_j]
+                        close_num_rand_view[j, k, r] += dist_mat_bin[m1_label, m2_label]
+            close_num_rand_view[k, j, :] = close_num_rand_view[j, k, :]
+
+    PyMem_Free(marker1_labels)
+    PyMem_Free(marker2_labels)
+
+    return close_num_rand
+
+''''
+//     cdef np.ndarray marker1_labels_rand = [np.permutation(num_choices)[:m1n]]
+//     cdef np.ndarray marker2_labels_rand = [np.permutation(num_choices)[:m2n]]
+
+// for j, m1n in enumerate(marker_nums):
+//     for k, m2n in enumerate(marker_nums[j:], j):
+//         for r in range(bootstrap_num):
+//             # Select same amount of random cell labels as positive ones in close_num
+//             marker1_labels_rand = np.random.choice(a=choice_ar, size=m1n, replace=False)
+//             marker2_labels_rand = np.random.choice(a=choice_ar, size=m2n, replace=False)
+
+//             # Record the number of interactions and store in close_num_rand in the index
+//             # corresponding to both markers, for every permutation
+//             close_num_rand[j, k, r] = \
+//                 np.sum(dist_mat_bin[np.ix_(marker1_labels_rand, marker2_labels_rand)])
+
+//         # System should be symetric
+//         close_num_rand[k, j, :] = close_num_rand[j, k, :]
+// return close_num_rand
+'''

--- a/ark/utils/spatial_analysis_utils.py
+++ b/ark/utils/spatial_analysis_utils.py
@@ -11,6 +11,7 @@ from scipy.spatial.distance import cdist
 
 import ark.settings as settings
 from ark.utils import io_utils, misc_utils
+from ark.utils._bootstrapping import compute_close_num_rand
 
 
 def calc_dist_matrix(label_maps, save_path=None):
@@ -246,33 +247,15 @@ def compute_close_cell_num_random(marker_nums, dist_mat, dist_lim, bootstrap_num
             Large matrix of random positive marker counts for every permutation in the bootstrap
     """
 
-    # Get marker counts
-    marker_count = len(marker_nums)
-
-    # Create close_num_rand
-    close_num_rand = np.zeros((
-        marker_count, marker_count, bootstrap_num), dtype=np.uint16)
-
     # Generate binarized distance matrix
     dist_mat_bin = (dist_mat.values < dist_lim).astype(np.uint16)
 
     # static choice array
-    choice_ar = list(range(dist_mat.shape[0]))
+    _marker_nums = np.array(marker_nums, dtype=np.uint16)
+    _choice_ar = np.array(list(range(dist_mat.shape[0])), dtype=np.uint16)
 
-    for j, m1n in enumerate(marker_nums):
-        for k, m2n in enumerate(marker_nums[j:], j):
-            for r in range(bootstrap_num):
-                # Select same amount of random cell labels as positive ones in close_num
-                marker1_labels_rand = np.random.choice(a=choice_ar, size=m1n, replace=False)
-                marker2_labels_rand = np.random.choice(a=choice_ar, size=m2n, replace=False)
-
-                # Record the number of interactions and store in close_num_rand in the index
-                # corresponding to both markers, for every permutation
-                close_num_rand[j, k, r] = \
-                    np.sum(dist_mat_bin[np.ix_(marker1_labels_rand, marker2_labels_rand)])
-
-            # System should be symetric
-            close_num_rand[k, j, :] = close_num_rand[j, k, :]
+    close_num_rand = compute_close_num_rand(dist_mat_bin, _marker_nums, _choice_ar,
+                                            int(bootstrap_num))
 
     return close_num_rand
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cryptography>=3.4.8,<4
+Cython>=0.29.24,<1
 google-api-python-client>=2.7.0,<3
 google-auth-httplib2>=0.1.0,<1
 google-auth-oauthlib>=0.4.4,<1

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,23 @@
 import setuptools
 from os import path
-from distutils.command.build_ext import build_ext as DistUtilsBuildExt
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Extension
+import numpy as np
+from Cython.Build import cythonize
 
 VERSION = '0.2.9'
 
+with open(path.join(path.dirname(__file__), 'requirements.txt')) as req_file:
+    requirements = req_file.read().splitlines()
 
 # set a long description which is basically the README
 with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
     long_description = f.read()
 
+extensions = [Extension(
+    name="ark.utils._bootstrapping",
+    sources=["ark/utils/_bootstrapping/_close_cell_num_random.pyx"],
+    include_dirs=[np.get_include()]
+)]
 
 setup(
     name='ark-analysis',
@@ -20,25 +28,8 @@ setup(
     author='Angelo Lab',
     url='https://github.com/angelolab/ark-analysis',
     download_url='https://github.com/angelolab/ark-analysis/archive/v{}.tar.gz'.format(VERSION),
-    install_requires=['cryptography>=3.4.8,<4',
-                      'google-api-python-client>=2.7.0,<3',
-                      'google-auth-httplib2>=0.1.0,<1',
-                      'google-auth-oauthlib>=0.4.4,<1',
-                      'jupyter>=1.0.0,<2',
-                      'jupyter_contrib_nbextensions>=0.5.1,<1',
-                      'jupyterlab>=3.1.9,<4',
-                      'matplotlib>=2.2.2,<3',
-                      'numpy>=1.16.3,<2',
-                      'pandas>=0.23.3,<1',
-                      'requests>=2.25.1,<3',
-                      'scikit-image>=0.14.3,<=0.16.2',
-                      'scikit-learn>=0.19.1,<1',
-                      'scipy>=1.1.0,<2',
-                      'seaborn>=0.10.1,<1',
-                      'statsmodels>=0.11.1,<1',
-                      'umap-learn>=0.4.6,<1',
-                      'xarray>=0.12.3,<1',
-                      'tqdm>=4.54.1,<5'],
+    ext_modules=cythonize(extensions),
+    install_requires=requirements,
     extras_require={
         'tests': ['pytest',
                   'pytest-cov',

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,17 @@ from setuptools import setup, find_packages, Extension
 import numpy as np
 from Cython.Build import cythonize
 
+CYTHON_DEBUG = False
+
+if CYTHON_DEBUG:
+    from Cython.Compiler.Options import get_directive_defaults
+    directive_defaults = get_directive_defaults()
+
+    directive_defaults['linetrace'] = True
+    directive_defaults['binding'] = True
+
+CYTHON_MACROS = [('CYTHON_TRACE', '1')] if CYTHON_DEBUG else None
+
 VERSION = '0.2.9'
 
 with open(path.join(path.dirname(__file__), 'requirements.txt')) as req_file:
@@ -16,7 +27,8 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
 extensions = [Extension(
     name="ark.utils._bootstrapping",
     sources=["ark/utils/_bootstrapping/_close_cell_num_random.pyx"],
-    include_dirs=[np.get_include()]
+    include_dirs=[np.get_include()],
+    define_macros=CYTHON_MACROS
 )]
 
 setup(
@@ -28,7 +40,7 @@ setup(
     author='Angelo Lab',
     url='https://github.com/angelolab/ark-analysis',
     download_url='https://github.com/angelolab/ark-analysis/archive/v{}.tar.gz'.format(VERSION),
-    ext_modules=cythonize(extensions),
+    ext_modules=cythonize(extensions, compiler_directives={'language_level': "3"}),
     install_requires=requirements,
     extras_require={
         'tests': ['pytest',


### PR DESCRIPTION
## **Purpose**

Despite our best efforts,`spatial_analysis_utils.compute_close_cell_num_random` is still slow.  It's so slow that even a bootstrap number of 100 causes the call to `compute_channel_spatial_enrichment` in the example notebook to take several minutes.  The fix would be simple if a more efficient algorithm existed, but none has been verified so far (though several have been tested).

This PR adds a ~10-30x speedup to the bootstrapping calculation by implementing the bulk of the iterations in cython.  In more quantifiable terms, a realistic `bootstrap_num=10000`, `calculate_cluster_spatial_enrichment` call in the demo notebook takes ~5 minutes, compared to the 30-90 mins it previously took.

## **Implementation**

cython compiles the code in `ark/utils/_bootstrapping/_close_cell_num_random.pyx` to c code which can be called just like a python module.  Currently, the same algorithm as the python version is used, only making edits to minimize python interpreter interaction. 

As for travis, the cython code should be automatically compiled, so that all tests work as the normally did.  Furthermore, since we're just embedding previous functionality into C, we can just test the wrapping python code, as we have been; i.e no new tests are needed.

## **Remaining issues**

### Messy cython
Firstly, the cython code is a little messy and could be cleaned up (stray comment, useless function arguments, stricter type declaration/binding, etc).

### Optimal algorithm
The line by line profiling show that the deepest iteration takes ~99.7% of the computation time.  This isn't because the accumulation or array index is slow, it's simply because there are on average `O(C^2 * m^4 * r)` additions, where `C` is number of cells, `m` is number of 'markers' (channels or clusters), and `r` is the bootstrapping number.  Because `C` will be massive, this is bad (this also explains why channel randomization is much slower than cluster randomization as num_channels > num_markers).

Theoretically, the most optimal time complexity for this task that I can think of is `O(C * D * m^4 * r)` where `D` is the average count of cells within the set distance limit.  Implementing an algorithm with this complexity requires a low-level 'hash-table-like' container for randomized columns, to search for positive columns per row within the binarized distance matrix.  Because `D` is constant for increasing `C, m, r`, this essentially moves the algorithm to be linear in number of cells, as opposed to quadratic.

I haven't tried implementing this solution yet and want to do that to test if the speedups are substantial