### PR TITLE
Add more extensive OS and Python version testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+  - windows
 
 include:
   jobs:
@@ -8,47 +9,71 @@ include:
       name: "Ubuntu 16.04"
       os: linux
       dist: xenial  # Ubuntu 16.04
+      language: python
     -
       name: "Ubuntu 18.04"
       os: linux
       dist: bionic  # Ubuntu 18.04
+      language: python
     -
       name: "Ubuntu 20.04"
       os: linux
-      dist: focal  # Ubuntu 20.04  
+      dist: focal  # Ubuntu 20.04 
+      language: python 
     -
       name: "Monterey"
       os: osx
       osx_image: xcode13.2  # Monterey
+      language: shell
     -
       name: "Big Sur"
       os: osx
       osx_image: xcode13.1  # Big Sur
+      language: shell
     -
       name: "Catalina"
       os: osx
       osx_image: xcode12.2  # Catalina, last version still supported
+      language: shell
+    -
+      name: "Windows"
+      os: windows  # only Windows Server, version 1803
+      language: shell
+      before_install:
+        - choco install python3 3.6.8
+        - python -m pip install --upgrade pip
+        - pip3 install -U pytest
 
 git:
   depth: false
-
-language: python
 
 python:
   - 3.6
   - 3.7
   - 3.8
-  - 3.9
-  - 3.10
+  - 3.9  # latest version supported for now
 
 before_install:
-  - pip install -U pip
-  - pip install -U pytest
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then pip3 install -U pip
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then pip3 install -U pytest
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install -U pip
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install -U pytest
 
-# We add python path to enable testing jupyter notebooks
+# before_install:
+#   - pip install -U pip
+#   - pip install -U pytest
+
+# # We add python path to enable testing jupyter notebooks
+# install:
+#   - travis_retry pip install -r requirements.txt
+#   - travis_retry pip install -r requirements-test.txt
+#   - travis_retry export PYTHONPATH=$PWD
+
 install:
-  - travis_retry pip install -r requirements.txt
-  - travis_retry pip install -r requirements-test.txt
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then travis_retry pip3 install -r requirements.txt
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then travis_retry pip3 install -r requirements-test.txt
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry pip install -r requirements.txt
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry pip install -r requirements-test.txt
   - travis_retry export PYTHONPATH=$PWD
 
 env:
@@ -58,7 +83,8 @@ cache: pip
 
 # command to run tests
 script:
-  - python -m pytest --cov=ark --pycodestyle ark
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then python3 -m pytest --cov=ark --pycodestyle ark
+  - if [ "$TRAVIS_OS_NAME" != "osx" ]; then python -m pytest --cov=ark --pycodestyle ark
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,10 +61,10 @@ python:
   - 3.9  # latest version supported for now
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then pip3 install -U pip
-  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then pip3 install -U pytest
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install -U pip
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install -U pytest
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then pip3 install -U pip; fi
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then pip3 install -U pytest; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install -U pip; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install -U pytest; fi
 
 # before_install:
 #   - pip install -U pip
@@ -77,10 +77,10 @@ before_install:
 #   - travis_retry export PYTHONPATH=$PWD
 
 install:
-  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then travis_retry pip3 install -r requirements.txt
-  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then travis_retry pip3 install -r requirements-test.txt
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry pip install -r requirements.txt
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry pip install -r requirements-test.txt
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then travis_retry pip3 install -r requirements.txt; fi
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then travis_retry pip3 install -r requirements-test.txt; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry pip install -r requirements.txt; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_retry pip install -r requirements-test.txt; fi
   - travis_retry export PYTHONPATH=$PWD
 
 env:
@@ -90,8 +90,8 @@ cache: pip
 
 # command to run tests
 script:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then python3 -m pytest --cov=ark --pycodestyle ark
-  - if [ "$TRAVIS_OS_NAME" != "osx" ]; then python -m pytest --cov=ark --pycodestyle ark
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then python3 -m pytest --cov=ark --pycodestyle ark; fi
+  - if [ "$TRAVIS_OS_NAME" != "osx" ]; then python -m pytest --cov=ark --pycodestyle ark; fi
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,23 @@
-dist: xenial
+include:
+  jobs:
+    -
+      os: linux
+      dist: xenial  # Ubuntu 16.04
+    -
+      os: linux
+      dist: bionic  # Ubuntu 18.04
+    -
+      os: linux
+      dist: focal  # Ubuntu 20.04  
+    -
+      os: osx
+      osx_image: xcode13.2  # Monterey
+    -
+      os: osx
+      osx_image: xcode13.1  # Big Sur
+    -
+      os: osx
+      osx_image: xcode12.2  # Catalina, last version still supported
 
 git:
   depth: false
@@ -7,14 +26,20 @@ language: python
 
 python:
   - 3.6
+  - 3.7
+  - 3.8
+  - 3.9
+  - 3.10
+
+before_install:
+  - pip install -U pip
+  - pip install -U pytest
 
 # We add python path to enable testing jupyter notebooks
 install:
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r requirements-test.txt
   - travis_retry export PYTHONPATH=$PWD
-  # this is needed to install the requirements
-  # - travis_retry python setup.py install
 
 env:
   - MPLBACKEND=Agg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,31 @@
+os:
+  - linux
+  - osx
+
 include:
   jobs:
     -
+      name: "Ubuntu 16.04"
       os: linux
       dist: xenial  # Ubuntu 16.04
     -
+      name: "Ubuntu 18.04"
       os: linux
       dist: bionic  # Ubuntu 18.04
     -
+      name: "Ubuntu 20.04"
       os: linux
       dist: focal  # Ubuntu 20.04  
     -
+      name: "Monterey"
       os: osx
       osx_image: xcode13.2  # Monterey
     -
+      name: "Big Sur"
       os: osx
       osx_image: xcode13.1  # Big Sur
     -
+      name: "Catalina"
       os: osx
       osx_image: xcode12.2  # Catalina, last version still supported
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
   - osx
   - windows
 
-include:
-  jobs:
+jobs:
+  include:
     -
       name: "Ubuntu 16.04"
       os: linux
@@ -43,6 +43,13 @@ include:
         - choco install python3 3.6.8
         - python -m pip install --upgrade pip
         - pip3 install -U pytest
+    - stage: deploy
+      deploy:
+        provider: pypi
+        user: $PYPI_USERNAME
+        password: $PYPI_PASSWORD
+        on:
+          tags: true
 
 git:
   depth: false
@@ -85,16 +92,6 @@ cache: pip
 script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then python3 -m pytest --cov=ark --pycodestyle ark
   - if [ "$TRAVIS_OS_NAME" != "osx" ]; then python -m pytest --cov=ark --pycodestyle ark
-
-jobs:
-  include:
-    - stage: deploy
-      deploy:
-        provider: pypi
-        user: $PYPI_USERNAME
-        password: $PYPI_PASSWORD
-        on:
-          tags: true
 
 after_success:
   - coveralls


### PR DESCRIPTION
**What is the purpose of this PR?**

Partially addresses #498. Sometimes, people will post an issue that we can't duplicate because our personal machines don't run the same operating systems. This is especially the case for Mac, which as of today includes 3 versions (Catalina, Big Sur, and Monterey) that are supported. It is important that we ensure we have a way to test our codebase on different operating systems.

Additionally, it will be useful to test our codebase on different Python versions too. This can help isolate issues when supporting multiple Python versions or when upgrading to a different Python version.

**How did you implement your changes**

We update the `.travis.yml` file to include builds for multiple jobs and multiple Python versions. We can discuss which ones we want to include.

**Remaining issues**

- Unsure if Travis can replicate the M1-chip computing environment
- Travis doesn't support Python on Windows build environments, so these will still need to be reported directly by the user