### PR TITLE
Allow segmentation pipeline to handle blank images

### DIFF
--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -41,6 +41,12 @@ def get_single_compartment_props(segmentation_labels, regionprops_base,
         props_options=list(REGIONPROPS_FUNCTION.keys())
     )
 
+    # if image is just background, return empty df
+    if len(np.unique(segmentation_labels)) < 2:
+        output_list = regionprops_base + regionprops_single_comp
+        blank_df = pd.DataFrame(columns=output_list)
+        return blank_df
+
     # get the base features
     cell_props = pd.DataFrame(regionprops_table(segmentation_labels,
                                                 properties=regionprops_base))

--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -239,10 +239,6 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
     unique_cell_ids = np.unique(segmentation_labels[..., 0].values)
     unique_cell_ids = unique_cell_ids[np.nonzero(unique_cell_ids)]
 
-    # if no cells in the image, skip processing and return blank df
-    if len(unique_cell_ids) < 1:
-        return pd.DataFrame({})
-
     # create labels for array holding channel counts and morphology metrics
     feature_names = np.concatenate((np.array(settings.PRE_CHANNEL_COL), input_images.channels,
                                     regionprops_names), axis=None)

--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -261,6 +262,10 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
                                               regionprops_base, regionprops_single_comp,
                                               **reg_props)
 
+    if len(unique_cell_ids) == 0:
+        fov_name = str(segmentation_labels.fovs.values)
+        warnings.warn("No cells found in the following image: {}".format(fov_name))
+
     if nuclear_counts:
         nuc_labels = segmentation_labels.loc[:, :, 'nuclear'].values
 
@@ -274,6 +279,9 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
         nuc_props = get_single_compartment_props(nuc_labels,
                                                  regionprops_base, regionprops_single_comp,
                                                  **reg_props)
+        if len(nuc_props) == 0:
+            fov_name = str(segmentation_labels.fovs.values)
+            warnings.warn("No nuclei found in the following image: {}".format(fov_name))
 
     # get the signal kwargs
     sig_kwargs = kwargs.get('signal_kwargs', {})

--- a/ark/segmentation/marker_quantification.py
+++ b/ark/segmentation/marker_quantification.py
@@ -239,6 +239,10 @@ def compute_marker_counts(input_images, segmentation_labels, nuclear_counts=Fals
     unique_cell_ids = np.unique(segmentation_labels[..., 0].values)
     unique_cell_ids = unique_cell_ids[np.nonzero(unique_cell_ids)]
 
+    # if no cells in the image, skip processing and return blank df
+    if len(unique_cell_ids) < 1:
+        return pd.DataFrame({})
+
     # create labels for array holding channel counts and morphology metrics
     feature_names = np.concatenate((np.array(settings.PRE_CHANNEL_COL), input_images.channels,
                                     regionprops_names), axis=None)

--- a/ark/segmentation/marker_quantification_test.py
+++ b/ark/segmentation/marker_quantification_test.py
@@ -543,6 +543,11 @@ def test_create_marker_count_matrices_multiple_compartments():
     normalized_with_nuc = normalized.loc[normalized['label'] != 2, ['label', 'label_nuclear']]
     assert np.array_equal(normalized_with_nuc['label'] * 2, normalized_with_nuc['label_nuclear'])
 
+    # blank nuclear segmentation mask doesn't cause any issues
+    segmentation_labels_unequal.values[1, ..., 1] = 0
+    _ = marker_quantification.create_marker_count_matrices(segmentation_labels_unequal,
+                                                           channel_data, nuclear_counts=True)
+
 
 def test_generate_cell_data_tree_loading():
     # is_mibitiff False case, load from directory tree

--- a/ark/segmentation/marker_quantification_test.py
+++ b/ark/segmentation/marker_quantification_test.py
@@ -41,6 +41,17 @@ def test_get_single_compartment_props():
         cell_props_columns=cell_props.columns.values
     )
 
+    # test that blank segmentation mask is handled appropriately
+    cell_props_blank = marker_quantification.get_single_compartment_props(
+        np.zeros((40, 40), dtype='int'),
+        regionprops_base,
+        regionprops_single_comp)
+
+    misc_utils.verify_same_elements(
+        all_features=copy.deepcopy(regionprops_base) + regionprops_single_comp,
+        cell_props_columns=cell_props_blank.columns.values
+    )
+
 
 def test_assign_single_compartment_props():
     cell_mask, channel_data = test_utils.create_test_extraction_data()

--- a/ark/segmentation/marker_quantification_test.py
+++ b/ark/segmentation/marker_quantification_test.py
@@ -250,6 +250,14 @@ def test_compute_marker_counts_base():
         > center_extraction.loc['whole_cell', :, 'chan0'].values
     )
 
+    # blank segmentation mask results in an empty df
+    blank_labels = test_utils.make_labels_xarray(label_data=np.zeros((1, 40, 40, 1), dtype='int'),
+                                                 compartment_names=['whole_cell'])
+
+    blank_output = marker_quantification.compute_marker_counts(input_images=input_images,
+                                                               segmentation_labels=blank_labels[0])
+    assert len(blank_output) == 0
+
 
 def test_compute_marker_counts_equal_masks():
     cell_mask, channel_data = test_utils.create_test_extraction_data()

--- a/ark/segmentation/marker_quantification_test.py
+++ b/ark/segmentation/marker_quantification_test.py
@@ -250,13 +250,13 @@ def test_compute_marker_counts_base():
         > center_extraction.loc['whole_cell', :, 'chan0'].values
     )
 
-    # blank segmentation mask results in an empty df
+    # blank segmentation mask results in the cells column of length 0
     blank_labels = test_utils.make_labels_xarray(label_data=np.zeros((1, 40, 40, 1), dtype='int'),
                                                  compartment_names=['whole_cell'])
 
     blank_output = marker_quantification.compute_marker_counts(input_images=input_images,
                                                                segmentation_labels=blank_labels[0])
-    assert len(blank_output) == 0
+    assert blank_output.shape[1] == 0
 
 
 def test_compute_marker_counts_equal_masks():
@@ -460,6 +460,11 @@ def test_create_marker_count_matrices_base():
 
     assert np.array_equal(normalized['chan0'], np.repeat(1, len(normalized)))
     assert np.array_equal(normalized['chan1'], np.repeat(5, len(normalized)))
+
+    # blank image doesn't cause any issues
+    segmentation_labels.values[1, ...] = 0
+    _ = marker_quantification.create_marker_count_matrices(segmentation_labels,
+                                                           channel_data)
 
     # error checking
     with pytest.raises(ValueError):


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**
Updates the segmentation pipeline to work with images without any cells. 

**How did you implement your changes**
Check for number unique objects in segmentation mask. If there aren't any cells, skips the `regionprops` extraction and just returns an empty df. Also adds tests to prevent future reversions
