### PR TITLE
VERSION 0.3.00 -> 0.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from os import path, pardir
 from setuptools import setup, find_packages
 
-VERSION = '0.3.00'
+VERSION = '0.3.0'
 
 PKG_FOLDER = path.abspath(path.join(__file__, pardir))
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from os import path, pardir
 from setuptools import setup, find_packages
 
-VERSION = '0.3.0'
+VERSION = '0.3.1'
 
 PKG_FOLDER = path.abspath(path.join(__file__, pardir))
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

This fixes an issue where version `0.3.00` does not exist, and pip / conda will try to install this version and fails.

**How did you implement your changes**

Adjusts the version from `0.3.00` to `0.3.1`. This should fix the installing it locally.


**Remaining issues**

None ATM.