### PR TITLE
Patch MibiTracker download to prevent downloading of channels from Moly points

### DIFF
--- a/templates_qc/example_qc_metric_eval.ipynb
+++ b/templates_qc/example_qc_metric_eval.ipynb
@@ -51,10 +51,14 @@
    "outputs": [],
    "source": [
     "# set MIBItracker specific parameters\n",
-    "email = 'qc.mibi@gmail.com'\n",
-    "password = 'The_MIBI_Is_Down_Again1!?'\n",
-    "run_name = '191008_JG85b'\n",
-    "run_label = 'JG85_Run2'"
+    "# email = 'qc.mibi@gmail.com'\n",
+    "# password = 'The_MIBI_Is_Down_Again1!?'\n",
+    "# run_name = '191008_JG85b'\n",
+    "# run_label = 'JG85_Run2'\n",
+    "email = 'alkong@stanford.edu\n",
+    "password = 'PalyVikes#2ALK'\n",
+    "run_name = '2021-12-13_test5'\n",
+    "run_label = '2021-12-13_test5'"
    ]
   },
   {
@@ -450,7 +454,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/templates_qc/example_qc_metric_eval.ipynb
+++ b/templates_qc/example_qc_metric_eval.ipynb
@@ -51,14 +51,10 @@
    "outputs": [],
    "source": [
     "# set MIBItracker specific parameters\n",
-    "# email = 'qc.mibi@gmail.com'\n",
-    "# password = 'The_MIBI_Is_Down_Again1!?'\n",
-    "# run_name = '191008_JG85b'\n",
-    "# run_label = 'JG85_Run2'\n",
-    "email = 'alkong@stanford.edu\n",
-    "password = 'PalyVikes#2ALK'\n",
-    "run_name = '2021-12-13_test5'\n",
-    "run_label = '2021-12-13_test5'"
+    "email = 'qc.mibi@gmail.com'\n",
+    "password = 'The_MIBI_Is_Down_Again1!?'\n",
+    "run_name = '191008_JG85b'\n",
+    "run_label = 'JG85_Run2'"
    ]
   },
   {


### PR DESCRIPTION
**What is the purpose of this PR?**

Runs user specify to download for QC analysis may contain Moly points. `example_qc_metric_eval.ipynb` is currently not equipped to handle this, so we add functionality in to prevent the download of Moly points.

**How did you implement your changes**

A check is added in `download_mibitracker_data` to remove any FOVs from the download which do not contain the channels desired. Since all other images will contain the full set of channels, this will remove any Moly points from the mix.
