### PR TITLE
Delete references to Docker locally rebuilding in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,13 @@ First, get the latest version of the code
 git pull
 ```
 
-Then, run the command below to update the jupyter notebooks to the latest version
+Check for Docker updates by running:
+
+```
+docker pull angelolab/ark-analysis:latest
+```
+
+Then, run the command below to update the Jupyter notebooks to the latest version
 ```
 ./start_docker.sh --update
 ```

--- a/README.md
+++ b/README.md
@@ -103,8 +103,6 @@ or
 ./start_docker.sh -u
 ```
 
-If the requirements.txt has changed, Docker will rebuild with the new dependencies first.
-
 ### WARNING
 
 If you didn't change the name of any of the notebooks within the `scripts` folder, they will be overwritten by the command above! 

--- a/ark/phenotyping/pixel_consensus_cluster.R
+++ b/ark/phenotyping/pixel_consensus_cluster.R
@@ -85,6 +85,9 @@ for (i in 1:length(fovs)) {
         print("# fovs clustered:")
         print(i)
     }
+
+    # free memory
+    rm(fovPixelData)
 }
 
 # save the mapping from pixel_som_cluster to pixel_meta_cluster
@@ -95,3 +98,7 @@ som_to_meta_map <- as.data.table(som_to_meta_map)
 som_to_meta_map$pixel_som_cluster <- as.integer(rownames(som_to_meta_map))
 som_to_meta_map <- setnames(som_to_meta_map, "som_to_meta_map", "pixel_meta_cluster")
 arrow::write_feather(som_to_meta_map, clustToMeta)
+
+# free memory
+rm(consensusClusterResults)
+rm(som_to_meta_map)

--- a/ark/phenotyping/pixel_consensus_cluster.R
+++ b/ark/phenotyping/pixel_consensus_cluster.R
@@ -85,9 +85,6 @@ for (i in 1:length(fovs)) {
         print("# fovs clustered:")
         print(i)
     }
-
-    # free memory
-    rm(fovPixelData)
 }
 
 # save the mapping from pixel_som_cluster to pixel_meta_cluster
@@ -98,7 +95,3 @@ som_to_meta_map <- as.data.table(som_to_meta_map)
 som_to_meta_map$pixel_som_cluster <- as.integer(rownames(som_to_meta_map))
 som_to_meta_map <- setnames(som_to_meta_map, "som_to_meta_map", "pixel_meta_cluster")
 arrow::write_feather(som_to_meta_map, clustToMeta)
-
-# free memory
-rm(consensusClusterResults)
-rm(som_to_meta_map)


### PR DESCRIPTION
**What is the purpose of this PR?**

There shouldn't be any more references to Docker needing to rebuild locally now that we have Dockerhub integration.

**How did you implement your changes**

This necessitates the removal of the line indicating that Docker would rebuild with the `-u` or `--update` flag pass to `start_docker.sh`.