### PR TITLE
raise error if wrong channel is specified: load_imgs_from_tree

### DIFF
--- a/ark/utils/load_utils.py
+++ b/ark/utils/load_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 
 from ark.utils.tiff_utils import read_mibitiff
-from ark.utils import io_utils as iou
+from ark.utils import io_utils as iou, misc_utils
 from ark.utils.google_drive_utils import path_join
 
 
@@ -97,8 +97,8 @@ def load_imgs_from_tree(data_dir, img_sub_folder=None, fovs=None, channels=None,
             directory containing folders of images
         img_sub_folder (str):
             optional name of image sub-folder within each fov
-        fovs (list):
-            optional list of folders to load imgs from. Default loads all folders
+        fovs (str, list):
+            optional list of folders to load imgs from, or the name of a single folder. Default loads all folders
         channels (list):
             optional list of imgs to load, otherwise loads all imgs
         dtype (str/type):
@@ -122,6 +122,10 @@ def load_imgs_from_tree(data_dir, img_sub_folder=None, fovs=None, channels=None,
     if len(fovs) == 0:
         raise ValueError(f"No fovs found in directory, {data_dir}")
 
+    # If the fov provided is a single string (`fov_1` instead of [`fov_1`])
+    if isinstance(fovs, str):
+        fovs = [fovs]    
+    
     if img_sub_folder is None:
         # no img_sub_folder, change to empty string to read directly from base folder
         img_sub_folder = ""
@@ -147,7 +151,10 @@ def load_imgs_from_tree(data_dir, img_sub_folder=None, fovs=None, channels=None,
 
         # get the corresponding indices found in channels_no_delim
         channels_indices = [channels_no_delim.index(chan.split('.')[0]) for chan in all_channels]
-
+        
+        # verify if all channels in `channels` are present in `all_channels`
+        misc_utils.verify_same_elements(channels, all_channels)
+        
         # reorder back to original
         channels = [chan for _, chan in sorted(zip(channels_indices, all_channels))]
 

--- a/ark/utils/load_utils_test.py
+++ b/ark/utils/load_utils_test.py
@@ -136,6 +136,19 @@ def test_load_imgs_from_tree():
                                                      for i in range(3)])
 
         assert loaded_xr.equals(data_xr)
+        
+        # check when fov is a single string
+        loaded_xr = \
+            load_utils.load_imgs_from_tree(temp_dir, img_sub_folder="TIFS", dtype="int16",
+                                           fovs='fov0', channels=some_chans)
+        
+        assert loaded_xr.equals(data_xr[:1, :, :, :1])
+        
+        # check that an error raises when a channel provided does not exist
+        with pytest.raises(ValueError):
+            loaded_xr = \
+                load_utils.load_imgs_from_tree(temp_dir, img_sub_folder="TIFS", dtype="int16",
+                                               channels=['chan4'])
 
     # test loading with data_xr containing float values
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #517. Channels that are provided are silently skipped if they do not exist. If an `fov` name is provided instead of a list, the `fov` name is iterated on.

**How did you implement your changes**

Added a check to see if `fovs` is a string, if so make it a list of `fovs`.
In order to counter the silently skipping issue, used `misc_utils.verify_same_elements` on the input channels, and the channels found with respect to the input channels.

**Remaining issues**

None atm.
