### PR TITLE
Ark 3.7 Docker Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
         user: $PYPI_USERNAME
         password: $PYPI_PASSWORD
         on:
-          tags: true
+          tags: false
     - stage: docker_deploy
       if: tag IS present
       python: 3.7
@@ -43,9 +43,9 @@ jobs:
         - "travis_wait 120 sleep 7200 &"
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin 
         - docker build -t "$TRAVIS_REPO_SLUG" . 1> /dev/null
-        - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
+        # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
         - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
-        - docker push "$TRAVIS_REPO_SLUG"
+        - docker push "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
 
 after_success:
   - coveralls


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #625.
Creates a tagged Docker Image for Python 3.7.

**How did you implement your changes**

Take a look at #627 for a dedicated Ark 3.6 Image.

A few changes to the `.travis.yml` file in addition to pushing a new tag `python-3.7`.

**Remaining issues**

None atm.

**DO NOT MERGE**