### PR TITLE
added dtype arg to generate_deepcell_input and create_overlay functions

### DIFF
--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -80,7 +80,8 @@ def relabel_segmentation(labeled_image, labels_dict):
 
 # TODO: Add metadata for channel name (eliminates need for fixed-order channels)
 def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs,
-                            is_mibitiff=False, img_sub_folder="TIFs", batch_size=5):
+                            is_mibitiff=False, img_sub_folder="TIFs", batch_size=5,
+                            dtype="int16"):
     """Saves nuclear and membrane channels into deepcell input format.
     Either nuc_channels or mem_channels should be specified.
 
@@ -104,6 +105,8 @@ def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs
             ignored if is_mibitiff is True
         batch_size (int):
             the number of fovs to process at once for each batch
+        dtype (str/type):
+            optional specifier of image type.  Overwritten with warning for float images
     Raises:
         ValueError:
             Raised if nuc_channels and mem_channels are both None or empty
@@ -126,11 +129,11 @@ def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs
         # load the images in the current fov batch
         if is_mibitiff:
             data_xr = load_utils.load_imgs_from_mibitiff(
-                tiff_dir, mibitiff_files=fovs, channels=channels
+                tiff_dir, mibitiff_files=fovs, channels=channels, dtype=dtype
             )
         else:
             data_xr = load_utils.load_imgs_from_tree(
-                tiff_dir, img_sub_folder="TIFs", fovs=fovs, channels=channels
+                tiff_dir, img_sub_folder="TIFs", fovs=fovs, channels=channels, dtype=dtype
             )
 
         # write each fov data to data_dir

--- a/ark/utils/plot_utils.py
+++ b/ark/utils/plot_utils.py
@@ -117,7 +117,7 @@ def create_overlay(fov, segmentation_dir, data_dir,
         data_dir=data_dir,
         files=[fov + '.tif'],
         xr_dim_name='channels',
-        xr_channel_names=['nuclear_channel', 'membrane_channel']
+        xr_channel_names=['nuclear_channel', 'membrane_channel'],
         dtype=dtype
     )
 

--- a/ark/utils/plot_utils.py
+++ b/ark/utils/plot_utils.py
@@ -85,7 +85,8 @@ def tif_overlay_preprocess(segmentation_labels, plotting_tif):
 
 
 def create_overlay(fov, segmentation_dir, data_dir,
-                   img_overlay_chans, seg_overlay_comp, alternate_segmentation=None):
+                   img_overlay_chans, seg_overlay_comp, alternate_segmentation=None,
+                   dtype='int16'):
     """Take in labeled contour data, along with optional mibi tif and second contour,
     and overlay them for comparison"
     Generates the outline(s) of the mask(s) as well as intensity from plotting tif. Predicted
@@ -104,6 +105,8 @@ def create_overlay(fov, segmentation_dir, data_dir,
             The segmentted compartment the user will overlay
         alternate_segmentation (numpy.ndarray):
             2D numpy array of labeled cell objects
+        dtype (str/type):
+            optional specifier of image type.  Overwritten with warning for float images
     Returns:
         numpy.ndarray:
             The image with the channel overlay
@@ -115,6 +118,7 @@ def create_overlay(fov, segmentation_dir, data_dir,
         files=[fov + '.tif'],
         xr_dim_name='channels',
         xr_channel_names=['nuclear_channel', 'membrane_channel']
+        dtype=dtype
     )
 
     # verify that the provided image channels exist in plotting_tif


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR allows high level functions in the jupyter notebook to handle images that are of a different datatype than the default int16.

**How did you implement your changes**

I added ```dtype``` as an argument for the ```data_utils.generate_deepcell_input``` and ```plot_utils.create_overlay functions```. The dtype argument is then passed to the load_imgs functions from load_utils.