### PR TITLE
Fixing Docker Startup Directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN R -e "BiocManager::install('FlowSOM')"
 RUN R -e "BiocManager::install('ConsensusClusterPlus')"
 
 # jupyter lab
-CMD jupyter lab --ip=0.0.0.0 --allow-root --no-browser --port=$JUPYTER_PORT --notebook-dir=/$JUPYTER_DIR/scripts
+CMD jupyter lab --ip=0.0.0.0 --allow-root --no-browser --port=$JUPYTER_PORT --notebook-dir=/$JUPYTER_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN R -e "BiocManager::install('FlowSOM')"
 RUN R -e "BiocManager::install('ConsensusClusterPlus')"
 
 # jupyter lab
-CMD jupyter lab --ip=0.0.0.0 --allow-root --no-browser --port=$JUPYTER_PORT --notebook-dir=/$JUPYTER_DIR
+CMD jupyter lab --ip=0.0.0.0 --allow-root --no-browser --port=$JUPYTER_PORT --notebook-dir=/$JUPYTER_DIR/scripts

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -57,6 +57,7 @@ if [ ! -z "$external" ]
     docker run -it \
       -p $PORT:$PORT \
       -e JUPYTER_PORT=$PORT\
+      -e JUPYTER_DIR=$JUPYTER_DIR\
       -v "$PWD/ark:/usr/local/lib/python3.6/site-packages/ark" \
       -v "$PWD/scripts:/scripts" \
       -v "$PWD/data:/data" \
@@ -73,6 +74,7 @@ if [ ! -z "$external" ]
     docker run -it \
       -p $PORT:$PORT \
       -e JUPYTER_PORT=$PORT\
+      -e JUPYTER_DIR=$JUPYTER_DIR\
       -v "$PWD/ark:/usr/local/lib/python3.6/site-packages/ark" \
       -v "$PWD/scripts:/scripts" \
       -v "$PWD/data:/data" \

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -56,8 +56,8 @@ if [ ! -z "$external" ]
   then
     docker run -it \
       -p $PORT:$PORT \
-      -e JUPYTER_PORT=$PORT\
-      -e JUPYTER_DIR=$JUPYTER_DIR\
+      -e JUPYTER_PORT=$PORT \
+      -e JUPYTER_DIR=$JUPYTER_DIR \
       -v "$PWD/ark:/usr/local/lib/python3.6/site-packages/ark" \
       -v "$PWD/scripts:/scripts" \
       -v "$PWD/data:/data" \
@@ -73,8 +73,8 @@ if [ ! -z "$external" ]
   else
     docker run -it \
       -p $PORT:$PORT \
-      -e JUPYTER_PORT=$PORT\
-      -e JUPYTER_DIR=$JUPYTER_DIR\
+      -e JUPYTER_PORT=$PORT \
+      -e JUPYTER_DIR=$JUPYTER_DIR \
       -v "$PWD/ark:/usr/local/lib/python3.6/site-packages/ark" \
       -v "$PWD/scripts:/scripts" \
       -v "$PWD/data:/data" \


### PR DESCRIPTION
- added scripts in --notebook-dir argument in Dockerfile
- fixed jupyterlab starup directory
- start_docker.sh formatting

**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #526. When Jupyter Lab is opened, it will open the `scripts` directory now instead of the base directory.

**How did you implement your changes**

Had to reintroduce the parameter `-e JUPYTER_DIR=$JUPYTER_DIR` in the `start_docker.sh` file.

**Remaining issues**

None atm.