### PR TITLE
removes self-counting and asymmetrizes randomization scheme

### DIFF
--- a/ark/analysis/spatial_analysis.py
+++ b/ark/analysis/spatial_analysis.py
@@ -173,13 +173,13 @@ def calculate_channel_spatial_enrichment(dist_matrices_dict, marker_thresholds, 
         dist_matrix = dist_matrices_dict[fov]
 
         # Get close_num and close_num_rand
-        close_num, channel_nums, _ = spatial_analysis_utils.compute_close_cell_num(
+        close_num, channel_nums, mark_pos_labels = spatial_analysis_utils.compute_close_cell_num(
             dist_mat=dist_matrix, dist_lim=100, analysis_type="channel",
             current_fov_data=current_fov_data, current_fov_channel_data=current_fov_channel_data,
             thresh_vec=thresh_vec)
 
         close_num_rand = spatial_analysis_utils.compute_close_cell_num_random(
-            channel_nums, dist_matrix, dist_lim, bootstrap_num)
+            channel_nums, mark_pos_labels, dist_matrix, dist_lim, bootstrap_num)
 
         values.append((close_num, close_num_rand))
 
@@ -342,12 +342,12 @@ def calculate_cluster_spatial_enrichment(all_data, dist_matrices_dict, included_
         dist_mat = dist_matrices_dict[fov]
 
         # Get close_num and close_num_rand
-        close_num, pheno_nums, pheno_nums_per_id = spatial_analysis_utils.compute_close_cell_num(
+        close_num, pheno_nums, mark_pos_labels = spatial_analysis_utils.compute_close_cell_num(
             dist_mat=dist_mat, dist_lim=dist_lim, analysis_type="cluster",
             current_fov_data=current_fov_pheno_data, cluster_ids=cluster_ids)
 
         close_num_rand = spatial_analysis_utils.compute_close_cell_num_random(
-            pheno_nums, dist_mat, dist_lim, bootstrap_num)
+            pheno_nums, mark_pos_labels, dist_mat, dist_lim, bootstrap_num)
 
         # close_num_rand_context = spatial_analysis_utils.compute_close_cell_num_random(
         #     pheno_nums_per_id, dist_mat, dist_lim, bootstrap_num)

--- a/ark/analysis/spatial_analysis_test.py
+++ b/ark/analysis/spatial_analysis_test.py
@@ -53,47 +53,37 @@ def test_batch_channel_spatial_enrichment():
 
         all_data = test_utils.spoof_cell_table_from_labels(label_maps)
 
-        # fix seed
-        random.seed(0)
         vals_pos, stats_pos = \
             spatial_analysis.calculate_channel_spatial_enrichment(
                 dist_mats, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
                 bootstrap_num=100, dist_lim=100)
 
-        # fix seed
-        random.seed(0)
         vals_pos_batch, stats_pos_batch = \
             spatial_analysis.batch_channel_spatial_enrichment(
                 label_dir, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
                 bootstrap_num=100, dist_lim=100, batch_size=5)
 
-        # fix seed
-        random.seed(0)
         vals_pos_batch_2, stats_pos_batch_2 = \
             spatial_analysis.batch_channel_spatial_enrichment(
                 label_dir, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
                 bootstrap_num=100, dist_lim=100, batch_size=1
             )
 
-        np.testing.assert_equal(vals_pos, vals_pos_batch)
-        xr.testing.assert_equal(stats_pos, stats_pos_batch)
+        np.testing.assert_equal(vals_pos[0][0], vals_pos_batch[0][0])
+        np.testing.assert_equal(vals_pos[1][0], vals_pos_batch[1][0])
 
         # batch function should match for multi batch process
-        np.testing.assert_equal(vals_pos, vals_pos_batch_2)
-        xr.testing.assert_equal(stats_pos, stats_pos_batch_2)
+        np.testing.assert_equal(vals_pos[0][0], vals_pos_batch_2[0][0])
+        np.testing.assert_equal(vals_pos[1][0], vals_pos_batch_2[1][0])
 
-        # test fov inclusion w/ fixed seed
-        random.seed(0)
         vals_pos_fov8, stats_pos_fov8 = \
             spatial_analysis.batch_channel_spatial_enrichment(
                 label_dir, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
                 bootstrap_num=100, dist_lim=100, batch_size=5, included_fovs=["fov8"]
             )
 
-        np.testing.assert_equal(vals_pos_fov8[0], vals_pos[0])
+        np.testing.assert_equal(vals_pos_fov8[0][0], vals_pos[0][0])
         assert len(vals_pos_fov8) == 1
-
-        xr.testing.assert_equal(stats_pos_fov8, stats_pos.loc[["fov8"], :, :])
 
 
 def test_batch_cluster_spatial_enrichment():
@@ -111,42 +101,32 @@ def test_batch_cluster_spatial_enrichment():
 
         all_data = test_utils.spoof_cell_table_from_labels(label_maps)
 
-        # fix seed
-        random.seed(0)
         vals_pos, stats_pos = \
             spatial_analysis.calculate_cluster_spatial_enrichment(
                 all_data, dist_mats, bootstrap_num=100, dist_lim=100)
 
-        # fix seed
-        random.seed(0)
         vals_pos_batch, stats_pos_batch = \
             spatial_analysis.batch_cluster_spatial_enrichment(
                 label_dir, all_data, bootstrap_num=100, dist_lim=100, batch_size=5)
 
-        # fix seed
-        random.seed(0)
         vals_pos_batch_2, stats_pos_batch_2 = \
             spatial_analysis.batch_cluster_spatial_enrichment(
                 label_dir, all_data, bootstrap_num=100, dist_lim=100, batch_size=1)
 
-        np.testing.assert_equal(vals_pos, vals_pos_batch)
-        xr.testing.assert_equal(stats_pos, stats_pos_batch)
+        np.testing.assert_equal(vals_pos[0][0], vals_pos_batch[0][0])
+        np.testing.assert_equal(vals_pos[1][0], vals_pos_batch[1][0])
 
         # batch function should match for multi batch process
-        np.testing.assert_equal(vals_pos, vals_pos_batch_2)
-        xr.testing.assert_equal(stats_pos, stats_pos_batch_2)
+        np.testing.assert_equal(vals_pos[0][0], vals_pos_batch_2[0][0])
+        np.testing.assert_equal(vals_pos[1][0], vals_pos_batch_2[1][0])
 
-        # test fov inclusion w/ fixed seed
-        random.seed(0)
         vals_pos_fov8, stats_pos_fov8 = \
             spatial_analysis.batch_cluster_spatial_enrichment(
                 label_dir, all_data, bootstrap_num=100, dist_lim=100, batch_size=5,
                 included_fovs=["fov8"])
 
-        np.testing.assert_equal(vals_pos_fov8[0], vals_pos[0])
+        np.testing.assert_equal(vals_pos_fov8[0][0], vals_pos[0][0])
         assert len(vals_pos_fov8) == 1
-
-        xr.testing.assert_equal(stats_pos_fov8, stats_pos.loc[["fov8"], :, :])
 
 
 def test_calculate_channel_spatial_enrichment():
@@ -189,6 +169,7 @@ def test_calculate_channel_spatial_enrichment():
     # Test both fov8 and fov9
     # Extract the p-values and z-scores of the distance of marker 1 vs marker 2 for negative
     # enrichment as tested against a random set of distances between centroids
+
     assert stats_neg.loc["fov8", "p_neg", 2, 3] < .05
     assert stats_neg.loc["fov8", "p_pos", 2, 3] > .05
     assert stats_neg.loc["fov8", "z", 2, 3] < 0
@@ -275,7 +256,6 @@ def test_calculate_cluster_spatial_enrichment():
     # Negative enrichment
     all_data_neg, dist_mat_neg = test_utils._make_dist_exp_mats_spatial_test(
         enrichment_type="negative", dist_lim=dist_lim)
-
     _, stats_neg = \
         spatial_analysis.calculate_cluster_spatial_enrichment(
             all_data_neg, dist_mat_neg,

--- a/ark/utils/_bootstrapping.pyx
+++ b/ark/utils/_bootstrapping.pyx
@@ -56,7 +56,7 @@ cdef inline void _init_flag_table(UINT8_t* flags, const Py_ssize_t* perm,
 @wraparound(False)  # Deactivate negative indexing
 @cdivision(True)    # Ignore modulo/divide by zero warning
 cdef inline void _list_accum(DTYPE_t[:] close_num_rand_view,
-                             const DTYPE_t[:, :] dist_mat_bin, Py_ssize_t* rand_rows,
+                             const DTYPE_t[:, :] dist_mat_bin, MAXINDEX_t[:] pos_labels,
                              Py_ssize_t* rand_cols, Py_ssize_t num_choices, int m1n, int m2n,
                              int bootstrap_num):
     """ List based accumulation for small secondary marker size
@@ -73,8 +73,8 @@ cdef inline void _list_accum(DTYPE_t[:] close_num_rand_view,
             typed memory view of the close_num_rand_view datastructure
         dist_mat_bin (np.ndarray[np.uint16]):
             binarized distance matrix
-        rand_rows (Py_ssize_t*):
-            pointer to mutable row randomization memory block
+        pos_labels (np.ndarray[np.uint64]):
+            marker indidcies within dist_mat_bin    
         rand_cols (Py_ssize_t*):
             pointer to mutable column randomization memory block
         num_choices (Py_ssize_t):
@@ -90,14 +90,18 @@ cdef inline void _list_accum(DTYPE_t[:] close_num_rand_view,
     cdef DTYPE_t accum
     cdef Py_ssize_t m1_label, m2_label
 
+    #print(m1n, m2n)
+
     if not m1n or not m2n:
         return
 
+    #print(pos_labels, m1n, m2n)
     for r in range(bootstrap_num):
+        #print(r)
         accum = 0
-        _c_permutation(rand_rows, num_choices)
+        #_c_permutation(rand_rows, num_choices)
         _c_permutation(rand_cols, num_choices)
-        for m1_label in rand_rows[:m1n]:
+        for m1_label in pos_labels:
             for m2_label in rand_cols[:m2n]:
                 accum += dist_mat_bin[m1_label, m2_label]
         close_num_rand_view[r] = accum
@@ -107,7 +111,7 @@ cdef inline void _list_accum(DTYPE_t[:] close_num_rand_view,
 @cdivision(True)    # Ignore modulo/divide by zero warning
 cdef inline void _dict_accum(DTYPE_t[:] close_num_rand_view,
                              const DTYPE_t[:] cols_in_row_flat, const MAXINDEX_t[:] row_indicies,
-                             Py_ssize_t* rand_rows, Py_ssize_t* rand_cols,
+                             const MAXINDEX_t[:] pos_labels, Py_ssize_t* rand_cols,
                              UINT8_t* rand_cols_flags, Py_ssize_t num_choices, int m1n, int m2n,
                              int bootstrap_num):
     """ Dictionary based accumulation for large secondary marker size
@@ -127,8 +131,8 @@ cdef inline void _dict_accum(DTYPE_t[:] close_num_rand_view,
             flattened list-of-lists representation of binarized distance matrix
         row_indicies (np.ndarray[np.uint64]):
             'deflattening' index array for `cols_in_row_flat`
-        rand_rows (Py_ssize_t*):
-            pointer to mutable row randomization memory block
+        pos_labels (np.ndarray[np.uint64]):
+            marker indidcies within dist_mat_bin    
         rand_cols (Py_ssize_t*):
             pointer to mutable column randomization memory block
         rand_cols_flags (uint8_t*):
@@ -146,16 +150,18 @@ cdef inline void _dict_accum(DTYPE_t[:] close_num_rand_view,
     cdef MAXINDEX_t flat_start, flat_end, m2_idx
     cdef Py_ssize_t m1_label, m2_label
 
+    #print(m1n, m2n)
+
     if not m1n or not m2n:
         return
 
     for r in range(bootstrap_num):   
         accum = 0
-        _c_permutation(rand_rows, num_choices)
+        #_c_permutation(rand_rows, num_choices)
         _c_permutation(rand_cols, num_choices)
         memset(rand_cols_flags, 0, num_choices * sizeof(UINT8_t))
         _init_flag_table(rand_cols_flags, rand_cols, m2n)
-        for m1_label in rand_rows[:m1n]:
+        for m1_label in pos_labels: 
             flat_start = row_indicies[m1_label]
             flat_end = row_indicies[m1_label + 1]
             for m2_idx in range(flat_start, flat_end):
@@ -169,7 +175,7 @@ cdef inline void _dict_accum(DTYPE_t[:] close_num_rand_view,
 @cdivision(True)    # Ignore modulo/divide by zero warning
 cdef _compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_flat,
                              MAXINDEX_t[:] row_indicies, DTYPE_t[:] marker_nums,
-                             int bootstrap_num):
+                             dict pos_labels, int bootstrap_num):
     """ Cython implementation of the spatial enrichment bootstrapper
 
     Args:
@@ -183,6 +189,8 @@ cdef _compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_
             that row.
         marker_nums (np.ndarray[np.uint16]):
             number of hits for each marker
+        pos_labels (dict):
+            marker indicies within dist_mat_bin
         bootstrap_num (int):
             number of bootstrapping iterations to perform
 
@@ -200,10 +208,10 @@ cdef _compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_
     cdef DTYPE_t[:, :, :] close_num_rand_view = close_num_rand
     
     # allocate marker_label randomization containers
-    cdef Py_ssize_t* rand_rows = <Py_ssize_t*> PyMem_Malloc(num_choices * sizeof(Py_ssize_t))
+    #cdef Py_ssize_t* rand_rows = <Py_ssize_t*> PyMem_Malloc(num_choices * sizeof(Py_ssize_t))
     cdef Py_ssize_t* rand_cols = <Py_ssize_t*> PyMem_Malloc(num_choices * sizeof(Py_ssize_t))
     cdef UINT8_t* rand_cols_flags = <UINT8_t*> PyMem_Malloc(num_choices * sizeof(UINT8_t))
-    if not rand_rows or not rand_cols or not rand_cols_flags:
+    if not rand_cols or not rand_cols_flags:
         raise MemoryError()
 
     # allocate 'm2n < avg_rowsize' memory
@@ -215,32 +223,36 @@ cdef _compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_
     cdef int mn
     cdef DTYPE_t avg_rowsize
     for mn in range(num_choices):
-        rand_rows[mn] = mn
         rand_cols[mn] = mn
-        avg_rowsize = row_indicies[mn + 1] - row_indicies[mn]
+        avg_rowsize += row_indicies[mn + 1] - row_indicies[mn]
 
     avg_rowsize /= num_choices
     for mn in range(num_markers):
         m2n_small[mn] = (marker_nums[mn] < avg_rowsize)
 
-    cdef int j, k, m1n, m2n
+    cdef int j, k, row_ind, m1n, m2n, swap_buf
 
     # start main bootstrapping loop
+    # TODO: split randomization from row/column choice (recovers get m1n < m2n speed boost)
     for j in range(num_markers):
         m1n = marker_nums[j]
-        for k in range(j, num_markers):
+        for k in range(num_markers):
             m2n = marker_nums[k]
             if m2n_small[k]:
-                _list_accum(close_num_rand_view[j, k, :], dist_mat_bin, rand_rows, rand_cols,
-                            num_choices, m1n, m2n, bootstrap_num)
-            else:
-                _dict_accum(close_num_rand_view[j, k, :], cols_in_row_flat, row_indicies,
-                            rand_rows, rand_cols, rand_cols_flags, num_choices, m1n, m2n,
+                #print('_list_accum')
+                _list_accum(close_num_rand_view[j, k, :], dist_mat_bin,
+                            pos_labels[j], rand_cols, num_choices, m1n, m2n,
                             bootstrap_num)
-            close_num_rand_view[k, j, :] = close_num_rand_view[j, k, :]
+            else:
+                #print('_dict_accum')
+                _dict_accum(close_num_rand_view[j, k, :], cols_in_row_flat, row_indicies,
+                            pos_labels[j], rand_cols, rand_cols_flags, num_choices, m1n,
+                            m2n, bootstrap_num)
+            # goodbye symmetry :'(
+            # close_num_rand_view[k, j, :] = close_num_rand_view[j, k, :]
 
     # free used memeory
-    PyMem_Free(rand_rows)
+    #PyMem_Free(rand_rows)
     PyMem_Free(rand_cols)
     PyMem_Free(rand_cols_flags)
     PyMem_Free(m2n_small)
@@ -248,7 +260,8 @@ cdef _compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_
     return close_num_rand
 
 def compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_flat,
-                           MAXINDEX_t[:] row_indicies, DTYPE_t[:] marker_nums, int bootstrap_num):
+                           MAXINDEX_t[:] row_indicies, DTYPE_t[:] marker_nums,
+                           dict pos_labels, int bootstrap_num):
     """ Python wrapper function for the cython implementation of the spatial enrichment
         bootstrapper
 
@@ -264,6 +277,8 @@ def compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_fl
             that row.
         marker_nums (np.ndarray[np.uint16]):
             number of hits for each marker
+        pos_labels (dict):
+            marker indicies within dist_mat_bin
         bootstrap_num (int):
             number of bootstrapping iterations to perform
 
@@ -272,4 +287,4 @@ def compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_fl
             3d array containing the enrichment matrix for each bootstrap iteration
     """
     return _compute_close_num_rand(dist_mat_bin, cols_in_row_flat, row_indicies, marker_nums,
-                                   bootstrap_num)
+                                   pos_labels, bootstrap_num)

--- a/ark/utils/_bootstrapping.pyx
+++ b/ark/utils/_bootstrapping.pyx
@@ -74,7 +74,7 @@ cdef inline void _list_accum(DTYPE_t[:] close_num_rand_view,
         dist_mat_bin (np.ndarray[np.uint16]):
             binarized distance matrix
         pos_labels (np.ndarray[np.uint64]):
-            marker indidcies within dist_mat_bin    
+            marker indices within dist_mat_bin    
         rand_cols (Py_ssize_t*):
             pointer to mutable column randomization memory block
         num_choices (Py_ssize_t):
@@ -127,7 +127,7 @@ cdef inline void _dict_accum(DTYPE_t[:] close_num_rand_view,
         row_indicies (np.ndarray[np.uint64]):
             'deflattening' index array for `cols_in_row_flat`
         pos_labels (np.ndarray[np.uint64]):
-            marker indidcies within dist_mat_bin    
+            marker indices within dist_mat_bin    
         rand_cols (Py_ssize_t*):
             pointer to mutable column randomization memory block
         rand_cols_flags (uint8_t*):
@@ -182,7 +182,7 @@ cdef _compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_
         marker_nums (np.ndarray[np.uint16]):
             number of hits for each marker
         pos_labels (dict):
-            marker indicies within dist_mat_bin
+            marker indices within dist_mat_bin
         bootstrap_num (int):
             number of bootstrapping iterations to perform
 
@@ -264,7 +264,7 @@ def compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_fl
         marker_nums (np.ndarray[np.uint16]):
             number of hits for each marker
         pos_labels (dict):
-            marker indicies within dist_mat_bin
+            marker indices within dist_mat_bin
         bootstrap_num (int):
             number of bootstrapping iterations to perform
 

--- a/ark/utils/_bootstrapping.pyx
+++ b/ark/utils/_bootstrapping.pyx
@@ -90,16 +90,11 @@ cdef inline void _list_accum(DTYPE_t[:] close_num_rand_view,
     cdef DTYPE_t accum
     cdef Py_ssize_t m1_label, m2_label
 
-    #print(m1n, m2n)
-
     if not m1n or not m2n:
         return
 
-    #print(pos_labels, m1n, m2n)
     for r in range(bootstrap_num):
-        #print(r)
         accum = 0
-        #_c_permutation(rand_rows, num_choices)
         _c_permutation(rand_cols, num_choices)
         for m1_label in pos_labels:
             for m2_label in rand_cols[:m2n]:
@@ -150,14 +145,11 @@ cdef inline void _dict_accum(DTYPE_t[:] close_num_rand_view,
     cdef MAXINDEX_t flat_start, flat_end, m2_idx
     cdef Py_ssize_t m1_label, m2_label
 
-    #print(m1n, m2n)
-
     if not m1n or not m2n:
         return
 
     for r in range(bootstrap_num):   
         accum = 0
-        #_c_permutation(rand_rows, num_choices)
         _c_permutation(rand_cols, num_choices)
         memset(rand_cols_flags, 0, num_choices * sizeof(UINT8_t))
         _init_flag_table(rand_cols_flags, rand_cols, m2n)
@@ -208,7 +200,6 @@ cdef _compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_
     cdef DTYPE_t[:, :, :] close_num_rand_view = close_num_rand
     
     # allocate marker_label randomization containers
-    #cdef Py_ssize_t* rand_rows = <Py_ssize_t*> PyMem_Malloc(num_choices * sizeof(Py_ssize_t))
     cdef Py_ssize_t* rand_cols = <Py_ssize_t*> PyMem_Malloc(num_choices * sizeof(Py_ssize_t))
     cdef UINT8_t* rand_cols_flags = <UINT8_t*> PyMem_Malloc(num_choices * sizeof(UINT8_t))
     if not rand_cols or not rand_cols_flags:
@@ -239,20 +230,15 @@ cdef _compute_close_num_rand(DTYPE_t[:, :] dist_mat_bin, DTYPE_t[:] cols_in_row_
         for k in range(num_markers):
             m2n = marker_nums[k]
             if m2n_small[k]:
-                #print('_list_accum')
                 _list_accum(close_num_rand_view[j, k, :], dist_mat_bin,
                             pos_labels[j], rand_cols, num_choices, m1n, m2n,
                             bootstrap_num)
             else:
-                #print('_dict_accum')
                 _dict_accum(close_num_rand_view[j, k, :], cols_in_row_flat, row_indicies,
                             pos_labels[j], rand_cols, rand_cols_flags, num_choices, m1n,
                             m2n, bootstrap_num)
-            # goodbye symmetry :'(
-            # close_num_rand_view[k, j, :] = close_num_rand_view[j, k, :]
 
     # free used memeory
-    #PyMem_Free(rand_rows)
     PyMem_Free(rand_cols)
     PyMem_Free(rand_cols_flags)
     PyMem_Free(m2n_small)

--- a/ark/utils/spatial_analysis_utils.py
+++ b/ark/utils/spatial_analysis_utils.py
@@ -121,7 +121,8 @@ def get_pos_cell_labels_cluster(pheno, current_fov_neighborhood_data,
 def compute_close_cell_num(dist_mat, dist_lim, analysis_type,
                            current_fov_data=None, current_fov_channel_data=None,
                            cluster_ids=None, cell_types_analyze=None, thresh_vec=None,
-                           cell_label_col=settings.CELL_LABEL, cell_type_col=settings.CLUSTER_ID):
+                           cell_label_col=settings.CELL_LABEL, cell_type_col=settings.CLUSTER_ID,
+                           count_self=False):
     """Finds positive cell labels and creates matrix with counts for cells positive for
     corresponding markers. Computes close_num matrix for both Cell Label and Threshold spatial
     analyses.
@@ -186,10 +187,9 @@ def compute_close_cell_num(dist_mat, dist_lim, analysis_type,
     mark1poslabels = []
 
     dist_mat_bin = xr.DataArray(
-        (dist_mat.values < dist_lim).astype(np.uint8),
+        (dist_mat.values < dist_lim & dist_mat.values > 0).astype(np.uint8),
         coords=dist_mat.coords
     )
-
     for j in range(num):
         if analysis_type == "cluster":
             mark1poslabels.append(
@@ -253,11 +253,8 @@ def compute_close_cell_num_random(marker_nums, mark_pos_labels, dist_mat, dist_l
     """
 
     # Generate binarized distance matrix
-    dist_mat_bin = (dist_mat.values < dist_lim).astype(np.uint16)
+    dist_mat_bin = (dist_mat.values < dist_lim & dist_mat.values > 0).astype(np.uint16)
     
-    # remove self counts
-    np.fill_diagonal(dist_mat_bin, 0)
-
     # assures that marker counts don't exceed number of cells
     for mn in marker_nums:
         if mn >= dist_mat_bin.shape[0]:

--- a/ark/utils/spatial_analysis_utils.py
+++ b/ark/utils/spatial_analysis_utils.py
@@ -282,7 +282,14 @@ def compute_close_cell_num_random(marker_nums, mark_pos_labels, dist_mat, dist_l
 
     # sort marker_nums and save permutation
     # this can speed up compute_close_num_rand
-    marker_order = [(mn, np.array(mark_pos_labels[i], dtype=np.uint64), i) for i, mn in enumerate(marker_nums)]
+    marker_order = [
+        (
+            mn,
+            np.flatnonzero(dist_mat[dist_mat.dims[0]].isin(mark_pos_labels[i])),
+            i
+        )
+        for i, mn in enumerate(marker_nums)
+    ]
     marker_order.sort(key=lambda x: x[0])
     sorted_marker_nums, sorted_pos_labels, sort_permutation = zip(*marker_order)
     _marker_nums = np.array(sorted_marker_nums, dtype=np.uint16)

--- a/ark/utils/spatial_analysis_utils.py
+++ b/ark/utils/spatial_analysis_utils.py
@@ -204,13 +204,6 @@ def compute_close_cell_num(dist_mat, dist_lim, analysis_type,
                                             current_marker=current_fov_channel_data.columns[j]))
         mark1_num.append(len(mark1poslabels[j]))
 
-    # we'll need this because for cluster-based context-dependent randomization
-    # we need to facet our randomization of labels based on the cell_types and associated
-    # cell_ids the user specifies
-    mark1labels_per_id = None
-    if analysis_type == "cluster":
-        mark1labels_per_id = dict(zip(cluster_ids, mark1poslabels))
-
     # iterating k from [j, end] cuts out 1/2 the steps (while symmetric)
     for j, m1n in enumerate(mark1_num):
         for k, m2n in enumerate(mark1_num[j:], j):
@@ -224,7 +217,7 @@ def compute_close_cell_num(dist_mat, dist_lim, analysis_type,
             # symmetry :)
             close_num[k, j] = close_num[j, k]
 
-    return close_num, mark1_num, mark1poslabels 
+    return close_num, mark1_num, mark1poslabels
 
 
 # TODO: passing marker_nums and mark_pos_labels is redundant:
@@ -253,7 +246,7 @@ def compute_close_cell_num_random(marker_nums, mark_pos_labels, dist_mat, dist_l
 
     # Generate binarized distance matrix
     dist_mat_bin = ((dist_mat.values < dist_lim) & (dist_mat.values > 0)).astype(np.uint16)
-    
+
     # assures that marker counts don't exceed number of cells
     for mn in marker_nums:
         if mn >= dist_mat_bin.shape[0]:

--- a/ark/utils/spatial_analysis_utils.py
+++ b/ark/utils/spatial_analysis_utils.py
@@ -121,8 +121,7 @@ def get_pos_cell_labels_cluster(pheno, current_fov_neighborhood_data,
 def compute_close_cell_num(dist_mat, dist_lim, analysis_type,
                            current_fov_data=None, current_fov_channel_data=None,
                            cluster_ids=None, cell_types_analyze=None, thresh_vec=None,
-                           cell_label_col=settings.CELL_LABEL, cell_type_col=settings.CLUSTER_ID,
-                           count_self=False):
+                           cell_label_col=settings.CELL_LABEL, cell_type_col=settings.CLUSTER_ID):
     """Finds positive cell labels and creates matrix with counts for cells positive for
     corresponding markers. Computes close_num matrix for both Cell Label and Threshold spatial
     analyses.
@@ -187,7 +186,7 @@ def compute_close_cell_num(dist_mat, dist_lim, analysis_type,
     mark1poslabels = []
 
     dist_mat_bin = xr.DataArray(
-        (dist_mat.values < dist_lim & dist_mat.values > 0).astype(np.uint8),
+        ((dist_mat.values < dist_lim) & (dist_mat.values > 0)).astype(np.uint8),
         coords=dist_mat.coords
     )
     for j in range(num):
@@ -253,7 +252,7 @@ def compute_close_cell_num_random(marker_nums, mark_pos_labels, dist_mat, dist_l
     """
 
     # Generate binarized distance matrix
-    dist_mat_bin = (dist_mat.values < dist_lim & dist_mat.values > 0).astype(np.uint16)
+    dist_mat_bin = ((dist_mat.values < dist_lim) & (dist_mat.values > 0)).astype(np.uint16)
     
     # assures that marker counts don't exceed number of cells
     for mn in marker_nums:

--- a/ark/utils/spatial_analysis_utils.py
+++ b/ark/utils/spatial_analysis_utils.py
@@ -285,7 +285,7 @@ def compute_close_cell_num_random(marker_nums, mark_pos_labels, dist_mat, dist_l
     marker_order = [
         (
             mn,
-            np.flatnonzero(dist_mat[dist_mat.dims[0]].isin(mark_pos_labels[i])),
+            np.flatnonzero(dist_mat[dist_mat.dims[0]].isin(mark_pos_labels[i])).astype(np.uint64),
             i
         )
         for i, mn in enumerate(marker_nums)

--- a/ark/utils/spatial_analysis_utils_test.py
+++ b/ark/utils/spatial_analysis_utils_test.py
@@ -4,7 +4,6 @@ import tempfile
 import numpy as np
 import pandas as pd
 import xarray as xr
-import random
 from ark.utils import spatial_analysis_utils
 
 import ark.settings as settings

--- a/ark/utils/spatial_analysis_utils_test.py
+++ b/ark/utils/spatial_analysis_utils_test.py
@@ -165,6 +165,9 @@ def test_compute_close_cell_num_random():
 
     assert example_closenumrand.shape == (len(marker_nums), len(marker_nums), 100)
 
+    # test asymmetry
+    assert (example_closenumrand[0, 1, :] != example_closenumrand[1, 0, :]).any()
+
     # bad marker nums
     marker_nums[0] = example_distmat.shape[0] + 1
 

--- a/ark/utils/spatial_analysis_utils_test.py
+++ b/ark/utils/spatial_analysis_utils_test.py
@@ -165,6 +165,14 @@ def test_compute_close_cell_num_random():
 
     assert example_closenumrand.shape == (len(marker_nums), len(marker_nums), 100)
 
+    # bad marker nums
+    marker_nums[0] = example_distmat.shape[0] + 1
+
+    with pytest.raises(ValueError):
+        example_closenumrand = spatial_analysis_utils.compute_close_cell_num_random(
+            marker_nums, marker_pos_labels, example_distmat, dist_lim=100, bootstrap_num=100
+        )
+
 
 def test_calculate_enrichment_stats():
     # Positive enrichment

--- a/ark/utils/spatial_analysis_utils_test.py
+++ b/ark/utils/spatial_analysis_utils_test.py
@@ -115,9 +115,9 @@ def test_compute_close_cell_num():
         current_fov_data=all_data, current_fov_channel_data=fov_channel_data,
         thresh_vec=thresh_vec)
 
-    assert (example_closenum[:2, :2] == 16).all()
-    assert (example_closenum[3:5, 3:5] == 25).all()
-    assert (example_closenum[5:7, 5:7] == 1).all()
+    assert (example_closenum[:2, :2] == 12).all()
+    assert (example_closenum[3:5, 3:5] == 20).all()
+    assert (example_closenum[5:7, 5:7] == 0).all()
 
     # Now test indexing with cell labels by removing a cell label from the expression matrix but
     # not the distance matrix
@@ -132,9 +132,9 @@ def test_compute_close_cell_num():
         current_fov_data=all_data, current_fov_channel_data=fov_channel_data,
         thresh_vec=thresh_vec)
 
-    assert (example_closenum[:2, :2] == 9).all()
-    assert (example_closenum[3:5, 3:5] == 25).all()
-    assert (example_closenum[5:7, 5:7] == 1).all()
+    assert (example_closenum[:2, :2] == 6).all()
+    assert (example_closenum[3:5, 3:5] == 20).all()
+    assert (example_closenum[5:7, 5:7] == 0).all()
 
     # now, test for cluster enrichment
     all_data, example_dist_mat = test_utils._make_dist_exp_mats_spatial_utils_test()
@@ -144,22 +144,27 @@ def test_compute_close_cell_num():
         dist_mat=example_dist_mat, dist_lim=100, analysis_type="cluster",
         current_fov_data=all_data, cluster_ids=cluster_ids)
 
-    assert example_closenum[0, 0] == 16
-    assert example_closenum[1, 1] == 25
-    assert example_closenum[2, 2] == 1
+    assert example_closenum[0, 0] == 12
+    assert example_closenum[1, 1] == 20
+    assert example_closenum[2, 2] == 0
 
 
 def test_compute_close_cell_num_random():
     data_markers, example_distmat = test_utils._make_dist_exp_mats_spatial_utils_test()
 
+    marker_pos_labels = [
+        data_markers[data_markers[settings.CELL_TYPE] == lineage][settings.CELL_LABEL]
+        for lineage in data_markers[settings.CELL_TYPE].unique()
+    ]
+
     # Generate random inputs to test shape
-    marker_nums = [random.randrange(0, 10) for i in range(20)]
+    marker_nums = [len(marker_labels) for marker_labels in marker_pos_labels]
 
     example_closenumrand = spatial_analysis_utils.compute_close_cell_num_random(
-        marker_nums, example_distmat, dist_lim=100, bootstrap_num=100
+        marker_nums, marker_pos_labels, example_distmat, dist_lim=100, bootstrap_num=100
     )
 
-    assert example_closenumrand.shape == (20, 20, 100)
+    assert example_closenumrand.shape == (len(marker_nums), len(marker_nums), 100)
 
 
 def test_calculate_enrichment_stats():


### PR DESCRIPTION
## **Purpose**

Corrects bootstrapping randomization to asymmetric pairing scheme.  Closes #485.

## **Implementation**

Currently building off of the speed up PR.  Most changes are to the arguments of the relevant functions.  Still runs at about the same speed, although there's still a small speed up which could be gained by assuring that the marker/cell_type undergoing dictionary storage is the larger of the two.  This was guaranteed in the symmetric version, but now requires (at a minimum) a `rand_rows_or_cols` flag to reap the full benefits of said speed-up.

## **Remaining issues**

Still need to correct the test functions' arguments