### PR TITLE
Revert index back to 1 when getting shape of `pixel_cluster_mask`

### DIFF
--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -229,7 +229,7 @@ def generate_pixel_cluster_mask(fovs, base_dir, tiff_dir, chan_file,
         y_coords = fov_data['column_index'].values
 
         # convert to 1D indexing
-        coordinates = x_coords * img_data.shape[0] + y_coords
+        coordinates = x_coords * img_data.shape[1] + y_coords
 
         # get the cooresponding cluster labels for each pixel
         cluster_labels = list(fov_data[pixel_cluster_col])


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #556. There was an issue merging the indexing PR into `master` which reverted:

```
coordinates = x_coords * img_data.shape[1] + y_coords
```

to

```
coordinates = x_coords * img_data.shape[0] + y_coords
```

We should revert this back.

**How did you implement your changes**

See above.
