### PR TITLE
Deploy a Docker image using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,15 @@ script:
 
 jobs:
   include:
-    - stage: deploy
+    - stage: pypi_deploy
       deploy:
         provider: pypi
         user: $PYPI_USERNAME
         password: $PYPI_PASSWORD
         on:
-          tags: true
-    - stage: docker_push
-      if: tag IS present
+          tags: true  # with PyPI, deploy only on a tagged commit to master
+    - stage: docker_deploy
+      if: branch = master  # with Docker, deploy every time on a commit to master
       python: 3.6
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
 jobs:
   include:
     - stage: pypi_deploy
+      python: 3.6
       deploy:
         provider: pypi
         user: $PYPI_USERNAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
         on:
           tags: true  # with PyPI, deploy only on a tagged commit to master
     - stage: docker_deploy
-      if: branch = master  # with Docker, deploy every time on a commit to master
+      if: branch = master  # TODO: change to deploy only on tagged commits once this works
       python: 3.6
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
         on:
           tags: true
     - stage: docker_push
-      if tag IS present
+      if: tag IS present
       python: 3.6
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
         on:
           tags: true
     - stage: docker_deploy
-      if: branch = master
+      if: tag IS present
       python: 3.6
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ install:
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r requirements-test.txt
   - travis_retry export PYTHONPATH=$PWD
-  # this is needed to install the requirements
-  # - travis_retry python setup.py install
 
 env:
   - MPLBACKEND=Agg
@@ -34,6 +32,15 @@ jobs:
         password: $PYPI_PASSWORD
         on:
           tags: true
+    - stage: docker_push
+      if tag IS present
+      python: 3.6
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "DOCKER_USERNAME" --password-stdin
+        - docker build -t "$TRAVIS_REPO_SLUG" .
+        - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
+        - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
+        - docker push "$TRAVIS_REPO_SLUG"
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         - echo "$DOCKER_PASSWORD" | docker login -u "DOCKER_USERNAME" --password-stdin
         - docker build -t "$TRAVIS_REPO_SLUG" .
         - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
-        - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
+        # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"  # TODO: fails on a non-tagged commit, either hard code or deploy both PyPI and Docker at the same time
         - docker push "$TRAVIS_REPO_SLUG"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,15 @@ jobs:
         user: $PYPI_USERNAME
         password: $PYPI_PASSWORD
         on:
-          tags: true  # with PyPI, deploy only on a tagged commit to master
+          tags: true
     - stage: docker_deploy
-      if: branch = master  # TODO: change to deploy only on tagged commits once this works
+      if: branch = master
       python: 3.6
       script:
-        - echo "$DOCKER_PASSWORD" | docker login -u "DOCKER_USERNAME" --password-stdin
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - docker build -t "$TRAVIS_REPO_SLUG" .
         - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
-        # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"  # TODO: fails on a non-tagged commit, either hard code or deploy both PyPI and Docker at the same time
+        - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
         - docker push "$TRAVIS_REPO_SLUG"
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Then input the command:
 git clone https://github.com/angelolab/ark-analysis.git
 ```
 
-Next, you'll need to set up a docker image with all of the required dependencies.
- - First, [download](https://hub.docker.com/?overlay=onboarding) docker desktop. 
- - Once it's sucessfully installed, make sure it is running by looking in toolbar for the Docker whale.
+Next, you'll need to set up the Docker image with all of the required dependencies:
+ - First, [download](https://hub.docker.com/?overlay=onboarding) Docker Desktop. 
+ - Once it's sucessfully installed, make sure it is running by looking in toolbar for the Docker whale. 
  - Once it's running, enter the following commands into terminal 
 
 ```
 cd ark-analysis
-docker build -t ark-analysis '.'
+docker pull angelolab/ark-analysis:latest
 ``` 
 
 You've now installed the code base. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build Status](https://travis-ci.com/angelolab/ark-analysis.svg?branch=master)](https://travis-ci.com/angelolab/ark-analysis)
 [![Coverage Status](https://coveralls.io/repos/github/angelolab/ark-analysis/badge.svg?branch=master)](https://coveralls.io/github/angelolab/ark-analysis?branch=master)
-[![Docker](https://img.shields.io/docker/cloud/build/eaudeweb/scratch?label=Docker&style=flat)](https://hub.docker.com/r/angelolab/ark-analysis/tags)
 
 # ark-analysis
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.com/angelolab/ark-analysis.svg?branch=master)](https://travis-ci.com/angelolab/ark-analysis)
 [![Coverage Status](https://coveralls.io/repos/github/angelolab/ark-analysis/badge.svg?branch=master)](https://coveralls.io/github/angelolab/ark-analysis?branch=master)
+[![Docker](https://img.shields.io/docker/cloud/build/eaudeweb/scratch?label=Docker&style=flat)](https://hub.docker.com/r/angelolab/ark-analysis/tags)
 
 # ark-analysis
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os import path
 from distutils.command.build_ext import build_ext as DistUtilsBuildExt
 from setuptools import setup, find_packages
 
-VERSION = '0.2.9'
+VERSION = '0.2.10'
 
 
 # set a long description which is basically the README

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -63,7 +63,7 @@ if [ ! -z "$external" ]
       -v "$PWD/data:/data" \
       -v "$external:/data/external" \
       -v "$PWD/.toks:/home/.toks" \
-      ark-analysis:latest
+      angelolab/ark-analysis
   else
     docker run -it \
       -p $PORT:$PORT \
@@ -73,5 +73,5 @@ if [ ! -z "$external" ]
       -v "$PWD/$JUPYTER_DIR:/$JUPYTER_DIR" \
       -v "$PWD/data:/data" \
       -v "$PWD/.toks:/home/.toks" \
-      ark-analysis:latest
+      angelolab/ark-analysis
 fi


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses one part of #502. Instead of having the user build the Docker locally every time, we want to push a new Docker image on a tagged commit. In this way, the user can simply download the latest Docker image.

We piggyback off https://github.com/vanvalenlab/deepcell-tf/blob/ad2b019fa912a7d417964429e4c4142abd0d3175/.travis.yml#L72.

**How did you implement your changes**

Add a new entry to the `jobs` section of `.travis.yml` called `docker_deploy` which handles pushing to Docker Hub.

**Remaining issues**

We won't be able to find potential bugs until we push an actual tagged commit. Additionally, some of the following issues may need to be resolved with a 2nd PR:

- We'll need to add our Docker username and password as `$DOCKER_USERNAME` and `$DOCKER_PASSWORD`
- Add a Docker Hub badge to `README.md`
- Change documentation instructing user to download from Docker Hub and not build locally
- Currently, we push to Docker on a commit to `master` every time but to PyPI on just tagged commits to `master`. This workflow may need to be adjusted because of the way Docker tagging works.