### PR TITLE
Ark 3.6 Docker Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
         user: $PYPI_USERNAME
         password: $PYPI_PASSWORD
         on:
-          tags: true
+          tags: false
     - stage: docker_deploy
       if: tag IS present
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
         user: $PYPI_USERNAME
         password: $PYPI_PASSWORD
         on:
-          tags: false
+          tags: true
     - stage: docker_deploy
       if: tag IS present
       python: 3.6
@@ -40,9 +40,8 @@ jobs:
         - "travis_wait 120 sleep 7200 &"
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin 
         - docker build -t "$TRAVIS_REPO_SLUG" . 1> /dev/null
-        # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":3.6
         - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
-        - docker push "$TRAVIS_REPO_SLUG"
+        - docker push "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - "travis_wait 120 sleep 7200 &"
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin 
         - docker build -t "$TRAVIS_REPO_SLUG" . 1> /dev/null
-        - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
+        # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":3.6
         - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
         - docker push "$TRAVIS_REPO_SLUG"
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #625.
Creates a Docker Image of ark-analysis at Python version 3.6. 

**How did you implement your changes**

Created a new branch from the following commit:
* #607
* SHA: 45740977ba9168c3c3eb9430113a4285f97d86ab

**Remaining issues**

* [x] Need to build the docker for 3.6 (tagged appropriately)
* [x] Need to then build the docker for 3.7 (tagged appropriately)

**DO NOT MERGE**