### PR TITLE
Ensure the meta cluster rename drop down menu for remapping doesn't get cut off

### DIFF
--- a/ark/utils/metacluster_remap_gui/metaclustergui.py
+++ b/ark/utils/metacluster_remap_gui/metaclustergui.py
@@ -306,9 +306,10 @@ class MetaClusterGui():
         ])
         self.toolbar = widgets.HBox([
             self.tools,
-            self.metacluster_info,
+            self.metacluster_info
         ])
-        self.toolbar.layout.justify_content = 'space-between'
+
+        self.toolbar.layout.justify_content = 'center'
         self.plot_output = widgets.Output()
         self.gui = widgets.VBox([self.plot_output, self.toolbar])
 


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #630. The way the toolbar is set up, the meta cluster renaming textbox/drop-down menu can get cut off on the far right. This needs to be pushed further to the center.

**How did you implement your changes**

Adjust the toolbar's `layout.justify_content` setting to `'center'`.
