### PR TITLE
Removed `v` in `download_url` within setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description='Toolbox for analysis on segmented images from MIBI',
     author='Angelo Lab',
     url='https://github.com/angelolab/ark-analysis',
-    download_url='https://github.com/angelolab/ark-analysis/archive/v{}.tar.gz'.format(VERSION),
+    download_url='https://github.com/angelolab/ark-analysis/archive/{}.tar.gz'.format(VERSION),
     install_requires=requirements,
     extras_require={
         'tests': ['pytest',


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Fixes a downloading issue when trying to install ark-analysis within toffy.

**How did you implement your changes**


Removed the `v` in the download_url.

**Remaining issues**

None.

Note, we do not need to create a new release.