### PR TITLE
Notebook update fix and external drive compatibility

### DIFF
--- a/start_docker.sh
+++ b/start_docker.sh
@@ -18,6 +18,7 @@ do
     -e|--external)
       external="$2"
       shift
+      shift
       ;;
     *)
       echo "$1 is not an accepted option..."
@@ -48,6 +49,7 @@ if [ -d "$PWD/scripts" ]
   else
     mkdir "$PWD/scripts"
     cp "$PWD"/templates/*.ipynb "$PWD/scripts/."
+fi
 
 # find lowest open port available
 PORT=8888
@@ -57,7 +59,7 @@ until [[ $(docker container ls | grep 0.0.0.0:$PORT | wc -l) -eq 0 ]]
     ((PORT=$PORT+1))
 done
 
-if [ $external -ne '' ]
+if [ ! -z "$external" ]
   then
     docker run -it \
       -p $PORT:$PORT \

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -2,6 +2,8 @@
 
 # check for template developer flag
 JUPYTER_DIR='scripts'
+update=0
+external=''
 while test $# -gt 0
 do
   case "$1" in
@@ -9,9 +11,19 @@ do
       JUPYTER_DIR='templates'
       shift
       ;;
+    -u|--update)
+      update=1
+      shift
+      ;;
+    -e|--external)
+      external="$2"
+      shift
+      ;;
     *)
       echo "$1 is not an accepted option..."
-      echo "-d, --develop-notebook-templates : Mount templates for direct editing."
+      echo "-d, --develop-notebook-templates  : Mount templates for direct editing."
+      echo "-u, --update                      : Update default scripts"
+      echo "-e, --external                    : Mount external drives to /data/external"
       exit
       ;;
   esac
@@ -24,8 +36,18 @@ if [[ $(find . -mmin -1440 -type f -print | grep requirements.txt | wc -l) -eq 1
     docker build -t ark-analysis .
 fi
 
-# catch and pass update flag to notebook update routine
-bash update_notebooks.sh "$@"
+# perform update if requested
+if [ -d "$PWD/scripts" ]
+  then
+    if [ $update -ne 0 ]
+      then
+        bash update_notebooks.sh
+      else
+        cp -n "$PWD"/templates/*.ipynb "$PWD/scripts/."
+    fi
+  else
+    mkdir "$PWD/scripts"
+    cp "$PWD"/templates/*.ipynb "$PWD/scripts/."
 
 # find lowest open port available
 PORT=8888
@@ -35,12 +57,26 @@ until [[ $(docker container ls | grep 0.0.0.0:$PORT | wc -l) -eq 0 ]]
     ((PORT=$PORT+1))
 done
 
-docker run -it \
-  -p $PORT:$PORT \
-  -e JUPYTER_PORT=$PORT\
-  -e JUPYTER_DIR=$JUPYTER_DIR\
-  -v "$PWD/ark:/usr/local/lib/python3.6/site-packages/ark" \
-  -v "$PWD/$JUPYTER_DIR:/$JUPYTER_DIR" \
-  -v "$PWD/data:/data" \
-  -v "$PWD/.toks:/home/.toks" \
-  ark-analysis:latest
+if [ $external -ne '' ]
+  then
+    docker run -it \
+      -p $PORT:$PORT \
+      -e JUPYTER_PORT=$PORT\
+      -e JUPYTER_DIR=$JUPYTER_DIR\
+      -v "$PWD/ark:/usr/local/lib/python3.6/site-packages/ark" \
+      -v "$PWD/$JUPYTER_DIR:/$JUPYTER_DIR" \
+      -v "$PWD/data:/data" \
+      -v "$external:/data/external" \
+      -v "$PWD/.toks:/home/.toks" \
+      ark-analysis:latest
+  else
+    docker run -it \
+      -p $PORT:$PORT \
+      -e JUPYTER_PORT=$PORT\
+      -e JUPYTER_DIR=$JUPYTER_DIR\
+      -v "$PWD/ark:/usr/local/lib/python3.6/site-packages/ark" \
+      -v "$PWD/$JUPYTER_DIR:/$JUPYTER_DIR" \
+      -v "$PWD/data:/data" \
+      -v "$PWD/.toks:/home/.toks" \
+      ark-analysis:latest
+fi

--- a/update_notebooks.sh
+++ b/update_notebooks.sh
@@ -1,66 +1,29 @@
 #!/bin/bash
 
-# behavior depends on scripts directory's presence
-if [ -d "$PWD/scripts" ]
-then
-
-  # check for update flag
-  update=0
-  while test $# -gt 0
-  do
-    case "$1" in
-      -u|--update)
-        update=1
-        shift
-        ;;
-      *)
-        echo "$1 is not an accepted option..."
-        shift
-        ;;
-    esac
-  done
-
-  # perform update if requested
-  if [ $update -ne 0 ]
+# check for each template's existance
+for f in "$PWD"/templates/*.ipynb
+do
+  # get basename of notebook
+  name=$(basename "$f")
+  # get difference between similarly named notebook in scripts folder
+  DIFF=$(diff "$f" "$PWD/scripts/$name" 2>/dev/null)
+  # get exit-code of diff
+  #   *-------------------------------------------------------------------*
+  #   |  0  |   successful and no differences.  systematically univeral   |
+  #   |  1  |   successful and differences.  systematically universal     |
+  #   | -1  |   error (no file, etc.).  error code is system dependent    |
+  #   |  2  |   error (no file, etc.).  error code is system dependent    |
+  #   *-------------------------------------------------------------------*
+  DIFFEXIT=$?
+  # check for error
+  if [ $DIFFEXIT -ne 0 ] && [ $DIFFEXIT -ne 1 ]
   then
-    # check for each template's existance
-    for f in "$PWD"/templates/*.ipynb
-    do
-      # get basename of notebook
-      name=$(basename "$f")
-
-      # get difference between similarly named notebook in scripts folder
-      DIFF=$(diff "$f" "$PWD/scripts/$name" 2>/dev/null)
-
-      # get exit-code of diff
-      #   *-------------------------------------------------------------------*
-      #   |  0  |   successful and no differences.  systematically univeral   |
-      #   |  1  |   successful and differences.  systematically universal     |
-      #   | -1  |   error (no file, etc.).  error code is system dependent    |
-      #   |  2  |   error (no file, etc.).  error code is system dependent    |
-      #   *-------------------------------------------------------------------*
-      DIFFEXIT=$?
-
-      # check for error
-      if [ $DIFFEXIT -ne 0 ] && [ $DIFFEXIT -ne 1 ]
-      then
-        echo "$name was not found.  Creating new file $name in scripts"
-        cp -- "$f" "$PWD/scripts/$name"
-
-      # if difference, add updated file
-      elif [ "$DIFF" != "" ]
-      then
-        echo "WARNING: The file $name is being overwritten..."
-        cp -- "$f" "$PWD/scripts/$name"
-      fi
-    done
-  else
-    # -n for no overwrite
-    # this is to prevent the case of an empty scripts directory not being filled
-    cp -n "$PWD"/templates/*.ipynb "$PWD/scripts/."
+    echo "$name was not found.  Creating new file $name in scripts"
+    cp -- "$f" "$PWD/scripts/$name"
+  # if difference, add updated file
+  elif [ "$DIFF" != "" ]
+  then
+    echo "WARNING: The file $name is being overwritten..."
+    cp -- "$f" "$PWD/scripts/$name"
   fi
-else
-  # since there is no scripts directory, just make one and copy from templates
-  mkdir "$PWD/scripts"
-  cp "$PWD"/templates/*.ipynb "$PWD/scripts/."
-fi
+done


### PR DESCRIPTION
## **Purpose**

Fixes issue #477 and adds configurable external drive compatibility via the `--external '/path/to/drive'` or `-e '/path/to/drive'` argument flags.

## **Implementation**

Moves some logic from `update_notebooks.sh` into `start_docker.sh` so that `update_notebooks.sh` is called conditionally.  As for external drive compatibility, that just needs to be added to docker's filepaths in the preferences menu.

## **Remaining issues**

Need to add a blurb to readme about external drives.

Also, the `--external` tag takes a path as a second argument in order to be compatible with multiple OS's.  On macOS, this would always be `/Volumes`, while on Windows, it could be `G:\\`, `F:\\`, etc.  I could see this being kind of annoying for macOS users, so a separate `--mount_volumes | -m` option could be added.