### PR TITLE
remove hardcoded variable_sizes arg

### DIFF
--- a/ark/utils/load_utils.py
+++ b/ark/utils/load_utils.py
@@ -167,7 +167,8 @@ def load_imgs_from_tree(data_dir, img_sub_folder=None, fovs=None, channels=None,
             dtype = data_dtype
 
     if max_image_size is not None:
-        img_data = np.zeros((len(fovs), max_image_size, max_image_size, len(channels)), dtype=dtype)
+        img_data = np.zeros((len(fovs), max_image_size, max_image_size, len(channels)),
+                            dtype=dtype)
     else:
         img_data = np.zeros((len(fovs), test_img.shape[0], test_img.shape[1], len(channels)),
                             dtype=dtype)

--- a/ark/utils/load_utils_test.py
+++ b/ark/utils/load_utils_test.py
@@ -168,9 +168,9 @@ def test_load_imgs_from_tree():
 
         loaded_xr = \
             load_utils.load_imgs_from_tree(temp_dir, img_sub_folder="TIFs", dtype="int16",
-                                           variable_sizes=True)
+                                           max_image_size=12)
 
-        assert loaded_xr.shape == (3, 1024, 1024, 3)
+        assert loaded_xr.shape == (3, 12, 12, 3)
 
 
 def test_load_imgs_from_dir():


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Updates load_imgs_from_tree to support variable image sizes of arbitrary size, as specified by the user

**How did you implement your changes**

Changes the variable_sizes boolean arg to a max_img_size integer arg specifying the length of the largest image that will be loaded. This is in contrast to hardcoding in 1024 as the largest image size, which is what the function currently does

**Remaining issues**
