### PR TITLE
Singleton list of dtype fix

### DIFF
--- a/ark/utils/misc_utils.py
+++ b/ark/utils/misc_utils.py
@@ -156,8 +156,8 @@ def make_iterable(a, ignore_str=True):
         List[T]:
             a as singleton in list, or a if a was already iterable.
     """
-    return a if hasattr(a, '__iter__') and not (isinstance(a, str) and ignore_str) else [a]
-
+    return a if hasattr(a, '__iter__') and not ((isinstance(a, str) and ignore_str) or
+                                                 isinstance(a, type)) else [a]
 
 def verify_in_list(warn=False, **kwargs):
     """Verify at least whether the values in the first list exist in the second

--- a/ark/utils/misc_utils.py
+++ b/ark/utils/misc_utils.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-
+from collections.abc import Iterable
 import numpy as np
 import xarray as xr
 
@@ -156,8 +156,8 @@ def make_iterable(a, ignore_str=True):
         List[T]:
             a as singleton in list, or a if a was already iterable.
     """
-    return a if hasattr(a, '__iter__') and not ((isinstance(a, str) and ignore_str) or
-                                                 isinstance(a, type)) else [a]
+    return a if isinstance(a, Iterable) and not ((isinstance(a, str) and ignore_str) or
+                                                isinstance(a, type)) else [a]
 
 def verify_in_list(warn=False, **kwargs):
     """Verify at least whether the values in the first list exist in the second

--- a/ark/utils/misc_utils.py
+++ b/ark/utils/misc_utils.py
@@ -157,7 +157,8 @@ def make_iterable(a, ignore_str=True):
             a as singleton in list, or a if a was already iterable.
     """
     return a if isinstance(a, Iterable) and not ((isinstance(a, str) and ignore_str) or
-                                                isinstance(a, type)) else [a]
+                                                 isinstance(a, type)) else [a]
+
 
 def verify_in_list(warn=False, **kwargs):
     """Verify at least whether the values in the first list exist in the second

--- a/ark/utils/misc_utils_test.py
+++ b/ark/utils/misc_utils_test.py
@@ -154,39 +154,39 @@ def test_create_invalid_data_str():
     for id in invalid_data[:10]:
         assert invalid_data_str3.find(id) != -1
 
+
 def test_make_iterable():
-    
+
     # Input is string, ignore_str = True
     input_str = "test"
     assert misc_utils.make_iterable(input_str, ignore_str=True) == ["test"]
-    
+
     # Input is string, ignore_str = False
     assert misc_utils.make_iterable(input_str, ignore_str=False) == "test"
-    
+
     # Input is a list of objects, ignore_str = True
-    input_list = [1,2,3,4]
-    assert misc_utils.make_iterable(input_list, ignore_str=True) == [1,2,3,4]
-    
+    input_list = [1, 2, 3, 4]
+    assert misc_utils.make_iterable(input_list, ignore_str=True) == [1, 2, 3, 4]
+
     # Input is a list of objects, ignore_str = False
-    assert misc_utils.make_iterable(input_list, ignore_str=False) == [1,2,3,4]
-    
+    assert misc_utils.make_iterable(input_list, ignore_str=False) == [1, 2, 3, 4]
+
     # Input is of type(<...>) = type (a fundamental data type such as str, int, bool)
     assert misc_utils.make_iterable(str, ignore_str=True) == [str]
-    
-    assert misc_utils.make_iterable(str, ignore_str=False) == [str]
-    
-    assert misc_utils.make_iterable(int, ignore_str=True) == [int]
-    
-    assert misc_utils.make_iterable(int, ignore_str=False) == [int]
-    
-    assert misc_utils.make_iterable(bool, ignore_str=True) == [bool]
-    
-    assert misc_utils.make_iterable(bool, ignore_str=False) == [bool]
-    
-    # Input is a numpy array
-    input_np_arr = np.array([1,2,3,4,5])
-    np.testing.assert_equal(misc_utils.make_iterable(input_np_arr, ignore_str=True),
-                            np.array([1,2,3,4,5]))
-    np.testing.assert_equal(misc_utils.make_iterable(input_np_arr, ignore_str=False),
-                            np.array([1,2,3,4,5]))
 
+    assert misc_utils.make_iterable(str, ignore_str=False) == [str]
+
+    assert misc_utils.make_iterable(int, ignore_str=True) == [int]
+
+    assert misc_utils.make_iterable(int, ignore_str=False) == [int]
+
+    assert misc_utils.make_iterable(bool, ignore_str=True) == [bool]
+
+    assert misc_utils.make_iterable(bool, ignore_str=False) == [bool]
+
+    # Input is a numpy array
+    input_np_arr = np.array([1, 2, 3, 4, 5])
+    np.testing.assert_equal(misc_utils.make_iterable(input_np_arr, ignore_str=True),
+                            np.array([1, 2, 3, 4, 5]))
+    np.testing.assert_equal(misc_utils.make_iterable(input_np_arr, ignore_str=False),
+                            np.array([1, 2, 3, 4, 5]))

--- a/ark/utils/misc_utils_test.py
+++ b/ark/utils/misc_utils_test.py
@@ -153,3 +153,40 @@ def test_create_invalid_data_str():
     invalid_data_str3 = misc_utils.create_invalid_data_str(invalid_data=invalid_data)
     for id in invalid_data[:10]:
         assert invalid_data_str3.find(id) != -1
+
+def test_make_iterable():
+    
+    # Input is string, ignore_str = True
+    input_str = "test"
+    assert misc_utils.make_iterable(input_str, ignore_str=True) == ["test"]
+    
+    # Input is string, ignore_str = False
+    assert misc_utils.make_iterable(input_str, ignore_str=False) == "test"
+    
+    # Input is a list of objects, ignore_str = True
+    input_list = [1,2,3,4]
+    assert misc_utils.make_iterable(input_list, ignore_str=True) == [1,2,3,4]
+    
+    # Input is a list of objects, ignore_str = False
+    assert misc_utils.make_iterable(input_list, ignore_str=False) == [1,2,3,4]
+    
+    # Input is of type(<...>) = type (a fundamental data type such as str, int, bool)
+    assert misc_utils.make_iterable(str, ignore_str=True) == [str]
+    
+    assert misc_utils.make_iterable(str, ignore_str=False) == [str]
+    
+    assert misc_utils.make_iterable(int, ignore_str=True) == [int]
+    
+    assert misc_utils.make_iterable(int, ignore_str=False) == [int]
+    
+    assert misc_utils.make_iterable(bool, ignore_str=True) == [bool]
+    
+    assert misc_utils.make_iterable(bool, ignore_str=False) == [bool]
+    
+    # Input is a numpy array
+    input_np_arr = np.array([1,2,3,4,5])
+    np.testing.assert_equal(misc_utils.make_iterable(input_np_arr, ignore_str=True),
+                            np.array([1,2,3,4,5]))
+    np.testing.assert_equal(misc_utils.make_iterable(input_np_arr, ignore_str=False),
+                            np.array([1,2,3,4,5]))
+


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes angelolab/toffy#120. Fixes a dtype iteration issue.

**How did you implement your changes**

Added a check to allow `str` to become an iterable as `[str]`. Added several tests for the following objects: `list`, `np.array`, and the following types `str`, `bool`, `int`.

**Remaining issues**

None atm.
