### PR TITLE
Handle variable size images for Deepcell input generation

### DIFF
--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -452,23 +452,24 @@ def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs
         # load the images in the current fov batch
         if is_mibitiff:
             data_xr = load_utils.load_imgs_from_mibitiff(
-                tiff_dir, mibitiff_files=[fov], channels=channels)
+                tiff_dir, mibitiff_files=[fov], channels=channels
+            )
         else:
             data_xr = load_utils.load_imgs_from_tree(
-                tiff_dir, img_sub_folder=img_sub_folder, fovs=[fov], channels=channels)
+                tiff_dir, img_sub_folder=img_sub_folder, fovs=[fov], channels=channels
+            )
 
-        # write each fov data to data_dir
-        for fov in data_xr.fovs.values:
-            out = np.zeros((2, data_xr.shape[1], data_xr.shape[2]), dtype=data_xr.dtype)
+        fov_name = data_xr.fovs.values[0]
+        out = np.zeros((2, data_xr.shape[1], data_xr.shape[2]), dtype=data_xr.dtype)
 
-            # sum over channels and add to output
-            if nuc_channels:
-                out[0] = np.sum(data_xr.loc[fov, :, :, nuc_channels].values, axis=2)
-            if mem_channels:
-                out[1] = np.sum(data_xr.loc[fov, :, :, mem_channels].values, axis=2)
+        # sum over channels and add to output
+        if nuc_channels:
+            out[0] = np.sum(data_xr.loc[fov_name, :, :, nuc_channels].values, axis=2)
+        if mem_channels:
+            out[1] = np.sum(data_xr.loc[fov_name, :, :, mem_channels].values, axis=2)
 
-            save_path = os.path.join(data_dir, f"{fov}.tif")
-            io.imsave(save_path, out, plugin='tifffile', check_contrast=False)
+        save_path = os.path.join(data_dir, f"{fov_name}.tif")
+        io.imsave(save_path, out, plugin='tifffile', check_contrast=False)
 
 
 def stitch_images(data_xr, num_cols):

--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -432,6 +432,7 @@ def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs
             the number of fovs to process at once for each batch
         dtype (str/type):
             optional specifier of image type.  Overwritten with warning for float images
+
     Raises:
         ValueError:
             Raised if nuc_channels and mem_channels are both None or empty
@@ -447,17 +448,14 @@ def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs
     # filter channels for None (just in case)
     channels = [channel for channel in channels if channel is not None]
 
-    # define a list of fov batches to process over
-    fov_batches = [fovs[i:i + batch_size] for i in range(0, len(fovs), batch_size)]
-
-    for fovs in fov_batches:
+    for fov in fovs:
         # load the images in the current fov batch
         if is_mibitiff:
             data_xr = load_utils.load_imgs_from_mibitiff(
-                tiff_dir, mibitiff_files=fovs, channels=channels)
+                tiff_dir, mibitiff_files=[fov], channels=channels)
         else:
             data_xr = load_utils.load_imgs_from_tree(
-                tiff_dir, img_sub_folder=img_sub_folder, fovs=fovs, channels=channels)
+                tiff_dir, img_sub_folder=img_sub_folder, fovs=[fov], channels=channels)
 
         # write each fov data to data_dir
         for fov in data_xr.fovs.values:

--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -405,8 +405,7 @@ def relabel_segmentation(labeled_image, labels_dict):
 
 # TODO: Add metadata for channel name (eliminates need for fixed-order channels)
 def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs,
-                            is_mibitiff=False, img_sub_folder="TIFs", batch_size=5,
-                            dtype="int16"):
+                            is_mibitiff=False, img_sub_folder="TIFs", dtype="int16"):
     """Saves nuclear and membrane channels into deepcell input format.
     Either nuc_channels or mem_channels should be specified.
 
@@ -428,8 +427,6 @@ def generate_deepcell_input(data_dir, tiff_dir, nuc_channels, mem_channels, fovs
         img_sub_folder (str):
             if is_mibitiff is False, define the image subfolder for each fov
             ignored if is_mibitiff is True
-        batch_size (int):
-            the number of fovs to process at once for each batch
         dtype (str/type):
             optional specifier of image type.  Overwritten with warning for float images
 

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -102,10 +102,9 @@ def test_generate_deepcell_input():
             fov2path = os.path.join(temp_dir, 'fov2.tif')
             fov3path = os.path.join(temp_dir, 'fov3.tif')
 
-            # by setting batch_size=2, we test a batch size with a remainder
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs'
             )
 
             fov1 = np.moveaxis(io.imread(fov1path), 0, -1)
@@ -122,7 +121,7 @@ def test_generate_deepcell_input():
 
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs'
             )
 
             nuc_sums = data_xr.loc[:, :, :, nucs].sum(dim='channels').values
@@ -144,7 +143,7 @@ def test_generate_deepcell_input():
 
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs'
             )
 
             fov1 = np.moveaxis(io.imread(fov1path), 0, -1)
@@ -164,7 +163,7 @@ def test_generate_deepcell_input():
 
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs'
             )
 
             fov1 = np.moveaxis(io.imread(fov1path), 0, -1)

--- a/ark/utils/notebooks_test_utils.py
+++ b/ark/utils/notebooks_test_utils.py
@@ -851,7 +851,7 @@ def fov_channel_input_set(tb, fovs=None, nucs_list=None, mems_list=None, is_mibi
     mibitiff_deepcell = """
         data_utils.generate_deepcell_input(
             deepcell_input_dir, tiff_dir, nucs, mems, fovs,
-            is_mibitiff=%s, img_sub_folder="TIFs", batch_size=5
+            is_mibitiff=%s, img_sub_folder="TIFs"
         )
     """ % str(is_mibitiff)
     tb.inject(mibitiff_deepcell, after='gen_input')

--- a/templates_ark/1_Segment_Image_Data.ipynb
+++ b/templates_ark/1_Segment_Image_Data.ipynb
@@ -189,8 +189,7 @@
     "    mems,\n",
     "    fovs,\n",
     "    is_mibitiff=False,\n",
-    "    img_sub_folder=None,\n",
-    "    batch_size=5\n",
+    "    img_sub_folder=None\n",
     ")"
    ]
   },


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #701. If a user specifies a cohort with variable size images, `generate_deepcell_input` will fail because it attempts to batch images of different sizes into one `xarray`. Users should be able to generate this input regardless of the image sizes specified.

**How did you implement your changes**

Because it was observed that batching doesn't improve speed over a per-FOV iteration, we'll change it to the latter. This will be a fail-safe against loading multiple variable-sized images.