### PR TITLE
Adjustments to the Windows Docker Setup

### DIFF
--- a/docs/_rtd/windows_setup.md
+++ b/docs/_rtd/windows_setup.md
@@ -42,7 +42,6 @@ In your Command Prompt, follow similar steps to clone the `ark-analysis` repo an
 * Run `git clone https://github.com/angelolab/ark-analysis.git` to clone the `ark-analysis` repo
 * Run `cd ark-analysis` to enter the cloned repo
 * Pull the latest Docker image by running `docker pull angelolab/ark-analysis:latest`
-* Build the Docker by running `docker build -t ark-analysis .`. Note that the `.` following `ark-analysis` should not be quoted.
 
 To run the script, you have to use `bash start_docker.sh`. If you run into issues with invalid carriage returns (`\r`), please run the following before trying again:
 

--- a/docs/_rtd/windows_setup.md
+++ b/docs/_rtd/windows_setup.md
@@ -18,7 +18,8 @@ Now run the following steps:
 * Set the version to WSL 2: `wsl --set-default-version 2`
 * Type just `wsl` on the command line. You'll likely get an error indicating no installed distributions, meaning you'll need to associate one with your WSL backend. We recommend installing Ubuntu 20.04 LTS in the Microsoft Store.
 * Once Ubuntu is installed, open it (it will open the Ubuntu terminal) and set a username and password to finalize installation.
-* Run `sudo apt-get update` in the Ubuntu terminal (alternatively, you can run `wsl sudo apt-get update` in the Windows Command Prompt)
+* Run `sudo apt-get update` in the Ubuntu terminal to view all the necessary updates. (alternatively, you can run `wsl sudo apt-get update` in the Windows Command Prompt)
+* Run `sudo apt-get upgrade` to download and install the necessary updates. (alternatively, you can run `wsl sudo apt-get upgrade`).
 
 Note that if using a VM or the Hyper-V backend, nested virtualization needs to be turned on. This process varies depending on which virtualization platform you use: you'll have to consult their documentation for the how-tos. 
 
@@ -40,6 +41,7 @@ In your Command Prompt, follow similar steps to clone the `ark-analysis` repo an
 
 * Run `git clone https://github.com/angelolab/ark-analysis.git` to clone the `ark-analysis` repo
 * Run `cd ark-analysis` to enter the cloned repo
+* Pull the latest Docker image by running `docker pull angelolab/ark-analysis:latest`
 * Build the Docker by running `docker build -t ark-analysis .`. Note that the `.` following `ark-analysis` should not be quoted.
 
 To run the script, you have to use `bash start_docker.sh`. If you run into issues with invalid carriage returns (`\r`), please run the following before trying again:


### PR DESCRIPTION
- Added a couple of steps to the setup
- Removed the docker build step, added the docker pull and upgrade step.

**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**


The purpose of this PR is to add a couple of steps that I took to get the Docker Image of ark-analysis working on Windows 11 utilizing WSL2. These steps were not in the original [Windows setup](https://github.com/angelolab/ark-analysis/blob/d932484d6c73f2cc08f24fb2c5597f4666a2de17/docs/_rtd/windows_setup.md).

**How did you implement your changes**

I removed the `docker build -t ark-analysis` step that @alex-l-kong [stated](https://github.com/angelolab/ark-analysis/pull/492#issuecomment-1043639157). 

I added the `sudo apt-get upgrade` step after `sudo apt-get update`.

**Remaining issues**

None that I currently know of.
