### PR TITLE
Change default zip size

### DIFF
--- a/ark/utils/deepcell_service_utils.py
+++ b/ark/utils/deepcell_service_utils.py
@@ -14,7 +14,7 @@ from ark.utils import misc_utils
 
 def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
                            suffix='_feature_0', host='https://deepcell.org', job_type='mesmer',
-                           scale=1.0, timeout=3600, zip_size=100, parallel=False):
+                           scale=1.0, timeout=3600, zip_size=10, parallel=False):
     """Handles all of the necessary data manipulation for running deepcell tasks.
     Creates .zip files (to be used as input for DeepCell),
     calls run_deepcell_task method,


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**
Closes #587. Changes the default zip file size so that large cohorts don't cause an error. 

**How did you implement your changes**
Changed default from 100 to 10

**Remaining issues**