### PR TITLE
Allow generate_deepcell_input to accept other img_sub_folder values (including None) for non-MIBItiff inputs

### DIFF
--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -80,7 +80,7 @@ def relabel_segmentation(labeled_image, labels_dict):
 
 # TODO: Add metadata for channel name (eliminates need for fixed-order channels)
 def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs,
-                            is_mibitiff=False, img_sub_folder="TIFs", batch_size=5,
+                            is_mibitiff=False, img_sub_folder=None, batch_size=5,
                             dtype="int16"):
     """Saves nuclear and membrane channels into deepcell input format.
     Either nuc_channels or mem_channels should be specified.
@@ -133,7 +133,7 @@ def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs
             )
         else:
             data_xr = load_utils.load_imgs_from_tree(
-                tiff_dir, img_sub_folder="TIFs", fovs=fovs, channels=channels, dtype=dtype
+                tiff_dir, img_sub_folder=img_sub_folder, fovs=fovs, channels=channels, dtype=dtype
             )
 
         # write each fov data to data_dir

--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -80,7 +80,7 @@ def relabel_segmentation(labeled_image, labels_dict):
 
 # TODO: Add metadata for channel name (eliminates need for fixed-order channels)
 def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs,
-                            is_mibitiff=False, img_sub_folder=None, batch_size=5,
+                            is_mibitiff=False, img_sub_folder="TIFs", batch_size=5,
                             dtype="int16"):
     """Saves nuclear and membrane channels into deepcell input format.
     Either nuc_channels or mem_channels should be specified.

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -44,7 +44,7 @@ def test_generate_deepcell_input():
             # by setting batch_size=2, we test a batch size with a remainder
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
             )
 
             fov1 = np.moveaxis(io.imread(fov1path), 0, -1)
@@ -61,7 +61,7 @@ def test_generate_deepcell_input():
 
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
             )
 
             nuc_sums = data_xr.loc[:, :, :, nucs].sum(dim='channels').values
@@ -83,7 +83,7 @@ def test_generate_deepcell_input():
 
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
             )
 
             fov1 = np.moveaxis(io.imread(fov1path), 0, -1)

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -103,7 +103,7 @@ def test_generate_deepcell_input():
 
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
             )
 
             fov1 = np.moveaxis(io.imread(fov1path), 0, -1)

--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -188,7 +188,7 @@
    "outputs": [],
    "source": [
     "# generate and save deepcell input tifs\n",
-    "# set img_sub_folder param to None if tiff_dir does not contain one for fov data\n",
+    "# set img_sub_folder param to None if the image files in tiff_dir are not in a separate sub folder \n",
     "data_utils.generate_deepcell_input(\n",
     "    deepcell_input_dir,\n",
     "    tiff_dir,\n",

--- a/templates/Segment_Image_Data.ipynb
+++ b/templates/Segment_Image_Data.ipynb
@@ -188,9 +188,16 @@
    "outputs": [],
    "source": [
     "# generate and save deepcell input tifs\n",
+    "# set img_sub_folder param to None if tiff_dir does not contain one for fov data\n",
     "data_utils.generate_deepcell_input(\n",
-    "    deepcell_input_dir, tiff_dir, nucs, mems, fovs,\n",
-    "    is_mibitiff=False, img_sub_folder=\"TIFs\", batch_size=5\n",
+    "    deepcell_input_dir,\n",
+    "    tiff_dir,\n",
+    "    nucs,\n",
+    "    mems,\n",
+    "    fovs,\n",
+    "    is_mibitiff=MIBItiff,\n",
+    "    img_sub_folder=\"TIFs\",\n",
+    "    batch_size=5\n",
     ")"
    ]
   },
@@ -416,7 +423,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #470. A bug in `generate_deepcell_input` defaulted the `img_sub_folder` value passed into `load_imgs_for_tree` to always be `'TIFs'`. We need it to accept the `img_sub_folder` value passed into `generate_deepcell_input` instead.

**How did you implement your changes**

In addition to changing this, we also change the default value for `img_sub_folder` of `generate_deepcell_input` to be `None` instead of `'TIFs'`.
