### PR TITLE
Add template developer mode for start_docker.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY ark /opt/ark-analysis/ark
 RUN pip install /opt/ark-analysis
 
 # jupyter lab
-CMD jupyter lab --ip=0.0.0.0 --allow-root --no-browser --port=$JUPYTER_PORT
+CMD jupyter lab --ip=0.0.0.0 --allow-root --no-browser --port=$JUPYTER_PORT --notebook-dir=/$JUPYTER_DIR

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+# check for template developer flag
+JUPYTER_DIR='scripts'
+while test $# -gt 0
+do
+  case "$1" in
+    -d|--develop-notebook-templates)
+      JUPYTER_DIR='templates'
+      shift
+      ;;
+    *)
+      echo "$1 is not an accepted option..."
+      echo "-d, --develop-notebook-templates : Mount templates for direct editing."
+      shift
+      ;;
+  esac
+done
+
 # if requirements.txt has been changed in the last day, automatically rebuild Docker first
 if [[ $(find . -mmin -1440 -type f -print | grep requirements.txt | wc -l) -eq 1 ]]
   then
@@ -21,8 +38,9 @@ done
 docker run -it \
   -p $PORT:$PORT \
   -e JUPYTER_PORT=$PORT\
+  -e JUPYTER_DIR=$JUPYTER_DIR\
   -v "$PWD/ark:/usr/local/lib/python3.6/site-packages/ark" \
-  -v "$PWD/scripts:/scripts" \
+  -v "$PWD/$JUPYTER_DIR:/$JUPYTER_DIR" \
   -v "$PWD/data:/data" \
   -v "$PWD/.toks:/home/.toks" \
   ark-analysis:latest


### PR DESCRIPTION
**What is the purpose of this PR?**

Add a flag to enable a normal git workflow when developing template notebooks.

Use case:

> As a developer, I want changes to ipynb files to be immediately reflected in git status so that I choose to commit or discard those changes as I commit changes to supporting library files.

This is in addition to the default use case

> As data analyst, I don't want any of my changes to ipynb files to be tracked by git so that pulling updates to the notebooks doesn't cause merge conflicts and I can manually pull latest upstream ipynb files using


See original discussion here: https://github.com/angelolab/ark-analysis/pull/432#discussion_r716258072


**How did you implement your changes**

Added flag `-d`, `--develop-notebook-templates` to `start_docker.sh`

This enables mounting `templates` ipo `scripts`.

Dockerfile is also now passed the starting directory for Jupyter Lab so that the files are actually accessible upon launch.

**Remaining issues**

Needs documented where appropriate.

https://github.com/angelolab/ark-analysis/blob/master/docs/_rtd/contributing.md
https://github.com/angelolab/ark-analysis/blob/master/docs/_rtd/development.md
https://github.com/angelolab/ark-analysis/blob/master/README.md

