### PR TITLE
Put call to `update_notebooks.sh` back into `start_docker.sh`

### DIFF
--- a/start_docker.sh
+++ b/start_docker.sh
@@ -33,6 +33,13 @@ done
 # find lowest open port available
 PORT=8888
 
+if [ $update -ne 0 ]
+  then
+    bash update_notebooks.sh -u
+  else
+    bash update_notebooks.sh
+fi
+
 until [[ $(docker container ls | grep 0.0.0.0:$PORT | wc -l) -eq 0 ]]
   do
     ((PORT=$PORT+1))


### PR DESCRIPTION
**What is the purpose of this PR?**

When `start_docker.sh` was modified to handle multiple flag cases, the control statement to run `update_notebooks.sh` was removed. This needs to be added back in.

**How did you implement your changes**

See above.
