### PR TITLE
Address metacluster GUI height and width issues

### DIFF
--- a/ark/utils/metacluster_remap_gui/metaclustergui.py
+++ b/ark/utils/metacluster_remap_gui/metaclustergui.py
@@ -94,16 +94,16 @@ class MetaClusterGui():
         width_ratios = [
             int(self.mcd.cluster_count / 7),
             self.mcd.cluster_count,
-            self.mcd.metacluster_count,
+            self.mcd.metacluster_count * 2,
             ]
-        height_ratios = [6, self.mcd.marker_count, 1, 1]
+        height_ratios = [12, self.mcd.marker_count * 2, 3, 3]
 
         subplots = plt.subplots(
             4, 3,
             gridspec_kw={
                 'width_ratios': width_ratios,
                 'height_ratios': height_ratios},
-            figsize=(self.width, 6),
+            figsize=(self.width, 12),
             )
         with self.plot_output:
             plt.show()

--- a/ark/utils/metacluster_remap_gui/metaclustergui.py
+++ b/ark/utils/metacluster_remap_gui/metaclustergui.py
@@ -96,8 +96,10 @@ class MetaClusterGui():
             self.mcd.cluster_count,
             self.mcd.metacluster_count * 2,
         ]
-        marker_ratio = self.mcd.marker_count / 20
-        height_ratios = [6, self.mcd.marker_count * marker_ratio, marker_ratio, marker_ratio]
+        marker_ratio = max(self.mcd.marker_count / 20, 1)
+        height_ratios = [
+            6 * marker_ratio, self.mcd.marker_count * marker_ratio, marker_ratio, marker_ratio
+        ]
 
         subplots = plt.subplots(
             4, 3,

--- a/ark/utils/metacluster_remap_gui/metaclustergui.py
+++ b/ark/utils/metacluster_remap_gui/metaclustergui.py
@@ -96,7 +96,7 @@ class MetaClusterGui():
             self.mcd.cluster_count,
             self.mcd.metacluster_count * 2,
             ]
-        height_ratios = [12, self.mcd.marker_count * 2, 3, 3]
+        height_ratios = [6, self.mcd.marker_count * 2, 3, 3]
 
         subplots = plt.subplots(
             4, 3,

--- a/ark/utils/metacluster_remap_gui/metaclustergui.py
+++ b/ark/utils/metacluster_remap_gui/metaclustergui.py
@@ -95,16 +95,17 @@ class MetaClusterGui():
             int(self.mcd.cluster_count / 7),
             self.mcd.cluster_count,
             self.mcd.metacluster_count * 2,
-            ]
-        height_ratios = [6, self.mcd.marker_count * 2, 3, 3]
+        ]
+        marker_ratio = self.mcd.marker_count / 20
+        height_ratios = [6, self.mcd.marker_count * marker_ratio, marker_ratio, marker_ratio]
 
         subplots = plt.subplots(
             4, 3,
             gridspec_kw={
                 'width_ratios': width_ratios,
                 'height_ratios': height_ratios},
-            figsize=(self.width, 12),
-            )
+            figsize=(self.width, 6 * marker_ratio),
+        )
         with self.plot_output:
             plt.show()
 

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -33,6 +33,13 @@ done
 # find lowest open port available
 PORT=8888
 
+if [ $update -ne 0 ]
+  then
+    bash update_notebooks.sh -u
+  else
+    bash update_notebooks.sh
+fi
+
 until [[ $(docker container ls | grep 0.0.0.0:$PORT | wc -l) -eq 0 ]]
   do
     ((PORT=$PORT+1))


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #536 and closes #550. There are issues with the current hard-coded width and height settings for the visualization that cause the channel names to overlap and/ or the metacluster heatmap to become small and illegible. For now, we hard code new values. Depending on how we move forward, we may also add a programmatic way to compute these.

**How did you implement your changes**

The issue lies with:

```
width_ratios = [
    int(self.mcd.cluster_count / 7),
    self.mcd.cluster_count,
    self.mcd.metacluster_count,
]
height_ratios = [6, self.mcd.marker_count, 3, 3]
subplots = plt.subplots(
    4, 3,
    gridspec_kw={
    'width_ratios': width_ratios,
    'height_ratios': height_ratios},
    figsize=(self.width, 6),
)
```

We double the width of `self.mcd.metacluster_count`, double the height of `self.mcd.marker_count`, and double the height of the entire figure in the `figsize` param of `plt.subplots`.