### PR TITLE
Patch channel file path creation for pixel cluster overlay

### DIFF
--- a/templates_ark/example_pixel_clustering.ipynb
+++ b/templates_ark/example_pixel_clustering.ipynb
@@ -601,7 +601,7 @@
     "    )\n",
     "else:\n",
     "    chan_file = os.path.join(\n",
-    "        fovs[0], img_sub_folder, io_utils.list_files(os.path.join(tiff_dir, img_sub_folder, fovs[0]), substrs=['.tif', '.tiff'])[0]\n",
+    "        fovs[0], img_sub_folder, io_utils.list_files(os.path.join(tiff_dir, fovs[0], img_sub_folder), substrs=['.tif', '.tiff'])[0]\n",
     "    )\n",
     "\n",
     "# generate the pixel cluster masks for each fov in pixel_fovs\n",


### PR DESCRIPTION
**What is the purpose of this PR?**

The order of the file path creation for channel files contained in FOV folder subdirectories got swapped due to merging issues. The line:

```
chan_file = os.path.join(
    fovs[0], img_sub_folder, io_utils.list_files(os.path.join(tiff_dir, img_sub_folder, fovs[0]), substrs=['.tif', '.tiff'])[0]
)
```

should be

```
chan_file = os.path.join(
    fovs[0], img_sub_folder, io_utils.list_files(os.path.join(tiff_dir, fovs[0], img_sub_folder, substrs=['.tif', '.tiff'])[0]
)
```

**How did you implement your changes**

See above
