### PR TITLE
Clear unused intermediate DataFrame memory in channel averaging function

### DIFF
--- a/ark/phenotyping/create_pixel_som.R
+++ b/ark/phenotyping/create_pixel_som.R
@@ -78,3 +78,7 @@ somResults <- SOM(data=as.matrix(pixelSubsetData), rlen=numPasses,
 # write the weights to feather
 print("Save trained weights")
 arrow::write_feather(as.data.table(somResults$codes), pixelWeightsPath)
+
+# free memory
+rm(pixelSubsetData)
+rm(somResults)

--- a/ark/phenotyping/pixel_consensus_cluster.R
+++ b/ark/phenotyping/pixel_consensus_cluster.R
@@ -85,6 +85,9 @@ for (i in 1:length(fovs)) {
         print("# fovs clustered:")
         print(i)
     }
+
+    # free memory
+    rm(fovPixelData)
 }
 
 # save the mapping from pixel_som_cluster to pixel_meta_cluster
@@ -95,3 +98,7 @@ som_to_meta_map <- as.data.table(som_to_meta_map)
 som_to_meta_map$pixel_som_cluster <- as.integer(rownames(som_to_meta_map))
 som_to_meta_map <- setnames(som_to_meta_map, "som_to_meta_map", "pixel_meta_cluster")
 arrow::write_feather(som_to_meta_map, clustToMeta)
+
+# free memory
+rm(consensusClusterResults)
+rm(som_to_meta_map)

--- a/ark/phenotyping/run_pixel_som.R
+++ b/ark/phenotyping/run_pixel_som.R
@@ -74,6 +74,11 @@ for (i in 1:length(fovs)) {
         print("# fovs clustered:")
         print(i)
     }
+
+    # free memory
+    rm(fovPixelData_all)
+    rm(fovPixelData)
+    rm(clusters)
 }
 
 print("Done!")

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -710,7 +710,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
         del pixel_mat
         del pixel_mat_subset
 
-        if seg_labels:
+        if seg_labels is not None:
             del seg_labels
 
     # get mean 99.9% across all fovs for all markers

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -110,7 +110,7 @@ def compute_pixel_cluster_channel_avg(fovs, channels, base_dir, pixel_cluster_co
         # concat the results together
         cluster_avgs = pd.concat([cluster_avgs, agg_results])
 
-        # free memory because these can get very large
+        # free memory
         del fov_pixel_data
         del sum_by_cluster
         del count_by_cluster
@@ -495,6 +495,16 @@ def create_c2pc_data(fovs, pixel_consensus_path,
         num_cluster_per_seg_label = num_cluster_per_seg_label.set_index(cell_table_indices)
         cell_table = cell_table.combine_first(num_cluster_per_seg_label)
 
+        # free memory
+        del fov_pixel_data
+        del group_by_cluster_col
+        del num_cluster_per_seg_label
+        del new_columns
+        del cell_table_labels
+        del cluster_labels
+        del label_intersection
+        del cell_table_indices
+
     # NaN means the cluster wasn't found in the specified fov-cell pair
     cell_table = cell_table.fillna(0)
 
@@ -693,6 +703,15 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
                                              subset_dir,
                                              fov + ".feather"),
                                 compression='uncompressed')
+
+        # free memory
+        del img_xr
+        del img_data
+        del pixel_mat
+        del pixel_mat_subset
+
+        if seg_labels:
+            del seg_labels
 
     # get mean 99.9% across all fovs for all markers
     mean_quant = pd.DataFrame(quant_dat.mean(axis=1))
@@ -1133,6 +1152,9 @@ def apply_pixel_meta_cluster_remapping(fovs, channels, base_dir,
 
         # resave the data with the new meta cluster lables
         feather.write_dataframe(fov_data, fov_path, compression='uncompressed')
+
+        # free memory
+        del fov_data
 
     # re-compute average channel expression for each pixel meta cluster
     # and the number of pixels per meta cluster, add renamed meta cluster column in

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -110,6 +110,12 @@ def compute_pixel_cluster_channel_avg(fovs, channels, base_dir, pixel_cluster_co
         # concat the results together
         cluster_avgs = pd.concat([cluster_avgs, agg_results])
 
+        # free memory because these can get very large
+        del fov_pixel_data
+        del sum_by_cluster
+        del count_by_cluster
+        del agg_results
+
     # reset the index of cluster_avgs for consistency
     cluster_avgs = cluster_avgs.reset_index(drop=True)
 


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #548. Pixel channel averaging needs to be an iterative process due to the way they are batched per FOV. These individual pixel cluster files can be extremely large, and Python does not automatically release them from memory even if the variable is overwritten on the next iteration. This means that for massive datasets, Docker could easily run out of memory. This PR should prevent this from happening.

**How did you implement your changes**

`compute_pixel_cluster_channel_avg` will need to explicitly flush out these large, unused DataFrames with `del`. We do this for the intermediate `fov_pixel_data`, `sum_by_cluster`, `count_by_cluster`, and `agg_results` variables. This is especially important for the middle 2, because `groupby` objects can be very computationally expensive.

**Remaining issues**

This may not be the only memory adjustment we need to make, but it's a start.