### PR TITLE
Docker Image build instructions, removed rebuild logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Copy the URL listed after `Enter this URL instead to access the notebooks:`
 You will need to authenticate. Note the last URL (the one with `127.0.0.1:8888` at the beginning), copy the token that appears there (it will be after `token=` in the URL), paste it into the password prompt of the Jupyter notebook, and log in.
 
 ## Using the example notebooks:
-- The Segment_Image_Data notebook walks you through the appropriate steps to format your data, run the data through deepcell, extracts the counts for each marker in each cell, and creats a csv file with the normalized counts
+- The Segment_Image_Data notebook walks you through the appropriate steps to format your data, run the data through deepcell, extracts the counts for each marker in each cell, and creates a csv file with the normalized counts
 - The spatial_analysis notebook contains code for performing cluster- and channel-based randomization, as well as neighborhood analysis. 
 - The example_visualization notebooks contains code for basic plotting functions and visualizations
 

--- a/docs/_rtd/development.md
+++ b/docs/_rtd/development.md
@@ -94,3 +94,34 @@ Finally, to save an `xarray` to a file, use:
 You can load the `xarray` back in using:
 
 `arr = xr.load_dataarray(path)`
+
+
+### Building Docker Images Locally
+
+Open terminal and navigate to where you want the code stored.
+
+Then input the command:
+
+```
+git clone https://github.com/angelolab/ark-analysis.git
+```
+
+Next, you'll need to set up the Docker image with all of the required dependencies:
+ - First, [download](https://hub.docker.com/?overlay=onboarding) Docker Desktop. 
+ - Once it's sucessfully installed, make sure it is running by looking in toolbar for the Docker whale. 
+ - Once it's running, change directory into `ark-analysis`.
+
+```
+cd ark-analysis
+```
+
+Once you are in `ark-analysis`, the docker image can be built with the following command.
+```
+docker build -t ark-analysis
+``` 
+
+The docker image will now build. Note, the `R` scripts take a significant amount of time to compile. The docker image can then be started with:
+
+```
+./start_docker.sh
+```

--- a/docs/_rtd/development.md
+++ b/docs/_rtd/development.md
@@ -50,6 +50,21 @@ To enable, pass the either `-d` or  `--develop-notebook-templates` to `start_doc
 
 Now notebooks can be `git diff`ed and `git commit`ed without having to copy changed notedbooks between `./scripts` and `./templates`.
 
+### Building Docker Images Locally
+
+It may be useful to be able to manually build a new Docker Image as features get added, changes made and libraries updated. This
+will allow you to test and experience bleeding edge changes, as they can't necessarily be adjusted in the `requirements.txt` file.
+Specifically, updating Python libraries requires building a new docker image from scratch. 
+
+
+Once you are in `ark-analysis`, the Docker Image can be built with the following command.
+```
+docker build -t ark-analysis .
+``` 
+
+The docker image will now build and this process can take some time.
+
+
 ### More on xarrays
 
 One type of N-D array we use frequently is `xarray` ([documentation](http://xarray.pydata.org/en/stable/)). The main advantages `xarray` offers are:
@@ -95,33 +110,3 @@ You can load the `xarray` back in using:
 
 `arr = xr.load_dataarray(path)`
 
-
-### Building Docker Images Locally
-
-Open terminal and navigate to where you want the code stored.
-
-Then input the command:
-
-```
-git clone https://github.com/angelolab/ark-analysis.git
-```
-
-Next, you'll need to set up the Docker image with all of the required dependencies:
- - First, [download](https://hub.docker.com/?overlay=onboarding) Docker Desktop. 
- - Once it's sucessfully installed, make sure it is running by looking in toolbar for the Docker whale. 
- - Once it's running, change directory into `ark-analysis`.
-
-```
-cd ark-analysis
-```
-
-Once you are in `ark-analysis`, the docker image can be built with the following command.
-```
-docker build -t ark-analysis
-``` 
-
-The docker image will now build. Note, the `R` scripts take a significant amount of time to compile. The docker image can then be started with:
-
-```
-./start_docker.sh
-```

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -30,20 +30,6 @@ do
   esac
 done
 
-# if requirements.txt has been changed in the last half hour, automatically rebuild Docker first
-if [[ $(find . -mmin -30 -type f -print | grep requirements.txt | wc -l) -eq 1 ]]
-  then
-    echo "New requirements.txt file detected, rebuilding Docker"
-    docker build -t ark-analysis .
-fi
-
-if [ $update -ne 0 ]
-  then
-    bash update_notebooks.sh -u
-  else
-    bash update_notebooks.sh
-fi
-
 # find lowest open port available
 PORT=8888
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**


Closes #516.

Placed instructions for building the Docker Image locally in `docs/_rtd/development.md`. Removed the logic which rebuilds the image if changes are detected in `start_docker.sh`.

**How did you implement your changes**

Added instructions based off Installation instructions in the `README.md`. Deleted the logic directly.

**Remaining issues**

None atm.