### PR TITLE
Pin matplotlib at 3.4.3 in requirements.txt to prevent colorbar scaling issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ipympl==0.9.1
 jupyter_contrib_nbextensions>=0.5.1,<1
 jupyterlab>=3.4.3,<4
 jedi>=0.17.2,<0.18
-matplotlib>=3.5.2,<4
+matplotlib==3.4.3,<4
 numpy>=1.21.6,<2
 palettable>=3.3.0,<4
 pandas>=1.3.5,<2


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #614. Currently, the Python 3.7 image is built using the latest `matplotlib` version (3.5.x), which introduced several bugs to colorbar scaling. Several issues related to this are still open on the `matplotlib` repo, so it's best that we don't use this version for our purposes.

**How did you implement your changes**

Pin `requirements.txt` at version `3.4.2`.

**Remaining issues**

The Python 3.7 Docker image is still problematic because we haven't rebuilt it with `matplotlib==3.4.2` yet. Before this is done, users should continue using the Python 3.6/latest image.

Additionally, we should keep close watch of `matplotlib` updates on colorbar usage. Once they resolve the issue, we can matplotlib back to the most recent version.