### PR TITLE
Force the compression method of R feather saving `'uncompressed'`

### DIFF
--- a/ark/phenotyping/cell_consensus_cluster.R
+++ b/ark/phenotyping/cell_consensus_cluster.R
@@ -64,7 +64,7 @@ names(som_to_meta_map) <- clusterAvgs$cell_som_cluster
 print("Writing consensus clustering")
 cellClusterData <- arrow::read_feather(cellMatPath)
 cellClusterData$cell_meta_cluster <- som_to_meta_map[as.character(cellClusterData$cell_som_cluster)]
-arrow::write_feather(as.data.table(cellClusterData), cellMatPath)
+arrow::write_feather(as.data.table(cellClusterData), cellMatPath, compression='uncompressed')
 
 # save the mapping from cell_som_cluster to cell_meta_cluster
 print("Writing SOM to meta cluster mapping table")
@@ -73,4 +73,4 @@ som_to_meta_map <- as.data.table(som_to_meta_map)
 # assign cell_som_cluster column, then rename som_to_meta_map to cell_meta_cluster
 som_to_meta_map$cell_som_cluster <- as.integer(rownames(som_to_meta_map))
 som_to_meta_map <- setnames(som_to_meta_map, "som_to_meta_map", "cell_meta_cluster")
-arrow::write_feather(som_to_meta_map, clustToMeta)
+arrow::write_feather(som_to_meta_map, clustToMeta, compression='uncompressed')

--- a/ark/phenotyping/create_cell_som.R
+++ b/ark/phenotyping/create_cell_som.R
@@ -80,4 +80,4 @@ somResults <- SOM(data=as.matrix(clusterCountsNormSub), xdim=xdim, ydim=ydim,
 
 # write the weights to feather
 print("Save trained weights")
-arrow::write_feather(as.data.table(somResults$codes), cellWeightsPath)
+arrow::write_feather(as.data.table(somResults$codes), cellWeightsPath, compression='uncompressed')

--- a/ark/phenotyping/create_pixel_som.R
+++ b/ark/phenotyping/create_pixel_som.R
@@ -77,4 +77,4 @@ somResults <- SOM(data=as.matrix(pixelSubsetData), rlen=numPasses,
 
 # write the weights to feather
 print("Save trained weights")
-arrow::write_feather(as.data.table(somResults$codes), pixelWeightsPath)
+arrow::write_feather(as.data.table(somResults$codes), pixelWeightsPath, compression='uncompressed')

--- a/ark/phenotyping/pixel_consensus_cluster.R
+++ b/ark/phenotyping/pixel_consensus_cluster.R
@@ -29,7 +29,7 @@ mapConsensusLabels <- function(fov, pixelMatDir, som_to_meta_map) {
     fovPixelData$pixel_meta_cluster <- som_to_meta_map[as.character(fovPixelData$pixel_som_cluster)]
 
     # write data with consensus labels
-    arrow::write_feather(as.data.table(fovPixelData), matPath)
+    arrow::write_feather(as.data.table(fovPixelData), matPath, compression='uncompressed')
 }
 
 # get the number of cores
@@ -124,4 +124,4 @@ som_to_meta_map <- as.data.table(som_to_meta_map)
 # assign pixel_som_cluster column, then rename som_to_meta_map to pixel_meta_cluster
 som_to_meta_map$pixel_som_cluster <- as.integer(rownames(som_to_meta_map))
 som_to_meta_map <- setnames(som_to_meta_map, "som_to_meta_map", "pixel_meta_cluster")
-arrow::write_feather(som_to_meta_map, clustToMeta)
+arrow::write_feather(som_to_meta_map, clustToMeta, compression='uncompressed')

--- a/ark/phenotyping/run_cell_som.R
+++ b/ark/phenotyping/run_cell_som.R
@@ -62,4 +62,4 @@ clusterCountsNorm$cell_som_cluster <- as.integer(clusters[,1])
 
 # write to feather
 print("Writing clustered data")
-arrow::write_feather(as.data.table(clusterCountsNorm), cellMatPathNorm)
+arrow::write_feather(as.data.table(clusterCountsNorm), cellMatPathNorm, compression='uncompressed')

--- a/ark/phenotyping/run_pixel_som.R
+++ b/ark/phenotyping/run_pixel_som.R
@@ -35,7 +35,7 @@ mapSOMLabels <- function(fov, somWeights, pixelMatDir) {
     fovPixelData$pixel_som_cluster <- as.integer(clusters[,1])
 
     # write to feather
-    arrow::write_feather(as.data.table(fovPixelData),  matPath)
+    arrow::write_feather(as.data.table(fovPixelData),  matPath, compression='uncompressed')
 }
 
 # get the number of cores


### PR DESCRIPTION
**What is the purpose of this PR?**

There have been issues with consistency in saving the `.feather` files in Python vs R. To prevent interoperability issues, we change the compression argument passed into `write_feather` in R to `'uncompressed'`