### PR TITLE
Remove `channel_norm.feather` and `pixel_norm.feather` from `cluster_pixels` verification

### DIFF
--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -1050,7 +1050,10 @@ def cluster_pixels(fovs, channels, base_dir, data_dir='pixel_mat_data',
                                 (weights_name, base_dir))
 
     # verify that all provided fovs exist in the folder
+    # ensure that channel_norm and pixel_norm files are ignored
     data_files = io_utils.list_files(data_path, substrs='.feather')
+    data_files.remove('channel_norm.feather')
+    data_files.remove('pixel_norm.feather')
     misc_utils.verify_in_list(provided_fovs=fovs,
                               subsetted_fovs=io_utils.remove_file_extensions(data_files))
 

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -822,7 +822,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
     np.random.seed(seed)
 
     # create path for channel normalization values
-    channel_norm_path = os.path.join(base_dir, data_dir, 'channel_norm.feather')
+    channel_norm_path = os.path.join(base_dir, 'channel_norm.feather')
 
     if not os.path.exists(channel_norm_path):
 
@@ -839,7 +839,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
         channel_norm_df = feather.read_dataframe(channel_norm_path)
 
     # create path for pixel normalization values
-    pixel_norm_path = os.path.join(base_dir, data_dir, 'pixel_norm.feather')
+    pixel_norm_path = os.path.join(base_dir, 'pixel_norm.feather')
     if not os.path.exists(pixel_norm_path):
         # compute pixel percentiles
         pixel_norm_val = calculate_pixel_intensity_percentile(
@@ -1050,10 +1050,7 @@ def cluster_pixels(fovs, channels, base_dir, data_dir='pixel_mat_data',
                                 (weights_name, base_dir))
 
     # verify that all provided fovs exist in the folder
-    # ensure that channel_norm and pixel_norm files are ignored
     data_files = io_utils.list_files(data_path, substrs='.feather')
-    data_files.remove('channel_norm.feather')
-    data_files.remove('pixel_norm.feather')
     misc_utils.verify_in_list(provided_fovs=fovs,
                               subsetted_fovs=io_utils.remove_file_extensions(data_files))
 

--- a/ark/phenotyping/som_utils_test.py
+++ b/ark/phenotyping/som_utils_test.py
@@ -1129,29 +1129,21 @@ def test_create_pixel_matrix(fovs, chans, sub_dir, seg_dir_include,
                                           img_sub_folder=sub_dir,
                                           seg_dir=seg_dir)
 
-        # make the channel_norm.json file if the test requires it
+        # make the channel_norm.feather file if the test requires it
         # NOTE: pixel_mat_data already created in the previous validation tests
         if channel_norm_include:
-            # requires the pixel_mat_data directory
-            data_dir = os.path.join(temp_dir, 'pixel_mat_data')
-
-            # generate the data
             sample_channel_norm_df = pd.DataFrame({'channel': chans,
                                                   'norm_val': np.random.rand(len(chans))})
 
             feather.write_dataframe(sample_channel_norm_df,
-                                    os.path.join(data_dir, 'channel_norm.feather'),
+                                    os.path.join(temp_dir, 'channel_norm.feather'),
                                     compression='uncompressed')
 
-        # make the pixel_norm.json file if the test requires it
+        # make the pixel_norm.feather file if the test requires it
         if pixel_norm_include:
-            # requires the pixel_mat_preprocessed directory
-            data_dir = os.path.join(temp_dir, 'pixel_mat_data')
-
-            # generate the data
             sample_pixel_norm_df = pd.DataFrame({'pixel_norm_val': np.random.rand(1)})
             feather.write_dataframe(sample_pixel_norm_df,
-                                    os.path.join(data_dir, 'pixel_norm.feather'),
+                                    os.path.join(temp_dir, 'pixel_norm.feather'),
                                     compression='uncompressed')
 
         # create the pixel matrices
@@ -1171,13 +1163,13 @@ def test_create_pixel_matrix(fovs, chans, sub_dir, seg_dir_include,
         # if there wasn't originally a channel_norm.json, assert one was created
         if not channel_norm_include:
             assert os.path.exists(
-                os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm.feather')
+                os.path.join(temp_dir, 'channel_norm.feather')
             )
 
         # if there wasn't originally a pixel_norm.json, assert one was created
         if not pixel_norm_include:
             assert os.path.exists(
-                os.path.join(temp_dir, 'pixel_mat_data', 'pixel_norm.feather')
+                os.path.join(temp_dir, 'pixel_norm.feather')
             )
 
         for fov in fovs:
@@ -1242,7 +1234,7 @@ def test_create_pixel_matrix(fovs, chans, sub_dir, seg_dir_include,
         sample_channel_norm_df = pd.DataFrame({'channel': chans,
                                                'norm_val': mults})
         feather.write_dataframe(sample_channel_norm_df,
-                                os.path.join(data_dir, 'channel_norm.feather'),
+                                os.path.join(temp_dir, 'channel_norm.feather'),
                                 compression='uncompressed')
 
         som_utils.create_pixel_matrix(fovs=fovs,


### PR DESCRIPTION
**What is the purpose of this PR?**

Because the `channel_norm` and `pixel_norm` files were changed from `.json` to `.feather` format in `pixel_mat_dir`, they now get read in along with the `fov` files when retrieving them for verification in this line:

```
data_files = io_utils.list_files(data_path, substrs='.feather')
```

In some cases, this can cause `channel_norm.feather` to be read in as a FOV file by mistake. This needs to be prevented.

**How did you implement your changes**

Add two `.remove` statements after the aforementioned line to prevent `channel_norm.feather` and `pixel_norm.feather` from interfering. Because these are hard-coded names set in `create_pixel_matrix`, the naming will not cause any issues.
