### PR TITLE
Added exact_match to list_folders

### DIFF
--- a/ark/utils/io_utils.py
+++ b/ark/utils/io_utils.py
@@ -77,8 +77,8 @@ def list_files(dir_name, substrs=None, exact_match=False):
         matches = [file
                    for file in files
                    if any([
-                        substr == os.path.splitext(file)[0]
-                        for substr in substrs
+                       substr == os.path.splitext(file)[0]
+                       for substr in substrs
                    ])]
     else:
         matches = [file
@@ -186,7 +186,7 @@ def list_folders(dir_name, substrs=None, exact_match=False):
             Substring matching criteria, defaults to None (all folders)
         exact_match (bool):
             If True, will match exact folder names (so 'C' will match only 'C/').
-            If False, will match substr pattern in folder (so 'C' will match 'C/' and 'C_DIREC/').
+            If False, will match substr pattern in folder (so 'C' will match 'C/' & 'C_DIREC/').
 
     Returns:
         list:
@@ -207,14 +207,13 @@ def list_folders(dir_name, substrs=None, exact_match=False):
     if type(substrs) is not list:
         substrs = [substrs]
 
-    
     # Exact match case
     if exact_match:
         matches = [folder
                    for folder in folders
                    if any([
-                        substr == os.path.splitext(folder)[0]
-                        for substr in substrs
+                       substr == os.path.splitext(folder)[0]
+                       for substr in substrs
                    ])]
     else:
         matches = [folder

--- a/ark/utils/io_utils.py
+++ b/ark/utils/io_utils.py
@@ -176,7 +176,7 @@ def extract_delimited_names(names, delimiter='_', delimiter_optional=True):
     return names
 
 
-def list_folders(dir_name, substrs=None):
+def list_folders(dir_name, substrs=None, exact_match=False):
     """ List all folders in a directory containing at least one given substring
 
     Args:
@@ -184,6 +184,9 @@ def list_folders(dir_name, substrs=None):
             Parent directory for folders of interest
         substrs (str or list):
             Substring matching criteria, defaults to None (all folders)
+        exact_match (bool):
+            If True, will match exact folder names (so 'C' will match only 'C/').
+            If False, will match substr pattern in folder (so 'C' will match 'C/' and 'C_DIREC/').
 
     Returns:
         list:
@@ -204,12 +207,22 @@ def list_folders(dir_name, substrs=None):
     if type(substrs) is not list:
         substrs = [substrs]
 
-    matches = [folder
-               for folder in folders
-               if any([
-                   substr in folder
-                   for substr in substrs
-               ])]
+    
+    # Exact match case
+    if exact_match:
+        matches = [folder
+                   for folder in folders
+                   if any([
+                        substr == os.path.splitext(folder)[0]
+                        for substr in substrs
+                   ])]
+    else:
+        matches = [folder
+                   for folder in folders
+                   if any([
+                       substr in folder
+                       for substr in substrs
+                   ])]
 
     return matches
 

--- a/ark/utils/io_utils_test.py
+++ b/ark/utils/io_utils_test.py
@@ -169,6 +169,7 @@ def test_extract_delimited_names():
 
 
 def test_list_folders():
+    # Tests "Fuzzy Substring Matching",`exact_match` = False
     with tempfile.TemporaryDirectory() as temp_dir:
         # set up temp_dir subdirs
         dirnames = [
@@ -184,13 +185,62 @@ def test_list_folders():
         pathlib.Path(os.path.join(temp_dir, 'test_badfile.txt')).touch()
 
         # test substrs is None (default)
-        get_all = iou.list_folders(temp_dir)
-        assert get_all.sort() == dirnames.sort()
+        get_all = iou.list_folders(temp_dir, exact_match=False)
+        assert sorted(get_all) == sorted(dirnames)
 
         # test substrs is not list (single string)
-        get_txt = iou.list_folders(temp_dir, substrs='_txt')
-        assert get_txt.sort() == dirnames[0:2].sort()
+        get_txt = iou.list_folders(temp_dir, substrs='_txt', exact_match=False)
+        assert sorted(get_txt) == sorted(dirnames[0:2])
 
         # test substrs is list
-        get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'])
-        assert get_test_and_other.sort() == dirnames[1:].sort()
+        get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'], exact_match=False)
+        assert sorted(get_test_and_other) == sorted(dirnames[1:])
+        
+        
+    # Tests "Exact Substring Matching", `exact_match` = True
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # set up temp_dir subdirs
+        dirnames = [
+            'tf_txt',
+            'othertf_txt',
+            'test_csv',
+            'test_out',
+        ]
+        
+        dirnames.sort()
+        for dirname in dirnames:
+            os.mkdir(os.path.join(temp_dir, dirname))
+            
+        # add extra file
+        pathlib.Path(os.path.join(temp_dir, 'test_badfile.txt')).touch()
+        
+        # test substrs is None (default)
+        get_all = iou.list_folders(temp_dir, exact_match=True)
+        print(get_all.sort())
+        assert sorted(get_all) == dirnames
+
+        # test substrs is not list (single string)
+        get_txt = iou.list_folders(temp_dir, substrs='_txt', exact_match=True)
+        assert len(get_txt) == 0
+
+        # test substrs is list
+        get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'], exact_match=True)
+        assert len(get_test_and_other) == 0
+        
+        # test substrs is list (exact)
+        get_exact_n_substrs = iou.list_folders(temp_dir, substrs = ['tf_txt', 'othertf_txt'])
+        assert sorted(get_exact_n_substrs) == ['othertf_txt', 'tf_txt']
+        
+        # Test exact substr is not list (single string)
+        get_othertf_txt = iou.list_folders(temp_dir, substrs='othertf_txt', exact_match=True)
+        assert get_othertf_txt[0] == dirnames[0]
+        
+        # Test exact substr DNE (single string)
+        get_test_c = iou.list_folders(temp_dir, substrs='test_c', exact_match=True)
+        assert len(get_test_c) == 0
+        
+        # Test exact substr is not list (single string)
+        get_test_o = iou.list_folders(temp_dir, substrs='test_out', exact_match=True)
+        assert get_test_o[0] == dirnames[2]
+        
+        

--- a/ark/utils/io_utils_test.py
+++ b/ark/utils/io_utils_test.py
@@ -216,17 +216,7 @@ def test_list_folders():
 
         # test substrs is None (default)
         get_all = iou.list_folders(temp_dir, exact_match=True)
-        print(get_all.sort())
         assert sorted(get_all) == dirnames
-
-        # test substrs is not list (single string)
-        get_txt = iou.list_folders(temp_dir, substrs='_txt', exact_match=True)
-        assert len(get_txt) == 0
-
-        # test substrs is list
-        get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'],
-                                              exact_match=True)
-        assert len(get_test_and_other) == 0
 
         # test substrs is list (exact)
         get_exact_n_substrs = iou.list_folders(temp_dir, substrs=['tf_txt', 'othertf_txt'])
@@ -235,10 +225,6 @@ def test_list_folders():
         # Test exact substr is not list (single string)
         get_othertf_txt = iou.list_folders(temp_dir, substrs='othertf_txt', exact_match=True)
         assert get_othertf_txt[0] == dirnames[0]
-
-        # Test exact substr DNE (single string)
-        get_test_c = iou.list_folders(temp_dir, substrs='test_c', exact_match=True)
-        assert len(get_test_c) == 0
 
         # Test exact substr is not list (single string)
         get_test_o = iou.list_folders(temp_dir, substrs='test_out', exact_match=True)

--- a/ark/utils/io_utils_test.py
+++ b/ark/utils/io_utils_test.py
@@ -168,35 +168,9 @@ def test_list_folders():
             'othertf_txt',
             'test_csv',
             'test_out',
-        ]
-        for dirname in dirnames:
-            os.mkdir(os.path.join(temp_dir, dirname))
-
-        # add extra file
-        pathlib.Path(os.path.join(temp_dir, 'test_badfile.txt')).touch()
-
-        # test substrs is None (default)
-        get_all = iou.list_folders(temp_dir, exact_match=False)
-        assert sorted(get_all) == sorted(dirnames)
-
-        # test substrs is not list (single string)
-        get_txt = iou.list_folders(temp_dir, substrs='_txt', exact_match=False)
-        assert sorted(get_txt) == sorted(dirnames[0:2])
-
-        # test substrs is list
-        get_test_and_other = iou.list_folders(
-            temp_dir, substrs=['test_', 'other'], exact_match=False
-        )
-        assert sorted(get_test_and_other) == sorted(dirnames[1:])
-
-    # Tests "Exact Substring Matching", `exact_match` = True
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # set up temp_dir subdirs
-        dirnames = [
-            'tf_txt',
-            'othertf_txt',
-            'test_csv',
-            'test_out',
+            'test_csv1',
+            'test_csv2',
+            'Ntest_csv',
         ]
 
         dirnames.sort()
@@ -207,17 +181,39 @@ def test_list_folders():
         pathlib.Path(os.path.join(temp_dir, 'test_badfile.txt')).touch()
 
         # test substrs is None (default)
-        get_all = iou.list_folders(temp_dir, exact_match=True)
+        get_all = iou.list_folders(temp_dir, exact_match=False)
         assert sorted(get_all) == dirnames
 
-        # test substrs is list (exact)
-        get_exact_n_substrs = iou.list_folders(temp_dir, substrs=['tf_txt', 'othertf_txt'])
-        assert sorted(get_exact_n_substrs) == ['othertf_txt', 'tf_txt']
+        # test substrs is not list (single string)
+        get_txt = iou.list_folders(temp_dir, substrs='_txt', exact_match=False)
+        assert sorted(get_txt) == sorted(['othertf_txt', 'tf_txt'])
+
+        # test substrs is list
+        get_test_and_other = iou.list_folders(
+            temp_dir, substrs=['test_', 'other'], exact_match=False
+        )
+        assert sorted(get_test_and_other) == sorted(
+            ['Ntest_csv', 'test_csv', 'test_csv1', 'test_csv2', 'test_out', 'othertf_txt']
+        )
+
+        # Tests "Exact Substring Matching", `exact_match` = True
+
+        # Test substrs is None (default)
+        get_all = iou.list_folders(temp_dir, exact_match=True)
+        assert sorted(get_all) == sorted(dirnames)
 
         # Test exact substr is not list (single string)
         get_othertf_txt = iou.list_folders(temp_dir, substrs='othertf_txt', exact_match=True)
-        assert get_othertf_txt[0] == dirnames[0]
+        assert get_othertf_txt == [dirnames[1]]
 
-        # Test exact substr is not list (single string)
-        get_test_o = iou.list_folders(temp_dir, substrs='test_out', exact_match=True)
-        assert get_test_o[0] == dirnames[2]
+        # Test substrs, querying two folders (exactly)
+        get_exact_n_substrs = iou.list_folders(
+            temp_dir, substrs=['tf_txt', 'othertf_txt'], exact_match=True
+        )
+        assert sorted(get_exact_n_substrs) == ['othertf_txt', 'tf_txt']
+
+        # Test the substr that the user specifies which is contained within multiple folders,
+        # and only the folder that exactly matches the substring, not the one that contains it,
+        # is returned when `exact_match=True`
+        get_test_o = iou.list_folders(temp_dir, substrs='test_csv', exact_match=True)
+        assert get_test_o == ["test_csv"]

--- a/ark/utils/io_utils_test.py
+++ b/ark/utils/io_utils_test.py
@@ -103,11 +103,7 @@ def test_list_files():
 
     # test file name exact matching
     with tempfile.TemporaryDirectory() as temp_dir:
-        filenames = [
-            'chan0.tif',
-            'chan.tif',
-            'c.tif'
-        ]
+        filenames = ['chan0.tif', 'chan.tif', 'c.tif']
         for filename in filenames:
             pathlib.Path(os.path.join(temp_dir, filename)).touch()
 
@@ -129,12 +125,7 @@ def test_list_files():
 
 def test_remove_file_extensions():
     # test a mixture of file paths and extensions
-    files = [
-        'fov1.tiff',
-        'fov2.tif',
-        'fov3.png',
-        'fov4.jpg'
-    ]
+    files = ['fov1.tiff', 'fov2.tif', 'fov3.png', 'fov4.jpg']
 
     assert iou.remove_file_extensions(None) is None
     assert iou.remove_file_extensions([]) == []
@@ -193,8 +184,9 @@ def test_list_folders():
         assert sorted(get_txt) == sorted(dirnames[0:2])
 
         # test substrs is list
-        get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'],
-                                              exact_match=False)
+        get_test_and_other = iou.list_folders(
+            temp_dir, substrs=['test_', 'other'], exact_match=False
+        )
         assert sorted(get_test_and_other) == sorted(dirnames[1:])
 
     # Tests "Exact Substring Matching", `exact_match` = True

--- a/ark/utils/io_utils_test.py
+++ b/ark/utils/io_utils_test.py
@@ -196,8 +196,7 @@ def test_list_folders():
         get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'],
                                               exact_match=False)
         assert sorted(get_test_and_other) == sorted(dirnames[1:])
-        
-        
+
     # Tests "Exact Substring Matching", `exact_match` = True
     with tempfile.TemporaryDirectory() as temp_dir:
         # set up temp_dir subdirs
@@ -207,14 +206,14 @@ def test_list_folders():
             'test_csv',
             'test_out',
         ]
-        
+
         dirnames.sort()
         for dirname in dirnames:
             os.mkdir(os.path.join(temp_dir, dirname))
-            
+
         # add extra file
         pathlib.Path(os.path.join(temp_dir, 'test_badfile.txt')).touch()
-        
+
         # test substrs is None (default)
         get_all = iou.list_folders(temp_dir, exact_match=True)
         print(get_all.sort())
@@ -228,21 +227,19 @@ def test_list_folders():
         get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'],
                                               exact_match=True)
         assert len(get_test_and_other) == 0
-        
+
         # test substrs is list (exact)
-        get_exact_n_substrs = iou.list_folders(temp_dir, substrs = ['tf_txt', 'othertf_txt'])
+        get_exact_n_substrs = iou.list_folders(temp_dir, substrs=['tf_txt', 'othertf_txt'])
         assert sorted(get_exact_n_substrs) == ['othertf_txt', 'tf_txt']
-        
+
         # Test exact substr is not list (single string)
         get_othertf_txt = iou.list_folders(temp_dir, substrs='othertf_txt', exact_match=True)
         assert get_othertf_txt[0] == dirnames[0]
-        
+
         # Test exact substr DNE (single string)
         get_test_c = iou.list_folders(temp_dir, substrs='test_c', exact_match=True)
         assert len(get_test_c) == 0
-        
+
         # Test exact substr is not list (single string)
         get_test_o = iou.list_folders(temp_dir, substrs='test_out', exact_match=True)
         assert get_test_o[0] == dirnames[2]
-        
-        

--- a/ark/utils/io_utils_test.py
+++ b/ark/utils/io_utils_test.py
@@ -193,7 +193,8 @@ def test_list_folders():
         assert sorted(get_txt) == sorted(dirnames[0:2])
 
         # test substrs is list
-        get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'], exact_match=False)
+        get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'],
+                                              exact_match=False)
         assert sorted(get_test_and_other) == sorted(dirnames[1:])
         
         
@@ -224,7 +225,8 @@ def test_list_folders():
         assert len(get_txt) == 0
 
         # test substrs is list
-        get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'], exact_match=True)
+        get_test_and_other = iou.list_folders(temp_dir, substrs=['test_', 'other'],
+                                              exact_match=True)
         assert len(get_test_and_other) == 0
         
         # test substrs is list (exact)


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

This PR closes #360. It adds an `exact_match` function parameter to the `list_folders` function. In addition it adds specific tests for
the case where `exact_match` is set to True.

**How did you implement your changes**

1. The same case from `list_files` was used.
2. Instances of using `.sort()` within `assert` statements were replaced with `sorted()`, as `.sort()` returns `None`. 


**Remaining issues**

There could be more instances of using asserts with `.sort()`
instead of `sorted()`.

For example:

```python

a = [6,5,4,3]

assert a.sort() == [3,4,5,6]
```

Would not pass as `a.sort()` returns `None`.

However:

```python

a = [6,5,4,3]

assert sorted(a) == [3,4,5,6]
```

Would pass as `sorted()` returns the sorted iterable.