### PR TITLE
Add `dtype` argument to channel and pixel norm functions

### DIFF
--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -26,7 +26,7 @@ multiprocessing.set_start_method('spawn', force=True)
 
 
 def calculate_channel_percentiles(tiff_dir, fovs, channels, img_sub_folder,
-                                  percentile, dtype="int16"):
+                                  percentile, dtype="float32"):
     """Calculates average percentile for each channel in the dataset
 
     Args:
@@ -75,7 +75,7 @@ def calculate_channel_percentiles(tiff_dir, fovs, channels, img_sub_folder,
 
 
 def calculate_pixel_intensity_percentile(tiff_dir, fovs, channels, img_sub_folder,
-                                         channel_percentiles, percentile=0.05, dtype="int16"):
+                                         channel_percentiles, percentile=0.05, dtype="float32"):
     """Calculates average percentile per FOV for total signal in each pixel
 
     Args:
@@ -197,7 +197,7 @@ def check_for_modified_channels(tiff_dir, test_fov, img_sub_folder, channels):
                 pass
 
 
-def smooth_channels(fovs, tiff_dir, img_sub_folder, channels, smooth_vals, dtype="int16"):
+def smooth_channels(fovs, tiff_dir, img_sub_folder, channels, smooth_vals, dtype="float32"):
     """Adds additional smoothing for selected channels as a preprocessing step
 
     Args:
@@ -873,7 +873,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
                         data_dir='pixel_mat_data',
                         subset_dir='pixel_mat_subsetted',
                         norm_vals_name='post_rowsum_chan_norm.feather', is_mibitiff=False,
-                        blur_factor=2, subset_proportion=0.1, dtype="int16", seed=42,
+                        blur_factor=2, subset_proportion=0.1, dtype="float32", seed=42,
                         channel_percentile=0.99, batch_size=5):
     """For each fov, add a Gaussian blur to each channel and normalize channel sums for each pixel
 

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -168,7 +168,9 @@ def check_for_modified_channels(tiff_dir, test_fov, img_sub_folder, channels):
             example fov used to check channel names
         img_sub_folder (str):
             sub-folder within each FOV containing image data
-        channels (list): list of channels to use for analysis"""
+        channels (list):
+            list of channels to use for analysis
+    """
 
     # convert to path-compatible format
     if img_sub_folder is None:
@@ -195,7 +197,7 @@ def check_for_modified_channels(tiff_dir, test_fov, img_sub_folder, channels):
                 pass
 
 
-def smooth_channels(fovs, tiff_dir, img_sub_folder, channels, smooth_vals):
+def smooth_channels(fovs, tiff_dir, img_sub_folder, channels, smooth_vals, dtype="int16"):
     """Adds additional smoothing for selected channels as a preprocessing step
 
     Args:
@@ -210,6 +212,8 @@ def smooth_channels(fovs, tiff_dir, img_sub_folder, channels, smooth_vals):
         smooth_vals (list or int):
             amount to smooth channels. If a single int, applies
             to all channels. Otherwise, a custom value per channel can be supplied
+        dtype (type):
+            the type to use for loading the image data in
     """
 
     # no output if no channels specified
@@ -233,7 +237,8 @@ def smooth_channels(fovs, tiff_dir, img_sub_folder, channels, smooth_vals):
     for fov in fovs:
         for idx, chan in enumerate(channels):
             img = load_utils.load_imgs_from_tree(data_dir=tiff_dir, img_sub_folder=img_sub_folder,
-                                                 fovs=[fov], channels=[chan]).values[0, :, :, 0]
+                                                 fovs=[fov], channels=[chan],
+                                                 dtype=dtype).values[0, :, :, 0]
             chan_out = ndimage.gaussian_filter(img, sigma=smooth_vals[idx])
             imsave(os.path.join(tiff_dir, fov, img_sub_folder, chan + '_smoothed.tiff'),
                    chan_out, check_contrast=False)

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -25,7 +25,8 @@ from ark.utils import misc_utils
 multiprocessing.set_start_method('spawn', force=True)
 
 
-def calculate_channel_percentiles(tiff_dir, fovs, channels, img_sub_folder, percentile):
+def calculate_channel_percentiles(tiff_dir, fovs, channels, img_sub_folder,
+                                  percentile, dtype="int16"):
     """Calculates average percentile for each channel in the dataset
 
     Args:
@@ -39,6 +40,8 @@ def calculate_channel_percentiles(tiff_dir, fovs, channels, img_sub_folder, perc
             Sub folder within each FOV containing image data
         percentile (float):
             The specific percentile to compute
+        dtype (type):
+            The type to use for loading the image data in
 
     Returns:
         pd.DataFrame:
@@ -54,7 +57,8 @@ def calculate_channel_percentiles(tiff_dir, fovs, channels, img_sub_folder, perc
         for fov in fovs:
             # load image data and remove 0 valued pixels
             img = load_utils.load_imgs_from_tree(data_dir=tiff_dir, img_sub_folder=img_sub_folder,
-                                                 channels=[channel], fovs=[fov]).values[0, :, :, 0]
+                                                 channels=[channel], fovs=[fov],
+                                                 dtype=dtype).values[0, :, :, 0]
             img = img[img > 0]
 
             # record and store percentile, skip if no non-zero pixels
@@ -71,7 +75,7 @@ def calculate_channel_percentiles(tiff_dir, fovs, channels, img_sub_folder, perc
 
 
 def calculate_pixel_intensity_percentile(tiff_dir, fovs, channels, img_sub_folder,
-                                         channel_percentiles, percentile=0.05):
+                                         channel_percentiles, percentile=0.05, dtype="int16"):
     """Calculates average percentile per FOV for total signal in each pixel
 
     Args:
@@ -88,6 +92,8 @@ def calculate_pixel_intensity_percentile(tiff_dir, fovs, channels, img_sub_folde
             Computed by `calculate_channel_percentiles`
         percentile (float):
             The pixel intensity percentile per FOV to average over
+        dtype (type):
+            The type to use for loading the image data in
 
     Returns:
         float:
@@ -103,7 +109,8 @@ def calculate_pixel_intensity_percentile(tiff_dir, fovs, channels, img_sub_folde
     for fov in fovs:
         # load image data
         img_data = load_utils.load_imgs_from_tree(data_dir=tiff_dir, fovs=[fov],
-                                                  channels=channels, img_sub_folder=img_sub_folder)
+                                                  channels=channels, img_sub_folder=img_sub_folder,
+                                                  dtype=dtype)
 
         # normalize each channel by its percentile value
         norm_data = img_data[0].values / norm_vect
@@ -908,7 +915,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
         seed (int):
             The random seed to set for subsetting
         dtype (type):
-            The type to load the image segmentation labels in
+            The type to use for loading the image data in
         channel_percentile (float):
             Percentile used to normalize channels to same range
         batch_size (int):
@@ -953,10 +960,12 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
 
     if not os.path.exists(channel_norm_path):
         # compute channel percentiles
-        channel_norm_df = calculate_channel_percentiles(tiff_dir=tiff_dir, fovs=fovs,
+        channel_norm_df = calculate_channel_percentiles(tiff_dir=tiff_dir,
+                                                        fovs=fovs,
                                                         channels=channels,
                                                         img_sub_folder=img_sub_folder,
-                                                        percentile=channel_percentile)
+                                                        percentile=channel_percentile,
+                                                        dtype=dtype)
         # save output
         feather.write_dataframe(channel_norm_df, channel_norm_path, compression='uncompressed')
 
@@ -973,7 +982,8 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
         # compute pixel percentiles
         pixel_norm_val = calculate_pixel_intensity_percentile(
             tiff_dir=tiff_dir, fovs=fovs, channels=channels,
-            img_sub_folder=img_sub_folder, channel_percentiles=channel_norm_df
+            img_sub_folder=img_sub_folder, channel_percentiles=channel_norm_df,
+            dtype=dtype
         )
 
         pixel_norm_df = pd.DataFrame({'pixel_norm_val': [pixel_norm_val]})

--- a/ark/phenotyping/som_utils_test.py
+++ b/ark/phenotyping/som_utils_test.py
@@ -504,7 +504,8 @@ def test_smooth_channels(smooth_vals):
         smooth_channels = ['chan0', 'chan1']
 
         som_utils.smooth_channels(fovs=fovs, tiff_dir=temp_dir, img_sub_folder='TIFs',
-                                  channels=smooth_channels, smooth_vals=smooth_vals)
+                                  channels=smooth_channels, smooth_vals=smooth_vals,
+                                  dtype="int16")
 
         # check that correct value was applied
         for fov in fovs:

--- a/ark/utils/notebooks_test_utils.py
+++ b/ark/utils/notebooks_test_utils.py
@@ -216,6 +216,22 @@ def flowsom_pixel_setup(tb, flowsom_dir, create_seg_dir=True, img_shape=(50, 50)
     # define the main pixel output dir, the preprocessed dir, and the subsetted dir
     tb.execute_cell('dir_set')
 
+    # runs the blurring process for the first channel
+    run_chan_smoothing = """
+        blurred_channels = %s
+        smooth_vals = 6
+
+        som_utils.smooth_channels(
+            fovs=fovs,
+            tiff_dir=tiff_dir,
+            img_sub_folder=img_sub_folder,
+            channels=blurred_channels,
+            smooth_vals=smooth_vals,
+            dtype="int16"
+        )
+    """ % [chans[0]]
+    tb.inject(run_chan_smoothing, 'smooth_channels')
+
     # sets the channels to include
     tb.inject(
         """

--- a/templates_ark/example_pixel_clustering.ipynb
+++ b/templates_ark/example_pixel_clustering.ipynb
@@ -180,13 +180,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "smooth_channels"
+    ]
+   },
    "outputs": [],
    "source": [
     "# set an optional list of markers for additional blurring\n",
     "blurred_channels = []\n",
     "smooth_vals = 6\n",
-    "som_utils.smooth_channels(fovs=fovs, tiff_dir=tiff_dir, img_sub_folder=img_sub_folder, channels=blurred_channels, smooth_vals=smooth_vals)"
+    "\n",
+    "som_utils.smooth_channels(\n",
+    "    fovs=fovs,\n",
+    "    tiff_dir=tiff_dir,\n",
+    "    img_sub_folder=img_sub_folder,\n",
+    "    channels=blurred_channels,\n",
+    "    smooth_vals=smooth_vals,\n",
+    "    dtype=\"int16\"\n",
+    ")"
    ]
   },
   {

--- a/templates_ark/example_pixel_clustering.ipynb
+++ b/templates_ark/example_pixel_clustering.ipynb
@@ -197,7 +197,7 @@
     "    img_sub_folder=img_sub_folder,\n",
     "    channels=blurred_channels,\n",
     "    smooth_vals=smooth_vals,\n",
-    "    dtype=\"int16\"\n",
+    "    dtype=\"float32\"\n",
     ")"
    ]
   },
@@ -270,7 +270,7 @@
     "    is_mibitiff=MIBItiff,\n",
     "    blur_factor=blur_factor,\n",
     "    subset_proportion=subset_proportion,\n",
-    "    dtype=\"int16\"\n",
+    "    dtype=\"float32\"\n",
     ")"
    ]
   },


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #612. The `dtype` argument currently isn't propagated through to the channel and pixel normalization functions, causing the `load_imgs_from_tree` calls to attempt to load the images using the default `int16` type. This will throw a warning if the images were of type `float32` regardless of if the user passed `float32` to `create_pixel_matrix`.

**How did you implement your changes**

Add `dtype` with a default argument of `int16` to both `calculate_channel_percentiles` and `calculate_pixel_intensity_percentile`. Explicitly pass the `dtype` argument received by `create_pixel_matrix` to these functions.