### PR TITLE
PKG_FOLDER variable in `setup.py` cannot find `requirements.txt` due to filepath issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ VERSION = '0.3.1'
 
 PKG_FOLDER = path.abspath(path.join(__file__, pardir))
 
-# set a long description which is basically the README
-with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
-    long_description = f.read()
-
 with open(path.join(PKG_FOLDER, 'requirements.txt')) as req_file:
     requirements = req_file.read().splitlines()
+    
+# set a long description which is basically the README
+with open(path.join(PKG_FOLDER, 'README.md')) as f:
+    long_description = f.read()
 
 setup(
     name='ark-analysis',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from os import path, pardir
 from setuptools import setup, find_packages
 
-VERSION = '0.3.1'
+VERSION = '0.3.2'
 
 PKG_FOLDER = path.abspath(path.join(__file__, pardir))
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

`ark-analysis` will not install properly via PyPI, the issue seems to reside with the `PKG_FOLDER` variable.

**How did you implement your changes**

Set `PKG_FOLDER` the same as it is in `toffy`.

**Remaining issues**

Need to adjust ark-analysis requirement in angelolab/toffy#132, and make sure it can install properly.