### PR TITLE
Save fov images as int16

### DIFF
--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -27,6 +27,7 @@ def save_fov_images(fovs, data_dir, img_xr, sub_dir=None, name_suffix=''):
         name_suffix (str):
             Specify what to append at the end of every fov.
     """
+    img_xr = img_xr.astype('int16')
 
     if not os.path.exists(data_dir):
         raise FileNotFoundError("data_dir %s does not exist" % data_dir)

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -42,6 +42,8 @@ def test_save_fov_images():
 
         for fov in fovs:
             assert os.path.exists(os.path.join(temp_dir, fov + '.tiff'))
+            temp_img = io.imread(os.path.join(temp_dir, fov + '.tiff'))
+            assert temp_img.dtype == 'int16'
 
     # test 2: fov subset provided
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #521.
Edits the `save_fov_images` function so the pixel clustering notebook saves overlays images that can be loaded into photoshop.

**Remaining issues**

Could instead add the saving dtype as a default arg to the function, if that's something you think we'd use. 