### PR TITLE
Added Docker Vesion Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.com/angelolab/ark-analysis.svg?branch=master)](https://travis-ci.com/angelolab/ark-analysis)
 [![Coverage Status](https://coveralls.io/repos/github/angelolab/ark-analysis/badge.svg?branch=master)](https://coveralls.io/github/angelolab/ark-analysis?branch=master)
-![Docker Image Version (tag latest semver)](https://img.shields.io/docker/v/angelolab/ark-analysis/v0.4.1?color=%23469ae5&label=Docker%20Version)
+![Docker Image Version (latest by date)](https://img.shields.io/docker/v/angelolab/ark-analysis?arch=amd64&color=%23469ae5&label=Docker%20Version&sort=date)
 
 # ark-analysis
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.com/angelolab/ark-analysis.svg?branch=master)](https://travis-ci.com/angelolab/ark-analysis)
 [![Coverage Status](https://coveralls.io/repos/github/angelolab/ark-analysis/badge.svg?branch=master)](https://coveralls.io/github/angelolab/ark-analysis?branch=master)
+![Docker Image Version (tag latest semver)](https://img.shields.io/docker/v/angelolab/ark-analysis/v0.4.1?color=%23469ae5&label=Docker%20Version)
 
 # ark-analysis
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #671.

**How did you implement your changes**

Adds a Badge that has the version of the current Docker Image. It fetches the latest by release date (currently that's v0.4.1, but it'll auto-update to vX.Y.Z` as new releases get made).

**Remaining issues**

None ATM.