### PR TITLE
Spatial-LDA exploratory metrics and test utils.

### DIFF
--- a/ark/analysis/dimensionality_reduction_test.py
+++ b/ark/analysis/dimensionality_reduction_test.py
@@ -9,7 +9,7 @@ import ark.settings as settings
 
 def test_plot_dim_reduced_data():
     # this only tests errors, test_dimensionality_reduction tests the meat of this function
-    random_cell_data = test_utils.generate_cell_table(300)
+    random_cell_data = test_utils.make_cell_table(300)
 
     with pytest.raises(FileNotFoundError):
         # trying to save to a non-existant directory
@@ -33,7 +33,7 @@ def test_plot_dim_reduced_data():
 
 
 def test_dimensionality_reduction():
-    random_cell_data = test_utils.generate_cell_table(300)
+    random_cell_data = test_utils.make_cell_table(300)
     test_cols = test_utils.TEST_MARKERS
 
     test_algorithms = ['PCA', 'tSNE', 'UMAP']

--- a/ark/analysis/dimensionality_reduction_test.py
+++ b/ark/analysis/dimensionality_reduction_test.py
@@ -9,7 +9,7 @@ import ark.settings as settings
 
 def test_plot_dim_reduced_data():
     # this only tests errors, test_dimensionality_reduction tests the meat of this function
-    random_cell_data = test_utils.make_segmented_csv(300)
+    random_cell_data = test_utils.generate_cell_table(300)
 
     with pytest.raises(FileNotFoundError):
         # trying to save to a non-existant directory
@@ -33,7 +33,7 @@ def test_plot_dim_reduced_data():
 
 
 def test_dimensionality_reduction():
-    random_cell_data = test_utils.make_segmented_csv(300)
+    random_cell_data = test_utils.generate_cell_table(300)
     test_cols = test_utils.TEST_MARKERS
 
     test_algorithms = ['PCA', 'tSNE', 'UMAP']

--- a/ark/analysis/visualize_test.py
+++ b/ark/analysis/visualize_test.py
@@ -36,7 +36,7 @@ def test_draw_heatmap():
 def test_draw_boxplot():
     # trim random data so we don't have to visualize as many facets
     start_time = timeit.default_timer()
-    random_data = test_utils.make_segmented_csv(100)
+    random_data = test_utils.generate_cell_table(100)
     random_data = random_data[random_data[settings.PATIENT_ID].isin(np.arange(1, 5))]
 
     # basic error testing
@@ -71,7 +71,7 @@ def test_draw_boxplot():
 
 
 def test_get_sort_data():
-    random_data = test_utils.make_segmented_csv(100)
+    random_data = test_utils.generate_cell_table(100)
     sorted_data = visualize.get_sorted_data(random_data, settings.PATIENT_ID, settings.CELL_TYPE)
 
     row_sums = [row.sum() for index, row in sorted_data.iterrows()]
@@ -80,7 +80,7 @@ def test_get_sort_data():
 
 def test_plot_barchart():
     # mostly error checking here, test_visualize_cells tests the meat of the functionality
-    random_data = test_utils.make_segmented_csv(100)
+    random_data = test_utils.generate_cell_table(100)
 
     with pytest.raises(FileNotFoundError):
         # trying to save to a non-existant directory
@@ -94,7 +94,7 @@ def test_plot_barchart():
 
 
 def test_visualize_patient_population_distribution():
-    random_data = test_utils.make_segmented_csv(100)
+    random_data = test_utils.generate_cell_table(100)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         # test without a save_dir, check that we do not save the files

--- a/ark/analysis/visualize_test.py
+++ b/ark/analysis/visualize_test.py
@@ -36,7 +36,7 @@ def test_draw_heatmap():
 def test_draw_boxplot():
     # trim random data so we don't have to visualize as many facets
     start_time = timeit.default_timer()
-    random_data = test_utils.generate_cell_table(100)
+    random_data = test_utils.make_cell_table(100)
     random_data = random_data[random_data[settings.PATIENT_ID].isin(np.arange(1, 5))]
 
     # basic error testing
@@ -71,7 +71,7 @@ def test_draw_boxplot():
 
 
 def test_get_sort_data():
-    random_data = test_utils.generate_cell_table(100)
+    random_data = test_utils.make_cell_table(100)
     sorted_data = visualize.get_sorted_data(random_data, settings.PATIENT_ID, settings.CELL_TYPE)
 
     row_sums = [row.sum() for index, row in sorted_data.iterrows()]
@@ -80,7 +80,7 @@ def test_get_sort_data():
 
 def test_plot_barchart():
     # mostly error checking here, test_visualize_cells tests the meat of the functionality
-    random_data = test_utils.generate_cell_table(100)
+    random_data = test_utils.make_cell_table(100)
 
     with pytest.raises(FileNotFoundError):
         # trying to save to a non-existant directory
@@ -94,7 +94,7 @@ def test_plot_barchart():
 
 
 def test_visualize_patient_population_distribution():
-    random_data = test_utils.generate_cell_table(100)
+    random_data = test_utils.make_cell_table(100)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         # test without a save_dir, check that we do not save the files

--- a/ark/settings.py
+++ b/ark/settings.py
@@ -17,8 +17,8 @@ POST_CHANNEL_COL = CELL_LABEL  # first column after channel data
 
 # regionprops extraction
 REGIONPROPS_BASE = ['label', 'area', 'eccentricity', 'major_axis_length',
-                    'minor_axis_length', 'perimeter', 'convex_area', 'equivalent_diameter',
-                    'centroid-0', 'centroid-1']
+                    'minor_axis_length', 'perimeter', 'centroid', 'convex_area',
+                    'equivalent_diameter']
 REGIONPROPS_SINGLE_COMP = ['major_minor_axis_ratio', 'perim_square_over_area',
                            'major_axis_equiv_diam_ratio', 'convex_hull_resid',
                            'centroid_dif', 'num_concavities']

--- a/ark/settings.py
+++ b/ark/settings.py
@@ -1,7 +1,7 @@
 # hope u liek capital letters
 
-# default segmented csv column names
-CELL_SIZE = 'cell_size'             # cell size
+# default cell table column names
+CELL_SIZE = 'cell_size'             # cell size (number of pixels in the cell)
 CELL_LABEL = 'label'                # cell label number (regionprops)
 FOV_ID = 'SampleID'                 # cell's fov name
 CELL_TYPE = 'cell_type'             # cell type name (flowsom)
@@ -17,8 +17,8 @@ POST_CHANNEL_COL = CELL_LABEL  # first column after channel data
 
 # regionprops extraction
 REGIONPROPS_BASE = ['label', 'area', 'eccentricity', 'major_axis_length',
-                    'minor_axis_length', 'perimeter', 'centroid',
-                    'convex_area', 'equivalent_diameter']
+                    'minor_axis_length', 'perimeter', 'convex_area', 'equivalent_diameter',
+                    'centroid-0', 'centroid-1']
 REGIONPROPS_SINGLE_COMP = ['major_minor_axis_ratio', 'perim_square_over_area',
                            'major_axis_equiv_diam_ratio', 'convex_hull_resid',
                            'centroid_dif', 'num_concavities']

--- a/ark/settings.py
+++ b/ark/settings.py
@@ -26,3 +26,6 @@ REGIONPROPS_MULTI_COMP = ['nc_ratio']
 
 # spatial-LDA minimum required columns
 BASE_COLS = [FOV_ID, CELL_LABEL, CELL_SIZE, CENTROID_0, CENTROID_1, CLUSTER_ID, KMEANS_CLUSTER]
+
+# spatial_lda topic EDA key names
+EDA_KEYS = ['inertia', 'silhouette', 'gap_stat', 'gap_sds', 'percent_var_exp']

--- a/ark/settings.py
+++ b/ark/settings.py
@@ -1,15 +1,15 @@
 # hope u liek capital letters
 
 # default cell table column names
-CELL_SIZE = 'cell_size'             # cell size (number of pixels in the cell)
-CELL_LABEL = 'label'                # cell label number (regionprops)
-FOV_ID = 'SampleID'                 # cell's fov name
-CELL_TYPE = 'cell_type'             # cell type name (flowsom)
-CLUSTER_ID = 'FlowSOM_ID'           # cell cluster id (flowsom)
-PATIENT_ID = 'PatientID'            # cell's patient id
-KMEANS_CLUSTER = 'cluster_labels'   # generated cluster column name
-CENTROID_0 = 'centroid-0'           # cell centroid x-coordinate
-CENTROID_1 = 'centroid-1'           # cell centroid y-coordinate
+CELL_SIZE = 'cell_size'  # cell size (number of pixels in the cell)
+CELL_LABEL = 'label'  # cell label number (regionprops)
+FOV_ID = 'SampleID'  # cell's fov name
+CELL_TYPE = 'cell_type'  # cell type name (flowsom)
+CLUSTER_ID = 'FlowSOM_ID'  # cell cluster id (flowsom)
+PATIENT_ID = 'PatientID'  # cell's patient id
+KMEANS_CLUSTER = 'cluster_labels'  # generated cluster column name
+CENTROID_0 = 'centroid-0'  # cell centroid x-coordinate
+CENTROID_1 = 'centroid-1'  # cell centroid y-coordinate
 
 # standardized columns surrounding channel data
 PRE_CHANNEL_COL = CELL_SIZE  # last column before channel data

--- a/ark/spLDA/processing.py
+++ b/ark/spLDA/processing.py
@@ -2,7 +2,7 @@ import functools
 
 import numpy as np
 import pandas as pd
-from scipy.spatial.distance import cdist, pdist
+from scipy.spatial.distance import pdist
 from sklearn.cluster import KMeans
 from sklearn.metrics import silhouette_score
 from sklearn.model_selection import train_test_split
@@ -279,7 +279,7 @@ def compute_topic_eda(features, topics, num_boots=25):
     return stats
 
 
-def fov_density(cell_table, total_pix=1024**2):
+def fov_density(cell_table, total_pix=1024 ** 2):
     """Computes cellular density metrics for each field of view to determine an appropriate
     radius for the featurization step.
 
@@ -301,7 +301,7 @@ def fov_density(cell_table, total_pix=1024**2):
     density_stats = {
         "average_area": {k: v["cell_size"].mean() for (k, v) in cell_table.items()},
         "cellular_density": {
-            k: np.sum(v["cell_size"]) / total_pix for (k,v) in cell_table.items()}
-                     }
+            k: np.sum(v["cell_size"]) / total_pix for (k, v) in cell_table.items()}
+    }
 
     return density_stats

--- a/ark/spLDA/processing.py
+++ b/ark/spLDA/processing.py
@@ -38,8 +38,10 @@ def format_cell_table(cell_table, markers=None, clusters=None):
 
     # Only keep columns relevant for spatial-LDA
     if markers is not None:
-        BASE_COLS.append(markers)
-    drop_columns = [c for c in cell_table.columns if c not in BASE_COLS]
+        keep_cols = BASE_COLS + markers
+    else:
+        keep_cols = BASE_COLS
+    drop_columns = [c for c in cell_table.columns if c not in keep_cols]
     cell_table_drop = cell_table.drop(columns=drop_columns)
 
     # Rename columns
@@ -189,7 +191,7 @@ def create_difference_matrices(cell_table, features, training=True, inference=Tr
     return matrix_dict
 
 
-def gap_stat(features, k, clust_inertia, num_boots):
+def gap_stat(features, k, clust_inertia, num_boots=25):
     """Computes the Gap-statistic for a given k-means clustering model as introduced by
     Tibshirani, Walther and Hastie (2001).
 

--- a/ark/spLDA/processing.py
+++ b/ark/spLDA/processing.py
@@ -296,10 +296,12 @@ def fov_density(cell_table, total_pix=1024 ** 2):
         by cells divided by the total number of pixels in each field of view.
 
     """
-    density_stats = {
-        "average_area": {k: v["cell_size"].mean() for (k, v) in cell_table.items()},
-        "cellular_density": {
-            k: np.sum(v["cell_size"]) / total_pix for (k, v) in cell_table.items()}
-    }
+    average_area = {}
+    cellular_density = {}
+    for i in range(1, 5):
+        average_area[i] = cell_table[i].cell_size.mean()
+        cellular_density[i] = np.sum(cell_table[i].cell_size) / total_pix
+
+    density_stats = {"average_area": average_area, "cellular_density": cellular_density}
 
     return density_stats

--- a/ark/spLDA/processing.py
+++ b/ark/spLDA/processing.py
@@ -165,8 +165,6 @@ def create_difference_matrices(cell_table, features, training=True, inference=Tr
     """
     if not training and not inference:
         raise ValueError("One or both of 'training' or 'inference' must be True")
-    if training and features["train_features"] is None:
-        raise ValueError("train_features cannot be 'None'")
 
     cell_table = {
         k: v for (k, v) in cell_table.items() if k not in ["fovs", "markers", "clusters"]
@@ -256,12 +254,10 @@ def compute_topic_eda(features, topics, num_boots=25):
     # Check inputs
     if num_boots < 25:
         raise ValueError("Number of bootstrap samples must be at least 25")
-    if min(topics) <= 2:
-        raise ValueError("Number of topics must be greater than 2")
-    if max(topics) >= features.shape[0] - 1:
-        raise ValueError("Number of topics must be less than {}".format(features.shape[0] - 1))
+    if min(topics) <= 2 or max(topics) >= features.shape[0] - 1:
+        raise ValueError("Number of topics must be in [2, %d]" % (features.shape[0] - 1))
 
-    inertias, silhouettes, gap_stats, gap_sds, pct_vars = {}, {}, {}, {}, {}
+    inertias = silhouettes = gap_stats = gap_sds = pct_vars = {}
 
     # Compute the total sum of squared pairwise distances between all observations
     total_ss = np.sum(pdist(features) ** 2) / features.shape[0]

--- a/ark/spLDA/processing.py
+++ b/ark/spLDA/processing.py
@@ -294,7 +294,7 @@ def fov_density(cell_table, total_pix=1024 ** 2):
     """
     average_area = {}
     cellular_density = {}
-    for i in range(1, 5):
+    for i in cell_table["fovs"]:
         average_area[i] = cell_table[i].cell_size.mean()
         cellular_density[i] = np.sum(cell_table[i].cell_size) / total_pix
 

--- a/ark/spLDA/processing.py
+++ b/ark/spLDA/processing.py
@@ -184,3 +184,4 @@ def create_difference_matrices(cell_table, features, training=True, inference=Tr
 
     matrix_dict = {"train_diff_mat": train_diff_mat, "inference_diff_mat": inference_diff_mat}
     return matrix_dict
+

--- a/ark/spLDA/processing.py
+++ b/ark/spLDA/processing.py
@@ -267,7 +267,7 @@ def compute_topic_eda(features, topics, num_boots=25):
         stats['inertia'][k] = cluster_fit.inertia_
         stats['silhouette'][k] = silhouette_score(features, cluster_fit.labels_, 'euclidean')
         stats['gap_stat'][k], stats['gap_sds'][k] = gap_stat(features, k, cluster_fit.inertia_,
-                                                       num_boots)
+                                                             num_boots)
         stats['percent_var_exp'][k] = (total_ss - cluster_fit.inertia_) / total_ss
 
     return stats

--- a/ark/spLDA/processing.py
+++ b/ark/spLDA/processing.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 
 import numpy as np
@@ -36,10 +37,10 @@ def format_cell_table(cell_table, markers=None, clusters=None):
     spu.check_format_cell_table_args(cell_table=cell_table, markers=markers, clusters=clusters)
 
     # Only keep columns relevant for spatial-LDA
+    keep_cols = copy.deepcopy(BASE_COLS)
     if markers is not None:
-        keep_cols = BASE_COLS + markers
-    else:
-        keep_cols = BASE_COLS
+        keep_cols += markers
+
     drop_columns = [c for c in cell_table.columns if c not in keep_cols]
     cell_table_drop = cell_table.drop(columns=drop_columns)
 
@@ -216,12 +217,9 @@ def gap_stat(features, k, clust_inertia, num_boots=25):
     mins, maxs = features.apply(min, axis=0), features.apply(max, axis=0)
     n, p = features.shape
     w_kb = []
-    # Create bootstrapped reference data
-    boot_array = np.zeros((n, p))
     # Cluster each bootstrapped sample to get the inertia
     for b in range(num_boots):
-        for i in range(p):
-            boot_array[:, i] = np.random.uniform(low=mins[i], high=maxs[i], size=n)
+        boot_array = np.random.uniform(low=mins, high=maxs, size=(n, p))
         boot_clust = KMeans(n_clusters=k).fit(boot_array)
         w_kb.append(boot_clust.inertia_)
     # Gap statistic and standard error

--- a/ark/spLDA/processing.py
+++ b/ark/spLDA/processing.py
@@ -1,7 +1,6 @@
 import functools
 
 import numpy as np
-import pandas as pd
 from scipy.spatial.distance import pdist
 from sklearn.cluster import KMeans
 from sklearn.metrics import silhouette_score
@@ -220,14 +219,11 @@ def gap_stat(features, k, clust_inertia, num_boots=25):
     n, p = features.shape
     w_kb = []
     # Create bootstrapped reference data
-    boots = np.zeros(shape=(n * num_boots, p))
-    boot_ind = np.repeat(np.array(range(num_boots)), n)
-    np.random.shuffle(boot_ind)
-    for i in range(p):
-        boots[:, i] = np.random.uniform(low=mins[i], high=maxs[i], size=n * num_boots)
+    boot_array = np.zeros((n, p))
     # Cluster each bootstrapped sample to get the inertia
     for b in range(num_boots):
-        boot_array = pd.DataFrame(boots[boot_ind == b, :])
+        for i in range(p):
+            boot_array[:, i] = np.random.uniform(low=mins[i], high=maxs[i], size=n)
         boot_clust = KMeans(n_clusters=k).fit(boot_array)
         w_kb.append(boot_clust.inertia_)
     # Gap statistic and standard error

--- a/ark/spLDA/processing.py
+++ b/ark/spLDA/processing.py
@@ -257,19 +257,19 @@ def compute_topic_eda(features, topics, num_boots=25):
     if min(topics) <= 2 or max(topics) >= features.shape[0] - 1:
         raise ValueError("Number of topics must be in [2, %d]" % (features.shape[0] - 1))
 
-    inertias = silhouettes = gap_stats = gap_sds = pct_vars = {}
+    stat_names = ['inertia', 'silhouette', 'gap_stat', 'gap_sds', 'percent_var_exp']
+    stats = dict(zip(stat_names, [{} for name in stat_names]))
 
     # Compute the total sum of squared pairwise distances between all observations
     total_ss = np.sum(pdist(features) ** 2) / features.shape[0]
     for k in topics:
         cluster_fit = KMeans(n_clusters=k).fit(features)
-        inertias[k] = cluster_fit.inertia_
-        silhouettes[k] = silhouette_score(features, cluster_fit.labels_, metric='euclidean')
-        gap_stats[k], gap_sds[k] = gap_stat(features, k, cluster_fit.inertia_, num_boots)
-        pct_vars[k] = (total_ss - cluster_fit.inertia_) / total_ss
+        stats['inertia'][k] = cluster_fit.inertia_
+        stats['silhouette'][k] = silhouette_score(features, cluster_fit.labels_, 'euclidean')
+        stats['gap_stat'][k], stats['gap_sds'][k] = gap_stat(features, k, cluster_fit.inertia_,
+                                                       num_boots)
+        stats['percent_var_exp'][k] = (total_ss - cluster_fit.inertia_) / total_ss
 
-    stats = {"inertia": inertias, "silhouette": silhouettes,
-             "gap_stat": gap_stats, "gap_sds": gap_sds, "percent_var_exp": pct_vars}
     return stats
 
 

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -1,46 +1,132 @@
 import numpy as np
 import pytest
 
-import ark.spLDA.processing as pros
 import ark.settings as settings
+import ark.spLDA.processing as pros
 from ark.utils.misc_utils import verify_in_list
 from ark.utils.test_utils import make_cell_table
+from sklearn.cluster import KMeans
 
-# Generate, format, and featurize a test cell table
+# Generate a test cell table
 N_CELLS = 1000
-TRAIN_FRAC = 0.75
-TRAIN_CELLS = TRAIN_FRAC * N_CELLS
 TEST_CELL_TABLE = make_cell_table(N_CELLS)
-TEST_FORMAT = pros.format_cell_table(
-    cell_table=TEST_CELL_TABLE, clusters=list(np.unique(TEST_CELL_TABLE[settings.CLUSTER_ID])))
-TEST_FEATURES = pros.featurize_cell_table(cell_table=TEST_FORMAT, train_frac=TRAIN_FRAC)
-
 
 def test_format_cell_table():
+    # call formatting function
+    all_clusters = list(np.unique(TEST_CELL_TABLE[settings.CLUSTER_ID]))
+    all_markers = ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+    some_clusters = all_clusters[2:]
+    some_markers = all_markers[2:]
+
+    cluster_format1 = pros.format_cell_table(cell_table=TEST_CELL_TABLE, clusters=all_clusters)
+    marker_format1 = pros.format_cell_table(cell_table=TEST_CELL_TABLE, markers=all_markers)
+    cluster_format2 = pros.format_cell_table(cell_table=TEST_CELL_TABLE, clusters=some_clusters)
+    marker_format2 = pros.format_cell_table(cell_table=TEST_CELL_TABLE, markers=some_markers)
+
     # Check that number of FOVS match
-    fov_list=[x for x in TEST_FORMAT.keys() if x not in ['fovs', 'markers', 'clusters']]
+    cluster_fovs = [x for x in cluster_format1.keys() if x not in ['fovs', 'markers', 'clusters']]
+    marker_fovs = [x for x in marker_format1.keys() if x not in ['fovs', 'markers', 'clusters']]
     verify_in_list(
-        fovs1=list(np.unique(TEST_CELL_TABLE[settings.FOV_ID])), fovs2=fov_list)
+        fovs1=list(np.unique(TEST_CELL_TABLE[settings.FOV_ID])), fovs2=cluster_fovs)
+    verify_in_list(
+        fovs1=list(np.unique(TEST_CELL_TABLE[settings.FOV_ID])), fovs2=marker_fovs)
+
     # Check that columns were retained/renamed
     verify_in_list(
-        cols1=["x", "y", "cluster_id", "cluster", "is_index"], cols2=list(TEST_FORMAT[1].columns))
+        cols1=["x", "y", "cluster_id", "cluster", "is_index"],
+        cols2=list(cluster_format1[1].columns))
+    verify_in_list(
+        cols1=["x", "y", "cluster_id", "cluster", "is_index"],
+        cols2=list(marker_format1[1].columns))
+
     # Check that columns were dropped
-    assert len(TEST_CELL_TABLE.columns) > len(TEST_FORMAT[1].columns)
+    assert len(TEST_CELL_TABLE.columns) > len(cluster_format1[1].columns)
+    assert len(TEST_CELL_TABLE.columns) > len(marker_format1[1].columns)
+
+    # check that only specified clusters and markers are kept
+    assert not np.isin(all_clusters[:2], np.unique(cluster_format2[1].cluster_id)).any()
+    assert not np.isin(all_markers[:2], np.unique(marker_format2[1].columns)).any()
 
 
 def test_featurize_cell_table():
+    # call formatting function - only test on clusters to avoid repetition
+    all_clusters = list(np.unique(TEST_CELL_TABLE[settings.CLUSTER_ID]))
+    cluster_format = pros.format_cell_table(cell_table=TEST_CELL_TABLE, clusters=all_clusters)
+
+    # call featurization
+    features1 = pros.featurize_cell_table(cell_table=cluster_format, featurization='cluster',
+                                          train_frac=0.75)
+    features2 = pros.featurize_cell_table(cell_table=cluster_format, featurization='cluster',
+                                          train_frac=0.5)
+
     # Check for consistent dimensions
-    assert TEST_FEATURES["featurized_fovs"].shape[0] == TEST_CELL_TABLE.shape[0]
-    assert TEST_FEATURES["featurized_fovs"].shape[0] == N_CELLS
-    assert TEST_FEATURES["train_features"].shape[0] == TRAIN_CELLS
+    assert features1["featurized_fovs"].shape[0] == TEST_CELL_TABLE.shape[0] == N_CELLS
+    assert features2["featurized_fovs"].shape[0] == TEST_CELL_TABLE.shape[0] == N_CELLS
+    assert features1["train_features"].shape[0] == 0.75 * N_CELLS
+    assert features2["train_features"].shape[0] == 0.5 * N_CELLS
+
+
+def test_gap_stat():
+    # call formatting & featurization - only test on clusters to avoid repetition
+    all_clusters = list(np.unique(TEST_CELL_TABLE[settings.CLUSTER_ID]))
+    cluster_format = pros.format_cell_table(cell_table=TEST_CELL_TABLE, clusters=all_clusters)
+    features = pros.featurize_cell_table(cell_table=cluster_format, featurization='cluster')
+    inert = KMeans(n_clusters=5).fit(features['featurized_fovs']).inertia_
+
+    # compute gap_stat
+    gap = pros.gap_stat(features=features['featurized_fovs'], k=5, clust_inertia=inert,
+                        num_boots=25)
+
+    # check correct output length
+    assert len(gap) == 2
+    # check for non-negative outputs
+    assert gap[0] >= 0 and gap[1] >= 0
 
 
 def test_compute_topic_eda():
+    # Format & featurize cell table. Only test on clusters and 0.75 train frac to avoid repetition
+    all_clusters = list(np.unique(TEST_CELL_TABLE[settings.CLUSTER_ID]))
+    cluster_format = pros.format_cell_table(cell_table=TEST_CELL_TABLE, clusters=all_clusters)
+    features = pros.featurize_cell_table(cell_table=cluster_format, featurization='cluster')
     # at least 25 bootstrap iterations
     with pytest.raises(ValueError, match="Number of bootstrap samples must be at least"):
-        pros.compute_topic_eda(TEST_FEATURES["featurized_fovs"], topics=[5], num_boots=20)
+        pros.compute_topic_eda(features["featurized_fovs"], topics=[5], num_boots=20)
     # appropriate range of topics
     with pytest.raises(ValueError, match="Number of topics must be greater than 2"):
-        pros.compute_topic_eda(TEST_FEATURES["featurized_fovs"], topics=[2], num_boots=25)
+        pros.compute_topic_eda(features["featurized_fovs"], topics=[2], num_boots=25)
     with pytest.raises(ValueError, match=r"Number of topics must be less than"):
-        pros.compute_topic_eda(TEST_FEATURES["featurized_fovs"], topics=[1000], num_boots=25)
+        pros.compute_topic_eda(features["featurized_fovs"], topics=[1000], num_boots=25)
+    # check for correct output
+    eda = pros.compute_topic_eda(features=features["featurized_fovs"], topics=[5], num_boots=25)
+    verify_in_list(eda_correct_keys=settings.EDA_KEYS, eda_actual_keys=list(eda.keys()))
+
+
+def test_create_difference_matrices():
+    # Format & featurize cell table. Only test on clusters and 0.75 train frac to avoid repetition
+    all_clusters = list(np.unique(TEST_CELL_TABLE[settings.CLUSTER_ID]))
+    cluster_format = pros.format_cell_table(cell_table=TEST_CELL_TABLE, clusters=all_clusters)
+    features = pros.featurize_cell_table(cell_table=cluster_format, featurization='cluster')
+
+    # create difference matrices
+    diff_mat = pros.create_difference_matrices(cell_table=cluster_format, features=features)
+    diff_mat_train = pros.create_difference_matrices(cell_table=cluster_format,
+                                                     features=features, inference=False)
+
+    # check output names
+    verify_in_list(correct=['train_diff_mat', 'inference_diff_mat'], actual=list(diff_mat.keys()))
+    verify_in_list(correct=['train_diff_mat', 'inference_diff_mat'], actual=list(
+        diff_mat_train.keys()))
+    # check output values
+    assert all(list(diff_mat.values()))
+    assert diff_mat_train['inference_diff_mat'] is None
+    # check output dimensions
+    train_dims = [x.shape[1] for x in diff_mat['train_diff_mat'].values()]
+    infer_dims = [x.shape[1] for x in diff_mat['inference_diff_mat'].values()]
+    cell_table_infer_dims = [cluster_format[1].shape[0], cluster_format[2].shape[0],
+                             cluster_format[3].shape[0], cluster_format[4].shape[0]]
+    cell_table_train_dims = [np.round(x * 0.75) for x in cell_table_infer_dims]
+
+    for i in range(len(train_dims)):
+        assert train_dims[i] == cell_table_train_dims[i]
+        assert infer_dims[i] == cell_table_infer_dims[i]
+

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -120,3 +120,19 @@ def test_create_difference_matrices():
     # check output values
     assert all(list(diff_mat.values()))
     assert diff_mat_train['inference_diff_mat'] is None
+
+
+def test_fov_density():
+    # Format cell table
+    all_clusters = list(np.unique(TEST_CELL_TABLE[settings.CLUSTER_ID]))
+    cluster_format = pros.format_cell_table(cell_table=TEST_CELL_TABLE, clusters=all_clusters)
+    cell_dens = pros.fov_density(cluster_format)
+
+    # check for correct names
+    verify_in_list(correct=["average_area", "cellular_density"], actual=list(cell_dens.keys()))
+    # check for correct dims
+    assert len(cell_dens["average_area"]) == len(cluster_format["fovs"])
+    assert len(cell_dens["cellular_density"]) == len(cluster_format["fovs"])
+    # check for non-negative output
+    assert all([x >= 0 for x in cell_dens["average_area"].values()])
+    assert all([x >= 0 for x in cell_dens["cellular_density"].values()])

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -120,13 +120,3 @@ def test_create_difference_matrices():
     # check output values
     assert all(list(diff_mat.values()))
     assert diff_mat_train['inference_diff_mat'] is None
-    # check output dimensions
-    train_dims = [x.shape[1] for x in diff_mat['train_diff_mat'].values()]
-    infer_dims = [x.shape[1] for x in diff_mat['inference_diff_mat'].values()]
-    cell_table_infer_dims = [cluster_format[1].shape[0], cluster_format[2].shape[0],
-                             cluster_format[3].shape[0], cluster_format[4].shape[0]]
-    cell_table_train_dims = [np.round(x * 0.75).astype(int) for x in cell_table_infer_dims]
-
-    for i in range(len(train_dims)):
-        assert train_dims[i] == cell_table_train_dims[i]
-        assert infer_dims[i] == cell_table_infer_dims[i]

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -1,15 +1,16 @@
 import numpy as np
 import pytest
+from sklearn.cluster import KMeans
 
 import ark.settings as settings
 import ark.spLDA.processing as pros
 from ark.utils.misc_utils import verify_in_list
 from ark.utils.test_utils import make_cell_table
-from sklearn.cluster import KMeans
 
 # Generate a test cell table
 N_CELLS = 1000
 TEST_CELL_TABLE = make_cell_table(N_CELLS)
+
 
 def test_format_cell_table():
     # call formatting function
@@ -129,4 +130,3 @@ def test_create_difference_matrices():
     for i in range(len(train_dims)):
         assert train_dims[i] == cell_table_train_dims[i]
         assert infer_dims[i] == cell_table_infer_dims[i]
-

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+
+import ark.spLDA.processing as pros
+from ark.utils.misc_utils import verify_in_list
+from ark.utils.test_utils import make_cell_table
+
+# Generate, format, and featurize a test cell table
+N_CELLS = 1000
+TRAIN_FRAC = 0.75
+TRAIN_CELLS = TRAIN_FRAC * N_CELLS
+TEST_CELL_TABLE = make_cell_table(N_CELLS)
+TEST_FORMAT = pros.format_cell_table(
+    cell_table=TEST_CELL_TABLE, clusters=list(np.unique(TEST_CELL_TABLE["cluster_id"])))
+TEST_FEATURES = pros.featurize_cell_table(cell_table=TEST_FORMAT, train_frac=TRAIN_FRAC)
+
+
+def test_format_cell_table():
+    # Check that number of FOVS match
+    verify_in_list(
+        fovs1=list(np.unique(TEST_CELL_TABLE["SampleID"])), fovs2=list(TEST_FORMAT.keys()))
+    # Check that columns were retained/renamed
+    verify_in_list(
+        cols1=["x", "y", "cluster_id", "cluster", "is_index"], cols2=list(TEST_FORMAT[1].columns))
+    # Check that columns were dropped
+    assert len(TEST_CELL_TABLE.columns) < len(TEST_FORMAT[1].columns)
+
+
+def test_featurize_cell_table():
+    # Check for consistent dimensions
+    assert TEST_FEATURES["featurized_fovs"].shape[0] == TEST_CELL_TABLE.shape[0]
+    assert TEST_FEATURES["featurized_fovs"].shape[0] == N_CELLS
+    assert TEST_FEATURES["train_features"].shape[0] == TRAIN_CELLS
+
+
+def test_compute_topic_eda():
+    # at least 25 bootstrap iterations
+    with pytest.raises(ValueError, match="Number of bootstrap samples must be at least 25"):
+        pros.compute_topic_eda(TEST_FEATURES["featurized_fovs"], topics=[5], num_boots=20)
+    # appropriate range of topics
+    with pytest.raises(ValueError, match="Number of topics must be greater than 2"):
+        pros.compute_topic_eda(TEST_FEATURES["featurized_fovs"], topics=[2], num_boots=25)
+    with pytest.raises(ValueError, match=r"Number of topics must be less than"):
+        pros.compute_topic_eda(TEST_FEATURES["featurized_fovs"], topics=[1000], num_boots=25)

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import ark.spLDA.processing as pros
+import ark.settings as settings
 from ark.utils.misc_utils import verify_in_list
 from ark.utils.test_utils import make_cell_table
 
@@ -11,19 +12,20 @@ TRAIN_FRAC = 0.75
 TRAIN_CELLS = TRAIN_FRAC * N_CELLS
 TEST_CELL_TABLE = make_cell_table(N_CELLS)
 TEST_FORMAT = pros.format_cell_table(
-    cell_table=TEST_CELL_TABLE, clusters=list(np.unique(TEST_CELL_TABLE["cluster_id"])))
+    cell_table=TEST_CELL_TABLE, clusters=list(np.unique(TEST_CELL_TABLE[settings.CLUSTER_ID])))
 TEST_FEATURES = pros.featurize_cell_table(cell_table=TEST_FORMAT, train_frac=TRAIN_FRAC)
 
 
 def test_format_cell_table():
     # Check that number of FOVS match
+    fov_list=[x for x in TEST_FORMAT.keys() if x not in ['fovs', 'markers', 'clusters']]
     verify_in_list(
-        fovs1=list(np.unique(TEST_CELL_TABLE["SampleID"])), fovs2=list(TEST_FORMAT.keys()))
+        fovs1=list(np.unique(TEST_CELL_TABLE[settings.FOV_ID])), fovs2=fov_list)
     # Check that columns were retained/renamed
     verify_in_list(
         cols1=["x", "y", "cluster_id", "cluster", "is_index"], cols2=list(TEST_FORMAT[1].columns))
     # Check that columns were dropped
-    assert len(TEST_CELL_TABLE.columns) < len(TEST_FORMAT[1].columns)
+    assert len(TEST_CELL_TABLE.columns) > len(TEST_FORMAT[1].columns)
 
 
 def test_featurize_cell_table():

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -35,7 +35,7 @@ def test_featurize_cell_table():
 
 def test_compute_topic_eda():
     # at least 25 bootstrap iterations
-    with pytest.raises(ValueError, match="Number of bootstrap samples must be at least 25"):
+    with pytest.raises(ValueError, match="Number of bootstrap samples must be at least"):
         pros.compute_topic_eda(TEST_FEATURES["featurized_fovs"], topics=[5], num_boots=20)
     # appropriate range of topics
     with pytest.raises(ValueError, match="Number of topics must be greater than 2"):

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -125,7 +125,7 @@ def test_create_difference_matrices():
     infer_dims = [x.shape[1] for x in diff_mat['inference_diff_mat'].values()]
     cell_table_infer_dims = [cluster_format[1].shape[0], cluster_format[2].shape[0],
                              cluster_format[3].shape[0], cluster_format[4].shape[0]]
-    cell_table_train_dims = [np.round(x * 0.75) for x in cell_table_infer_dims]
+    cell_table_train_dims = [np.round(x * 0.75).astype(int) for x in cell_table_infer_dims]
 
     for i in range(len(train_dims)):
         assert train_dims[i] == cell_table_train_dims[i]

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -119,6 +119,9 @@ def test_create_difference_matrices():
     diff_mat = pros.create_difference_matrices(cell_table=cluster_format, features=features)
     diff_mat_train = pros.create_difference_matrices(cell_table=cluster_format,
                                                      features=features, inference=False)
+    diff_mat_infer = pros.create_difference_matrices(cell_table=cluster_format,
+                                                     features=features, training=False,
+                                                     inference=True)
 
     # check for valid inputs
     with pytest.raises(ValueError, match="One or both of"):
@@ -132,6 +135,7 @@ def test_create_difference_matrices():
     # check output values
     assert all(list(diff_mat.values()))
     assert diff_mat_train['inference_diff_mat'] is None
+    assert diff_mat_infer['train_diff_mat'] is None
 
 
 def test_fov_density():

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -93,9 +93,9 @@ def test_compute_topic_eda():
     with pytest.raises(ValueError, match="Number of bootstrap samples must be at least"):
         pros.compute_topic_eda(features["featurized_fovs"], topics=[5], num_boots=20)
     # appropriate range of topics
-    with pytest.raises(ValueError, match="Number of topics must be greater than 2"):
+    with pytest.raises(ValueError, match="Number of topics must be in"):
         pros.compute_topic_eda(features["featurized_fovs"], topics=[2], num_boots=25)
-    with pytest.raises(ValueError, match=r"Number of topics must be less than"):
+    with pytest.raises(ValueError, match=r"Number of topics must be in"):
         pros.compute_topic_eda(features["featurized_fovs"], topics=[1000], num_boots=25)
     # check for correct output
     eda = pros.compute_topic_eda(features=features["featurized_fovs"], topics=[5], num_boots=25)
@@ -112,6 +112,11 @@ def test_create_difference_matrices():
     diff_mat = pros.create_difference_matrices(cell_table=cluster_format, features=features)
     diff_mat_train = pros.create_difference_matrices(cell_table=cluster_format,
                                                      features=features, inference=False)
+
+    # check for valid inputs
+    with pytest.raises(ValueError, match="One or both of"):
+        pros.create_difference_matrices(cell_table=cluster_format, features=features,
+                                        training=False, inference=False)
 
     # check output names
     verify_in_list(correct=['train_diff_mat', 'inference_diff_mat'], actual=list(diff_mat.keys()))

--- a/ark/spLDA/processing_test.py
+++ b/ark/spLDA/processing_test.py
@@ -50,21 +50,28 @@ def test_format_cell_table():
 
 
 def test_featurize_cell_table():
-    # call formatting function - only test on clusters to avoid repetition
+    # call formatting function
     all_clusters = list(np.unique(TEST_CELL_TABLE[settings.CLUSTER_ID]))
-    cluster_format = pros.format_cell_table(cell_table=TEST_CELL_TABLE, clusters=all_clusters)
+    all_markers = ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+    cluster_names = list(np.unique(TEST_CELL_TABLE["cluster_labels"]))
+    cell_table_format = pros.format_cell_table(cell_table=TEST_CELL_TABLE, clusters=all_clusters,
+                                               markers=all_markers)
 
     # call featurization
-    features1 = pros.featurize_cell_table(cell_table=cluster_format, featurization='cluster',
+    features1 = pros.featurize_cell_table(cell_table=cell_table_format, featurization='cluster',
                                           train_frac=0.75)
-    features2 = pros.featurize_cell_table(cell_table=cluster_format, featurization='cluster',
+    features2 = pros.featurize_cell_table(cell_table=cell_table_format, featurization='cluster',
                                           train_frac=0.5)
+    features3 = pros.featurize_cell_table(cell_table=cell_table_format, featurization='marker',
+                                          train_frac=0.75)
 
-    # Check for consistent dimensions
+    # Check for consistent dimensions and correct column names
     assert features1["featurized_fovs"].shape[0] == TEST_CELL_TABLE.shape[0] == N_CELLS
     assert features2["featurized_fovs"].shape[0] == TEST_CELL_TABLE.shape[0] == N_CELLS
     assert features1["train_features"].shape[0] == 0.75 * N_CELLS
     assert features2["train_features"].shape[0] == 0.5 * N_CELLS
+    verify_in_list(correct=all_markers, actual=list(features3["featurized_fovs"].columns))
+    verify_in_list(correct=cluster_names, actual=list(features1["featurized_fovs"].columns))
 
 
 def test_gap_stat():

--- a/ark/utils/segmentation_utils_test.py
+++ b/ark/utils/segmentation_utils_test.py
@@ -290,8 +290,8 @@ def test_save_segmentation_labels():
 
 def test_concatenate_csv():
     # create sample data
-    test_data_1 = test_utils.make_segmented_csv(num_cells=10)
-    test_data_2 = test_utils.make_segmented_csv(num_cells=20)
+    test_data_1 = test_utils.make_cell_table(num_cells=10)
+    test_data_2 = test_utils.make_cell_table(num_cells=20)
 
     with pytest.raises(ValueError):
         # attempt to pass column_values list with different length than number of csv files

--- a/ark/utils/spatial_lda_utils.py
+++ b/ark/utils/spatial_lda_utils.py
@@ -1,6 +1,5 @@
 from ark.settings import BASE_COLS, CLUSTER_ID
 from ark.utils.misc_utils import verify_in_list
-from sklearn.metrics import silhouette_score
 
 
 def check_format_cell_table_args(cell_table, markers, clusters):
@@ -51,18 +50,3 @@ def check_featurize_cell_table_args(cell_table, featurization, radius, cell_inde
     verify_in_list(featurization=[featurization],
                    featurization_options=["cluster", "marker", "avg_marker", "count"])
     verify_in_list(cell_index=[cell_index], cell_table_columns=cell_table[1].columns.to_list())
-
-
-def silhouette(features, labels):
-    return silhouette_score(features, labels, metric='euclidean')
-
-
-def inertia(fit):
-    return fit.inertia_
-
-
-def filter_by_index(array, index, k, rows=True):
-    if rows:
-        return array[:, index == k]
-    else:
-        return array[index == k, :]

--- a/ark/utils/spatial_lda_utils.py
+++ b/ark/utils/spatial_lda_utils.py
@@ -1,5 +1,6 @@
 from ark.settings import BASE_COLS, CLUSTER_ID
 from ark.utils.misc_utils import verify_in_list
+from sklearn.metrics import silhouette_score
 
 
 def check_format_cell_table_args(cell_table, markers, clusters):
@@ -50,3 +51,18 @@ def check_featurize_cell_table_args(cell_table, featurization, radius, cell_inde
     verify_in_list(featurization=[featurization],
                    featurization_options=["cluster", "marker", "avg_marker", "count"])
     verify_in_list(cell_index=[cell_index], cell_table_columns=cell_table[1].columns.to_list())
+
+
+def silhouette(features, labels):
+    return silhouette_score(features, labels, metric='euclidean')
+
+
+def inertia(fit):
+    return fit.inertia_
+
+
+def filter_by_index(array, index, k, rows=True):
+    if rows:
+        return array[:, index == k]
+    else:
+        return array[index == k, :]

--- a/ark/utils/test_utils.py
+++ b/ark/utils/test_utils.py
@@ -549,8 +549,9 @@ def make_cell_table(num_cells, extra_cols=None):
             cluster labels, centroid coordinates, and more.
 
     """
-    # colmns from regionprops extraction
-    region_cols = settings.REGIONPROPS_BASE[2:] + settings.REGIONPROPS_SINGLE_COMP + \
+    # columns from regionprops extraction
+    region_cols = [x for x in settings.REGIONPROPS_BASE if x not in ['label','area','centroid']]+ \
+                  settings.REGIONPROPS_SINGLE_COMP + \
                   settings.REGIONPROPS_MULTI_COMP
     # consistent ordering of column names
     column_names = [settings.FOV_ID,
@@ -559,7 +560,7 @@ def make_cell_table(num_cells, extra_cols=None):
                     settings.KMEANS_CLUSTER,
                     settings.CELL_LABEL,
                     settings.CELL_TYPE,
-                    settings.CELL_SIZE] + TEST_MARKERS + region_cols
+                    settings.CELL_SIZE] + TEST_MARKERS + region_cols + ['centroid-0', 'centroid-1']
 
     if extra_cols is not None:
         column_names += list(extra_cols.values())

--- a/ark/utils/test_utils.py
+++ b/ark/utils/test_utils.py
@@ -551,9 +551,8 @@ def make_cell_table(num_cells, extra_cols=None):
     """
     # columns from regionprops extraction
     region_cols = [x for x in settings.REGIONPROPS_BASE if
-                   x not in ['label', 'area', 'centroid']] + \
-                  settings.REGIONPROPS_SINGLE_COMP + \
-                  settings.REGIONPROPS_MULTI_COMP
+                   x not in ['label', 'area', 'centroid']] + settings.REGIONPROPS_SINGLE_COMP
+    region_cols += settings.REGIONPROPS_MULTI_COMP
     # consistent ordering of column names
     column_names = [settings.FOV_ID,
                     settings.PATIENT_ID,

--- a/ark/utils/test_utils.py
+++ b/ark/utils/test_utils.py
@@ -550,7 +550,8 @@ def make_cell_table(num_cells, extra_cols=None):
 
     """
     # columns from regionprops extraction
-    region_cols = [x for x in settings.REGIONPROPS_BASE if x not in ['label','area','centroid']]+ \
+    region_cols = [x for x in settings.REGIONPROPS_BASE if
+                   x not in ['label', 'area', 'centroid']] + \
                   settings.REGIONPROPS_SINGLE_COMP + \
                   settings.REGIONPROPS_MULTI_COMP
     # consistent ordering of column names

--- a/ark/utils/test_utils.py
+++ b/ark/utils/test_utils.py
@@ -533,26 +533,46 @@ def make_labels_xarray(label_data, fov_ids=None, compartment_names=None, row_siz
 TEST_MARKERS = list('ABCDEFG')
 
 
-def make_segmented_csv(num_cells, extra_cols=None):
-    """ Generate segmented 'csv' file
+def generate_cell_table(num_cells, extra_cols=None):
+    """ Generate a cell table with default column names for testing purposes.
 
     Args:
         num_cells (int):
-            Number of rows (cells) in csv
+            Number of rows (cells) in the cell table
         extra_cols (dict):
             Extra columns to add in the format ``{'Column_Name' : data_1D, ...}``
 
     Returns:
         pandas.DataFrame:
-            segmented csv data
+            A structural example of a cell table containing simulated marker expressions,
+            cluster labels, centroid coordinates, and more.
 
     """
+    column_names = TEST_MARKERS
+    num_cols = len(column_names)
+    if extra_cols is not None:
+        num_cols += len(extra_cols.items())
+        for i in list(extra_cols.values()):
+            column_names.append(i)
+
     cell_data = pd.DataFrame(
-        np.random.random(size=(num_cells, len(TEST_MARKERS))),
-        columns=TEST_MARKERS
+        np.random.random(size=(num_cells, num_cols)),
+        columns=column_names
     )
-    cell_data[settings.CELL_TYPE] = choices(ascii_lowercase, k=num_cells)
-    cell_data[settings.PATIENT_ID] = choices(range(1, 10), k=num_cells)
+
+    cluster_id = choices(range(1,21), k=num_cells)
+    fields = [(settings.CELL_TYPE, choices(ascii_lowercase, k=num_cells)),
+              (settings.PATIENT_ID, choices(range(1, 10), k=num_cells)),
+              (settings.CELL_SIZE, np.random.uniform(100, 300, size=num_cells)),
+              (settings.FOV_ID, choices(range(1,5), k=num_cells)),
+              (settings.CLUSTER_ID, cluster_id),
+              (settings.KMEANS_CLUSTER, [ascii_lowercase[i] for i in cluster_id]),
+              (settings.CENTROID_0, np.random.choice(range(1024), size=num_cells, replace=False)),
+              (settings.CENTROID_1, np.random.choice(range(1024), size=num_cells, replace=False))
+              ]
+
+    for name, col in fields:
+        cell_data[name] = col
 
     return cell_data
 

--- a/ark/utils/test_utils.py
+++ b/ark/utils/test_utils.py
@@ -570,6 +570,8 @@ def make_cell_table(num_cells, extra_cols=None):
                              columns=column_names)
     # not-so-random filler data
     cluster_id = choices(range(1, 21), k=num_cells)
+    centroids = pd.DataFrame(np.array([(x, y) for x in range(1024) for y in range(1024)]))
+    centroid_loc = np.random.choice(range(1024 ** 2), size=num_cells, replace=False)
     fields = [(settings.FOV_ID, choices(range(1, 5), k=num_cells)),
               (settings.PATIENT_ID, choices(range(1, 10), k=num_cells)),
               (settings.CLUSTER_ID, cluster_id),
@@ -577,8 +579,8 @@ def make_cell_table(num_cells, extra_cols=None):
               (settings.CELL_LABEL, list(range(num_cells))),
               (settings.CELL_TYPE, choices(ascii_lowercase, k=num_cells)),
               (settings.CELL_SIZE, np.random.uniform(100, 300, size=num_cells)),
-              (settings.CENTROID_0, np.random.choice(range(1024), size=num_cells, replace=False)),
-              (settings.CENTROID_1, np.random.choice(range(1024), size=num_cells, replace=False))
+              (settings.CENTROID_0, np.array(centroids.iloc[centroid_loc, 0])),
+              (settings.CENTROID_1, np.array(centroids.iloc[centroid_loc, 1]))
               ]
 
     for name, col in fields:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ scikit-image>=0.14.3,<=0.16.2
 scikit-learn>=0.19.1,<1
 scipy>=1.1.0,<2
 seaborn>=0.10.1,<1
-spatial_lda>=0.1.0
+git+git://github.com/calico/spatial_lda.git@primary
 statsmodels>=0.11.1,<1
 tqdm>=4.54.1,<5
 umap-learn>=0.4.6,<1


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR adds functions which compute various exploratory metrics for determining (1) a potential radius to use for spatial-LDA featurization and (2) an appropriate number of topics for training/inference.  In addition, a function was added which generates a typical cell table with default column names.  Some columns also have data which is randomly generated for testing purposes.

**How did you implement your changes**

To get a rough idea of an appropriate number of topics, we leverage the speed of K-means clustering and compute diagnostic metrics on the result.  This includes standard clustering metrics like inertia and silhouette score.  It also includes more specialized metrics like the gap statistic which requires bootstrapping the data.  

For making a test cell table, standard column names and their ordering are taken from the documentation of `marker_quantification.generate_cell_table()`.  The new function is in `test_utils.py` and replaces `make_segmented_csv()`.  

**Remaining issues**

The initial build will fail because of a `ImportError` thrown by trying to import `logsumexp` from an outdated source.  The fixed have been merged into Calico's spatial_lda repo but have not been updated in pypi yet.  Because of that, some the tests have not been able to run yet.  Also the data for generating a test cell table is arbitrary and not realistic.  While this is mostly for testing functionality anyway, it may be nice to have data which is representative of an actual cell table.
