### PR TITLE
Add nuclear filtering functionality to pixel clustering pipeline

### DIFF
--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -238,7 +238,7 @@ def smooth_channels(fovs, tiff_dir, img_sub_folder, channels, smooth_vals):
                    chan_out, check_contrast=False)
 
 
-def filter_with_nuclear_mask(fovs, tiff_dir, seg_dir, channel,
+def filter_with_nuclear_mask(fovs, tiff_dir, seg_dir, channel=None,
                              img_sub_folder=None, exclude=True):
     """Filters out background staining using subcellular marker localization.
 
@@ -260,6 +260,15 @@ def filter_with_nuclear_mask(fovs, tiff_dir, seg_dir, channel,
             Whether to filter out nuclear or membrane signal
     """
 
+    # if seg_dir is None, the user cannot run filtering
+    if seg_dir is None:
+        raise ValueError('seg_dir cannot be set to None for nuclear filtering')
+
+    # if the user doesn't specify a channel, return
+    if channel is None:
+        print("No channel specified for nuclear filtering, skipping")
+        return
+
     # convert to path-compatible format
     if img_sub_folder is None:
         img_sub_folder = ''
@@ -272,8 +281,6 @@ def filter_with_nuclear_mask(fovs, tiff_dir, seg_dir, channel,
         # load the segmented image in
         seg_img = imread(os.path.join(seg_dir, fov + '_feature_1.tif'))[0, ...]
 
-        # print(seg_img)
-
         # mask out the nucleus
         if exclude:
             suffix = '_nuc_exclude.tiff'
@@ -283,12 +290,8 @@ def filter_with_nuclear_mask(fovs, tiff_dir, seg_dir, channel,
             suffix = '_nuc_include.tiff'
             seg_mask = seg_img == 0
 
-        # print(img)
-        # print(seg_mask)
-
         # filter out the nucleus or membrane depending on exclude parameter
         img[seg_mask] = 0
-        # print(img)
 
         # save filtered image
         imsave(os.path.join(tiff_dir, fov, img_sub_folder, channel + suffix), img,

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -262,12 +262,12 @@ def filter_with_nuclear_mask(fovs, tiff_dir, seg_dir, channel=None,
 
     # if seg_dir is None, the user cannot run filtering
     if seg_dir is None:
-        raise ValueError('seg_dir cannot be set to None for nuclear filtering')
-
-    # if the user doesn't specify a channel, return
-    if channel is None:
-        print("No channel specified for nuclear filtering, skipping")
+        print('No seg_dir provided, you must provide one to run nuclear filtering')
         return
+
+    # raise an error if the provided seg_dir does not exist
+    if not os.path.exists(seg_dir):
+        raise FileNotFoundError('seg_dir %s does not exist' % seg_dir)
 
     # convert to path-compatible format
     if img_sub_folder is None:

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -238,6 +238,63 @@ def smooth_channels(fovs, tiff_dir, img_sub_folder, channels, smooth_vals):
                    chan_out, check_contrast=False)
 
 
+def filter_with_nuclear_mask(fovs, tiff_dir, seg_dir, channel,
+                             img_sub_folder=None, exclude=True):
+    """Filters out background staining using subcellular marker localization.
+
+    Non-nuclear signal is removed from nuclear markers and vice-versa for membrane markers.
+
+    Args:
+        fovs (list):
+            The list of fovs to filter
+        tiff_dir (str):
+            Name of the directory containing the tiff files
+        seg_dir (str):
+            Name of the directory containing the segmented files
+        channel (str):
+            Channel to apply filtering to
+        img_sub_folder (str):
+            Name of the subdirectory inside `tiff_dir` containing the tiff files.
+            Set to `None` if there isn't any.
+        exclude (bool):
+            Whether to filter out nuclear or membrane signal
+    """
+
+    # convert to path-compatible format
+    if img_sub_folder is None:
+        img_sub_folder = ''
+
+    for fov in fovs:
+        # load the channel image in
+        img = load_utils.load_imgs_from_tree(data_dir=tiff_dir, img_sub_folder=img_sub_folder,
+                                             fovs=[fov], channels=[channel]).values[0, :, :, 0]
+
+        # load the segmented image in
+        seg_img = imread(os.path.join(seg_dir, fov + '_feature_1.tif'))[0, ...]
+
+        # print(seg_img)
+
+        # mask out the nucleus
+        if exclude:
+            suffix = '_nuc_exclude.tiff'
+            seg_mask = seg_img > 0
+        # mask out the membrane
+        else:
+            suffix = '_nuc_include.tiff'
+            seg_mask = seg_img == 0
+
+        # print(img)
+        # print(seg_mask)
+
+        # filter out the nucleus or membrane depending on exclude parameter
+        img[seg_mask] = 0
+        # print(img)
+
+        # save filtered image
+        imsave(os.path.join(tiff_dir, fov, img_sub_folder, channel + suffix), img,
+               check_contrast=False)
+
+
 def compute_pixel_cluster_channel_avg(fovs, channels, base_dir, pixel_cluster_col,
                                       pixel_data_dir='pixel_mat_data', keep_count=False):
     """Compute the average channel values across each pixel SOM cluster

--- a/ark/phenotyping/som_utils.py
+++ b/ark/phenotyping/som_utils.py
@@ -238,7 +238,7 @@ def smooth_channels(fovs, tiff_dir, img_sub_folder, channels, smooth_vals):
                    chan_out, check_contrast=False)
 
 
-def filter_with_nuclear_mask(fovs, tiff_dir, seg_dir, channel=None,
+def filter_with_nuclear_mask(fovs, tiff_dir, seg_dir, channel,
                              img_sub_folder=None, exclude=True):
     """Filters out background staining using subcellular marker localization.
 

--- a/ark/phenotyping/som_utils_test.py
+++ b/ark/phenotyping/som_utils_test.py
@@ -628,7 +628,6 @@ def test_filter_with_nuclear_mask(sub_dir, exclude, capsys):
 
             # load in the created channel file
             chan_img = io.imread(os.path.join(tiff_dir, fov, sub_dir, 'chan0' + suffix))
-            # print(chan_img)
 
             # retrieve the nuclear coords for the fov
             fov_nuclear_x, fov_nuclear_y = nuclear_coords[fov]

--- a/ark/phenotyping/som_utils_test.py
+++ b/ark/phenotyping/som_utils_test.py
@@ -11,6 +11,7 @@ import feather
 from matplotlib.colors import ListedColormap
 import numpy as np
 import pandas as pd
+from skimage.draw import circle
 import skimage.io as io
 import scipy.ndimage as ndimage
 from sklearn.utils import shuffle
@@ -542,6 +543,97 @@ def test_smooth_channels(smooth_vals):
         # check that empty list doesn't raise an error
         som_utils.smooth_channels(fovs=fovs, tiff_dir=temp_dir, img_sub_folder='TIFs',
                                   channels=[], smooth_vals=smooth_vals)
+
+
+@parametrize('sub_dir', [None, 'TIFs'])
+@parametrize('exclude', [False, True])
+def test_filter_with_nuclear_mask(sub_dir, exclude):
+    # define the fovs to use
+    fovs = ['fov0', 'fov1', 'fov2']
+
+    # define the channels to use
+    chans = ['chan0', 'chan1']
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # create a directory to store the image data
+        tiff_dir = os.path.join(temp_dir, 'sample_image_data')
+        os.mkdir(tiff_dir)
+
+        # create a segmentation dir
+        seg_dir = os.path.join(temp_dir, 'segmentation')
+        os.mkdir(seg_dir)
+
+        # define the base ellipse center and radius for the dummy nucleus
+        base_center = (4, 4)
+        base_radius = 2
+
+        # store the created nuclear centers for future reference
+        nuclear_coords = {}
+
+        for offset, fov in enumerate(['fov0', 'fov1', 'fov2']):
+            # generate a random segmented image
+            rand_img = np.random.randint(1, 16, size=(1, 10, 10))
+
+            # draw a dummy nucleus and store the coords
+            nuclear_x, nuclear_y = circle(
+                base_center[0] + offset, base_center[1] + offset, base_radius
+            )
+            rand_img[0, nuclear_x, nuclear_y] = 0
+            nuclear_coords[fov] = (nuclear_x, nuclear_y)
+
+            # save the nuclear segmetation
+            file_name = fov + "_feature_1.tif"
+            io.imsave(os.path.join(seg_dir, file_name), rand_img,
+                      check_contrast=False)
+
+        # create sample image data
+        test_utils.create_paired_xarray_fovs(
+            base_dir=tiff_dir, fov_names=fovs,
+            channel_names=chans, sub_dir=sub_dir, img_shape=(10, 10)
+        )
+
+        # run filtering on channel 0
+        som_utils.filter_with_nuclear_mask(
+            fovs, tiff_dir, seg_dir, 'chan0',
+            img_sub_folder=sub_dir, exclude=exclude
+        )
+
+        # use the correct suffix depending on the exclude arg setting
+        suffix = '_nuc_exclude.tiff' if exclude else '_nuc_include.tiff'
+
+        # for each fov, verify that either the nucleus or membrane is all 0
+        # depending on exclude arg setting
+        for fov in fovs:
+            # ensure path correctness if sub_dir is None
+            if sub_dir is None:
+                sub_dir = ''
+
+            # first assert new channel file was created for channel 0, but not channel 1
+            assert os.path.exists(os.path.join(tiff_dir, fov, sub_dir, 'chan0' + suffix))
+            assert not os.path.exists(os.path.join(tiff_dir, fov, sub_dir, 'chan1' + suffix))
+
+            # load in the created channel file
+            chan_img = io.imread(os.path.join(tiff_dir, fov, sub_dir, 'chan0' + suffix))
+            # print(chan_img)
+
+            # retrieve the nuclear coords for the fov
+            fov_nuclear_x, fov_nuclear_y = nuclear_coords[fov]
+
+            # extract the nuclear and membrane values
+            nuclear_vals = chan_img[fov_nuclear_x, fov_nuclear_y]
+
+            mask_arr = np.ones((10, 10), dtype=bool)
+            mask_arr[fov_nuclear_x, fov_nuclear_y] = False
+            membrane_vals = chan_img[mask_arr]
+
+            # assert the nuclear or membrane channel has been filtered out correctly
+            # and the other one is untouched
+            if exclude:
+                assert not np.all(nuclear_vals == 0)
+                assert np.all(membrane_vals == 0)
+            else:
+                assert np.all(nuclear_vals == 0)
+                assert not np.all(membrane_vals == 0)
 
 
 @parametrize('cluster_col', ['pixel_som_cluster', 'pixel_meta_cluster'])
@@ -1487,7 +1579,6 @@ def test_create_pixel_matrix_missing_fov(capsys):
         tiff_dir = os.path.join(temp_dir, 'sample_image_data')
 
         # test the case where we've already written FOVs to both data and subset folder
-        # TODO: place quant_dat.feather in pixel_output_dir after merging in master
         os.remove(os.path.join(temp_dir, 'pixel_mat_data', 'fov1.feather'))
         os.remove(os.path.join(temp_dir, 'pixel_mat_subsetted', 'fov1.feather'))
         sample_quant_data = pd.DataFrame(

--- a/templates_ark/example_pixel_clustering.ipynb
+++ b/templates_ark/example_pixel_clustering.ipynb
@@ -174,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For certain channels, such as membraneous tumor markers, the subcellular localization of the marker isn't important. Instead, what matters is that cells which are positive for the marker show up as positive. In these cases, we have sometimes found it useful to add additional blurring to these markers before clustering. This ensures that more of the pixels within the cell are positive for the marker, instead of only a few pixels at the border, especially for cells which are under-segmented. However, higher blur levels will also cause more of the pixels in neighboring cells to show up as positive. Therefore, this works best when you have other, robust markers (like CD45) which you can use to determine which cells are false positives for the blurred channel. If you have markers in your panel which fit this description, you can add them in the cell below. Then, when specifying the list of markers to include clustering, make sure to add `marker_name_smoothed`, as that is what the tiff will be called"
+    "For certain channels, such as membraneous tumor markers, the subcellular localization of the marker isn't important. Instead, what matters is that cells which are positive for the marker show up as positive. In these cases, we have sometimes found it useful to add additional blurring to these markers before clustering. This ensures that more of the pixels within the cell are positive for the marker, instead of only a few pixels at the border, especially for cells which are under-segmented. However, higher blur levels will also cause more of the pixels in neighboring cells to show up as positive. Therefore, this works best when you have other, robust markers (like CD45) which you can use to determine which cells are false positives for the blurred channel. If you have markers in your panel which fit this description, you can add them in the cell below. Then, when specifying the list of markers to include for clustering, make sure to add `{marker_name}_smoothed`, as that is what the tiff will be called"
    ]
   },
   {
@@ -204,9 +204,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Sometimes, markers will have background staining that you'll want to filter out for the clustering process. Define the name of the marker you want to filter using `filter_channel` (if you don't want to filter any, leave as `None`). If the marker is only present in the nucleus, set `exclude = False` to filter it out from the membrane. Conversely, if the marker is only present in the membrane, set `exclude = True` to filter it out from the nucleus.\n",
+    "\n",
+    "When specifying the list of markers to include for clustering, make sure to add `{marker_name}_nuc_exclude` or `{marker_name}_nuc_include` depending on what type of signal was filtered out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "filter_channels"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "filter_channel = None\n",
+    "nuclear_exclude = True\n",
+    "\n",
+    "som_utils.filter_with_nuclear_mask(\n",
+    "    fovs,\n",
+    "    tiff_dir,\n",
+    "    segmentation_dir,\n",
+    "    filter_channel,\n",
+    "    img_sub_folder,\n",
+    "    nuclear_exclude\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Set the following arguments\n",
     "\n",
-    "* `channels`: set a subset to run pixel clustering over\n",
+    "* `channels`: set a subset to run pixel clustering over.\n",
     "* `blur_factor`: the sigma to use for the Gaussian filter when running the Gaussian blur. Higher values are more aggressive in smoothing signal.\n",
     "* `subset_proportion`: the fraction of pixels to take from each fov. Sampling is random."
    ]

--- a/templates_ark/example_pixel_clustering.ipynb
+++ b/templates_ark/example_pixel_clustering.ipynb
@@ -204,9 +204,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sometimes, markers will have background staining that you'll want to filter out for the clustering process. Define the name of the marker you want to filter using `filter_channel` (if you don't want to filter any, leave as `None`). If the marker is only present in the nucleus, set `exclude = False` to filter it out from the membrane. Conversely, if the marker is only present in the membrane, set `exclude = True` to filter it out from the nucleus.\n",
+    "Sometimes, markers will have background staining that you'll want to filter out for the clustering process. Define the name of the marker you want to filter using `filter_channel`. If the marker is only present in the nucleus, set `exclude = False` to filter it out from the membrane. Conversely, if the marker is only present in the membrane, set `exclude = True` to filter it out from the nucleus.\n",
     "\n",
-    "When specifying the list of markers to include for clustering, make sure to add `{marker_name}_nuc_exclude` or `{marker_name}_nuc_include` depending on what type of signal was filtered out."
+    "When specifying the list of markers to include for clustering, make sure to add `{marker_name}_nuc_exclude` or `{marker_name}_nuc_include` depending on what type of signal was filtered out.\n",
+    "\n",
+    "Skip this cell if you don't want to run marker filtering."
    ]
   },
   {
@@ -219,7 +221,7 @@
    },
    "outputs": [],
    "source": [
-    "filter_channel = None\n",
+    "filter_channel = 'chan_name'\n",
     "nuclear_exclude = True\n",
     "\n",
     "som_utils.filter_with_nuclear_mask(\n",
@@ -778,7 +780,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.12 ('ark-3.7-R')",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -792,7 +794,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.6.13"
   },
   "toc-autonumbering": false,
   "toc-showcode": true,


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #619. Prior to pixel clustering, users may need to filter out non-nuclear marker signal from the nucleus and vice-versa for nuclear marker signal.

**How did you implement your changes**

Add a function `filter_with_nuclear_mask` to `som_utils` which runs this process. The code in #619 provides most of the functionality, however we'll need to make two modifications:

- Ensure `seg_dir is not None` prior to running. Users may run pixel clustering without segmentation labels, however they will not be able to run this function if that's the case because it relies on the `_feature_1.tiff` files.
- Ensure `channel` defaults to `None` in the notebook and function. This is the easiest guard against errors caused by running all the cells at once in the notebook.

The cell that calls this function in `example_pixel_clustering` will be placed after the smoothing process.

This PR also solidifies some of the notebook testing, as it was not using the renamed channels after smoothing. This should also apply for the nuclear filtering tests too.