### PR TITLE
pins docutils to 0.16

### DIFF
--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -1,4 +1,5 @@
 commonmark==0.9.1
+docutils==0.16
 ipython==7.16.1
 m2r2==0.2.5
 mock==4.0.2


### PR DESCRIPTION
## **Purpose**

Pins `docutils` to version 0.16 to fix read-the-docs build errors