### PR TITLE
Support rectangular images for pixel mask generation

### DIFF
--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -248,7 +248,7 @@ def generate_pixel_cluster_mask(fovs, base_dir, tiff_dir, chan_file,
         y_coords = fov_data['column_index'].values
 
         # convert to 1D indexing
-        coordinates = x_coords * img_data.shape[1] + y_coords
+        coordinates = x_coords * img_data.shape[2] + y_coords
 
         # get the cooresponding cluster labels for each pixel
         cluster_labels = list(fov_data[pixel_cluster_col])

--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -559,7 +559,7 @@ def download_example_data(save_dir: Union[str, pathlib.Path]):
     # Downloads the dataset
     ds = datasets.load_dataset("angelolab/ark_example")
 
-    data_path = pathlib.Path(ds["base_dataset"]["Data Path"][0]) / "input_data"
+    data_path = pathlib.Path(ds["base_dataset"]["Data Path"][0]) / "image_data"
 
     shutil.copytree(data_path, pathlib.Path(save_dir) / "image_data",
                     dirs_exist_ok=True, ignore=shutil.ignore_patterns('._*'))

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -472,7 +472,7 @@ def test_generate_pixel_cluster_mask():
         )
 
         # assert we have 3 fovs and the image size is the same as the mask (40, 40)
-        assert pixel_masks.shape == (3, 40, 40)
+        assert pixel_masks.shape == (3, 40, 20)
 
         # assert no value is greater than the highest SOM cluster value (10)
         assert np.all(pixel_masks <= 10)
@@ -484,7 +484,7 @@ def test_generate_pixel_cluster_mask():
         )
 
         # assert we have 3 fovs and the image size is the same as the mask (40, 40)
-        assert pixel_masks.shape == (3, 40, 40)
+        assert pixel_masks.shape == (3, 40, 20)
 
         # assert no value is greater than the highest meta cluster value (5)
         assert np.all(pixel_masks <= 5)

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -1,23 +1,21 @@
-import numpy as np
 import os
+import pathlib
 import tempfile
 from shutil import rmtree
-import pytest
+
 import feather
+import numpy as np
 import pandas as pd
-import xarray as xr
+import pytest
 import skimage.io as io
+import xarray as xr
 
-from ark.utils import data_utils, test_utils
-from ark.utils.data_utils import (
-    generate_and_save_cell_cluster_masks,
-    generate_and_save_pixel_cluster_masks,
-    relabel_segmentation,
-    label_cells_by_cluster
-)
 from ark import settings
-
-parametrize = pytest.mark.parametrize
+from ark.utils import data_utils, test_utils
+from ark.utils.data_utils import (download_example_data,
+                                  generate_and_save_cell_cluster_masks,
+                                  generate_and_save_pixel_cluster_masks,
+                                  label_cells_by_cluster, relabel_segmentation)
 
 
 def test_save_fov_images():
@@ -104,10 +102,9 @@ def test_generate_deepcell_input():
             fov2path = os.path.join(temp_dir, 'fov2.tif')
             fov3path = os.path.join(temp_dir, 'fov3.tif')
 
-            # by setting batch_size=2, we test a batch size with a remainder
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs'
             )
 
             fov1 = np.moveaxis(io.imread(fov1path), 0, -1)
@@ -124,7 +121,7 @@ def test_generate_deepcell_input():
 
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs'
             )
 
             nuc_sums = data_xr.loc[:, :, :, nucs].sum(dim='channels').values
@@ -146,7 +143,7 @@ def test_generate_deepcell_input():
 
             data_utils.generate_deepcell_input(
                 data_dir=temp_dir, tiff_dir=tiff_dir, nuc_channels=nucs, mem_channels=mems,
-                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs', batch_size=2
+                fovs=fovs, is_mibitiff=is_mibitiff, img_sub_folder='TIFs'
             )
 
             fov1 = np.moveaxis(io.imread(fov1path), 0, -1)
@@ -310,7 +307,7 @@ def test_label_cells_by_cluster():
 
 
 def test_generate_cell_cluster_mask():
-    fov = 'fov0'
+    fovs = ['fov0', 'fov1', 'fov2']
     som_cluster_cols = ['pixel_som_cluster_%d' % i for i in np.arange(5)]
     meta_cluster_cols = ['pixel_meta_cluster_%d' % i for i in np.arange(3)]
 
@@ -318,41 +315,54 @@ def test_generate_cell_cluster_mask():
         # bad segmentation path passed
         with pytest.raises(FileNotFoundError):
             data_utils.generate_cell_cluster_mask(
-                fov, temp_dir, 'bad_seg_dir', 'bad_consensus_path'
+                fovs, temp_dir, 'bad_seg_dir', 'bad_consensus_path'
             )
 
-        # generate a sample segmentation mask
-        cell_mask = np.random.randint(low=0, high=5, size=(40, 40), dtype="int16")
-        io.imsave(os.path.join(temp_dir, '%s_feature_0.tif' % fov), cell_mask,
-                  check_contrast=False)
+        # generate sample segmentation masks
+        cell_masks = np.random.randint(low=0, high=5, size=(3, 40, 40, 1), dtype="int16")
+
+        for fov in range(cell_masks.shape[0]):
+            fov_whole_cell = cell_masks[fov, :, :, 0]
+            io.imsave(os.path.join(temp_dir, 'fov%d_feature_0.tif' % fov), fov_whole_cell,
+                      check_contrast=False)
 
         # bad consensus path passed
         with pytest.raises(FileNotFoundError):
             data_utils.generate_cell_cluster_mask(
-                fov, temp_dir, temp_dir, 'bad_consensus_path'
+                fovs, temp_dir, temp_dir, 'bad_consensus_path'
             )
 
         # create a sample cell consensus file based on SOM cluster assignments
-        consensus_data_som = pd.DataFrame(
-            np.random.randint(low=0, high=100, size=(20, 5)), columns=som_cluster_cols
-        )
-
-        consensus_data_som['fov'] = fov
-        consensus_data_som['segmentation_label'] = consensus_data_som.index.values + 1
-        consensus_data_som['cell_som_cluster'] = np.tile(np.arange(1, 6), 4)
-        consensus_data_som['cell_meta_cluster'] = np.tile(np.arange(1, 3), 10)
+        consensus_data_som = pd.DataFrame()
 
         # create a sample cell consensus file based on meta cluster assignments
-        consensus_data_meta = pd.DataFrame(
-            np.random.randint(low=0, high=100, size=(20, 3)), columns=meta_cluster_cols
-        )
+        consensus_data_meta = pd.DataFrame()
 
-        consensus_data_meta['fov'] = fov
-        consensus_data_meta['segmentation_label'] = consensus_data_meta.index.values + 1
-        consensus_data_meta['cell_som_cluster'] = np.tile(np.arange(1, 6), 4)
-        consensus_data_meta['cell_meta_cluster'] = np.tile(np.arange(1, 3), 10)
+        # generate sample cell data with SOM and meta cluster assignments for each fov
+        for fov in fovs:
+            som_data_fov = pd.DataFrame(
+                np.random.randint(low=0, high=100, size=(20, 5)), columns=som_cluster_cols
+            )
 
-        # write both som and meta DataFrames
+            som_data_fov['fov'] = fov
+            som_data_fov['segmentation_label'] = som_data_fov.index.values + 1
+            som_data_fov['cell_som_cluster'] = np.tile(np.arange(1, 6), 4)
+            som_data_fov['cell_meta_cluster'] = np.tile(np.arange(1, 3), 10)
+
+            consensus_data_som = pd.concat([consensus_data_som, som_data_fov])
+
+            meta_data_fov = pd.DataFrame(
+                np.random.randint(low=0, high=100, size=(20, 3)), columns=meta_cluster_cols
+            )
+
+            meta_data_fov['fov'] = fov
+            meta_data_fov['segmentation_label'] = meta_data_fov.index.values + 1
+            meta_data_fov['cell_som_cluster'] = np.tile(np.arange(1, 6), 4)
+            meta_data_fov['cell_meta_cluster'] = np.tile(np.arange(1, 3), 10)
+
+            consensus_data_meta = pd.concat([consensus_data_meta, meta_data_fov])
+
+        # wrote both consensus DataFrames
         feather.write_dataframe(
             consensus_data_som, os.path.join(temp_dir, 'cluster_consensus_som.feather')
         )
@@ -364,54 +374,54 @@ def test_generate_cell_cluster_mask():
         # bad cluster column provided
         with pytest.raises(ValueError):
             data_utils.generate_cell_cluster_mask(
-                fov, temp_dir, temp_dir, 'cluster_consensus_som.feather', 'bad_cluster'
+                fovs, temp_dir, temp_dir, 'cluster_consensus_som.feather', 'bad_cluster'
             )
 
-        # bad fov provided
+        # bad fovs provided
         with pytest.raises(ValueError):
             data_utils.generate_cell_cluster_mask(
-                'fov1', temp_dir, temp_dir,
+                ['fov1', 'fov2', 'fov3'], temp_dir, temp_dir,
                 'cluster_consensus_som.feather', 'cell_som_cluster'
             )
 
         # test on SOM assignments
         cell_masks = data_utils.generate_cell_cluster_mask(
-            fov, temp_dir, temp_dir, 'cluster_consensus_som.feather', 'cell_som_cluster'
+            fovs, temp_dir, temp_dir, 'cluster_consensus_som.feather', 'cell_som_cluster'
         )
 
-        # assert we have 1 fovs and the image size is the same as the mask (40, 40)
-        assert cell_masks.shape == (1, 40, 40)
+        # assert we have 3 fovs and the image size is the same as the mask (40, 40)
+        assert cell_masks.shape == (3, 40, 40)
 
         # assert no value is greater than the highest SOM cluster value (5)
         assert np.all(cell_masks <= 5)
 
         # test on meta assignments
         cell_masks = data_utils.generate_cell_cluster_mask(
-            fov, temp_dir, temp_dir, 'cluster_consensus_meta.feather', 'cell_meta_cluster'
+            fovs, temp_dir, temp_dir, 'cluster_consensus_meta.feather', 'cell_meta_cluster'
         )
 
-        # assert we have 1 fovs and the image size is the same as the mask (40, 40)
-        assert cell_masks.shape == (1, 40, 40)
+        # assert we have 3 fovs and the image size is the same as the mask (40, 40)
+        assert cell_masks.shape == (3, 40, 40)
 
         # assert no value is greater than the highest SOM cluster value (2)
         assert np.all(cell_masks <= 2)
 
 
 def test_generate_pixel_cluster_mask():
-    fov = 'fov0'
+    fovs = ['fov0', 'fov1', 'fov2']
     chans = ['chan0', 'chan1', 'chan2', 'chan3']
 
     with tempfile.TemporaryDirectory() as temp_dir:
         # bad segmentation path passed
         with pytest.raises(FileNotFoundError):
             data_utils.generate_pixel_cluster_mask(
-                fov, temp_dir, 'bad_tiff_dir', 'bad_chan_file', 'bad_consensus_path'
+                fovs, temp_dir, 'bad_tiff_dir', 'bad_chan_file', 'bad_consensus_path'
             )
 
         # bad channel file path passed
         with pytest.raises(FileNotFoundError):
             data_utils.generate_pixel_cluster_mask(
-                fov, temp_dir, temp_dir, 'bad_chan_file', 'bad_consensus_path'
+                fovs, temp_dir, temp_dir, 'bad_chan_file', 'bad_consensus_path'
             )
 
         # generate sample fov folder with one channel value, no sub folder
@@ -423,68 +433,69 @@ def test_generate_pixel_cluster_mask():
         # bad consensus path passed
         with pytest.raises(FileNotFoundError):
             data_utils.generate_pixel_cluster_mask(
-                fov, temp_dir, temp_dir, os.path.join('fov0', 'chan0.tif'), 'bad_consensus_path'
+                fovs, temp_dir, temp_dir, os.path.join('fov0', 'chan0.tif'), 'bad_consensus_path'
             )
 
         # create a dummy consensus directory
         os.mkdir(os.path.join(temp_dir, 'pixel_mat_consensus'))
 
-        # create dummy data containing SOM and consensus labels for the fov
-        consensus_data = pd.DataFrame(np.random.rand(100, 4), columns=chans)
-        consensus_data['pixel_som_cluster'] = np.tile(np.arange(1, 11), 10)
-        consensus_data['pixel_meta_cluster'] = np.tile(np.arange(1, 6), 20)
-        consensus_data['row_index'] = np.random.randint(low=0, high=40, size=100)
-        consensus_data['column_index'] = np.random.randint(low=0, high=20, size=100)
+        # create dummy data containing SOM and consensus labels for each fov
+        for fov in fovs:
+            consensus_data = pd.DataFrame(np.random.rand(100, 4), columns=chans)
+            consensus_data['pixel_som_cluster'] = np.tile(np.arange(1, 11), 10)
+            consensus_data['pixel_meta_cluster'] = np.tile(np.arange(1, 6), 20)
+            consensus_data['row_index'] = np.random.randint(low=0, high=40, size=100)
+            consensus_data['column_index'] = np.random.randint(low=0, high=20, size=100)
 
-        feather.write_dataframe(
-            consensus_data, os.path.join(temp_dir, 'pixel_mat_consensus', fov + '.feather')
-        )
+            feather.write_dataframe(
+                consensus_data, os.path.join(temp_dir, 'pixel_mat_consensus', fov + '.feather')
+            )
 
         # bad cluster column provided
         with pytest.raises(ValueError):
             data_utils.generate_pixel_cluster_mask(
-                fov, temp_dir, temp_dir, os.path.join('fov0', 'chan0.tif'),
+                fovs, temp_dir, temp_dir, os.path.join('fov0', 'chan0.tif'),
                 'pixel_mat_consensus', 'bad_cluster'
             )
 
-        # bad fov provided
+        # bad fovs provided
         with pytest.raises(ValueError):
             data_utils.generate_pixel_cluster_mask(
-                'fov1', temp_dir, temp_dir, os.path.join('fov0', 'chan0.tif'),
+                ['fov1', 'fov2', 'fov3'], temp_dir, temp_dir, os.path.join('fov0', 'chan0.tif'),
                 'pixel_mat_consensus', 'pixel_som_cluster'
             )
 
         # test on SOM assignments
         pixel_masks = data_utils.generate_pixel_cluster_mask(
-            fov, temp_dir, temp_dir, os.path.join('fov0', 'chan0.tif'),
+            fovs, temp_dir, temp_dir, os.path.join('fov0', 'chan0.tif'),
             'pixel_mat_consensus', 'pixel_som_cluster'
         )
 
-        # assert we have 1 fov and the image size is the same as the mask (40, 40)
-        assert pixel_masks.shape == (1, 40, 20)
+        # assert we have 3 fovs and the image size is the same as the mask (40, 40)
+        assert pixel_masks.shape == (3, 40, 40)
 
         # assert no value is greater than the highest SOM cluster value (10)
         assert np.all(pixel_masks <= 10)
 
         # test on meta assignments
         pixel_masks = data_utils.generate_pixel_cluster_mask(
-            fov, temp_dir, temp_dir, os.path.join('fov0', 'chan0.tif'),
+            fovs, temp_dir, temp_dir, os.path.join('fov0', 'chan0.tif'),
             'pixel_mat_consensus', 'pixel_meta_cluster'
         )
 
-        # assert we have 1 fov and the image size is the same as the mask (40, 40)
-        assert pixel_masks.shape == (1, 40, 20)
+        # assert we have 3 fovs and the image size is the same as the mask (40, 40)
+        assert pixel_masks.shape == (3, 40, 40)
 
         # assert no value is greater than the highest meta cluster value (5)
         assert np.all(pixel_masks <= 5)
 
 
-@parametrize('sub_dir', [None, 'sub_dir'])
-@parametrize('name_suffix', ['', 'sample_suffix'])
-def test_generate_and_save_pixel_cluster_masks(sub_dir, name_suffix):
+def test_generate_and_save_pixel_cluster_masks():
     fov_count = 7
     fovs = [f"fov{i}" for i in range(fov_count)]
     chans = ['chan0', 'chan1', 'chan2', 'chan3']
+
+    batch_sizes = [1, 2, 3, 5, 10]
 
     with tempfile.TemporaryDirectory() as temp_dir:
         # create a dummy consensus directory
@@ -513,34 +524,34 @@ def test_generate_and_save_pixel_cluster_masks(sub_dir, name_suffix):
                 consensus_data, os.path.join(temp_dir, 'pixel_mat_consensus', fov + '.feather')
             )
 
-        generate_and_save_pixel_cluster_masks(fovs=fovs,
-                                              base_dir=temp_dir,
-                                              save_dir=os.path.join(temp_dir, 'pixel_masks'),
-                                              tiff_dir=temp_dir,
-                                              chan_file=os.path.join('fov0', 'chan0.tif'),
-                                              pixel_data_dir='pixel_mat_consensus',
-                                              pixel_cluster_col='pixel_meta_cluster',
-                                              sub_dir=sub_dir,
-                                              name_suffix=name_suffix)
+        # Test various batch_sizes, no sub_dir, name_suffix = ''.
+        for batch_size in batch_sizes:
+            generate_and_save_pixel_cluster_masks(fovs=fovs,
+                                                  base_dir=temp_dir,
+                                                  save_dir=os.path.join(temp_dir, 'pixel_masks'),
+                                                  tiff_dir=temp_dir,
+                                                  chan_file=os.path.join('fov0', 'chan0.tif'),
+                                                  pixel_data_dir='pixel_mat_consensus',
+                                                  pixel_cluster_col='pixel_meta_cluster',
+                                                  sub_dir=None,
+                                                  name_suffix=name_suffix,
+                                                  batch_size=batch_size)
 
-        # Open each pixel mask and make sure the shape and values are valid.
-        if sub_dir is None:
-            sub_dir = ''
-
-        for fov in fovs:
-            fov_name = fov + name_suffix + ".tiff"
-            pixel_mask = io.imread(os.path.join(temp_dir, 'pixel_masks', sub_dir, fov_name))
-            assert pixel_mask.shape == (40, 40)
-            assert np.all(pixel_mask <= 5)
+            # Open each pixel mask and make sure the shape and values are valid.
+            for fov in fovs:
+                fov_name = fov + name_suffix + ".tiff"
+                pixel_mask = io.imread(os.path.join(temp_dir, 'pixel_masks', fov_name))
+                assert pixel_mask.shape == (40, 40)
+                assert np.all(pixel_mask <= 5)
 
 
-@parametrize('sub_dir', [None, 'sub_dir'])
-@parametrize('name_suffix', ['', 'sample_suffix'])
-def test_generate_and_save_cell_cluster_masks(sub_dir, name_suffix):
+def test_generate_and_save_cell_cluster_masks():
     fov_count = 7
     fovs = [f"fov{i}" for i in range(fov_count)]
     som_cluster_cols = ['pixel_som_cluster_%d' % i for i in np.arange(5)]
     meta_cluster_cols = ['pixel_meta_cluster_%d' % i for i in np.arange(3)]
+
+    batch_sizes = [1, 2, 3, 5, 10]
 
     with tempfile.TemporaryDirectory() as temp_dir:
         # Create a save directory
@@ -594,23 +605,46 @@ def test_generate_and_save_cell_cluster_masks(sub_dir, name_suffix):
         )
 
         # Test various batch_sizes, no sub_dir, name_suffix = ''.
-        generate_and_save_cell_cluster_masks(fovs=fovs,
-                                             base_dir=temp_dir,
-                                             save_dir=os.path.join(temp_dir, 'cell_masks'),
-                                             seg_dir=temp_dir,
-                                             cell_data_name='cluster_consensus_som.feather',
-                                             cell_cluster_col='cell_som_cluster',
-                                             seg_suffix='_feature_0.tif',
-                                             sub_dir=sub_dir,
-                                             name_suffix=name_suffix
-                                             )
+        for batch_size in batch_sizes:
+            generate_and_save_cell_cluster_masks(fovs=fovs,
+                                                 base_dir=temp_dir,
+                                                 save_dir=os.path.join(temp_dir, 'cell_masks'),
+                                                 seg_dir=temp_dir,
+                                                 cell_data_name='cluster_consensus_som.feather',
+                                                 cell_cluster_col='cell_som_cluster',
+                                                 seg_suffix='_feature_0.tif',
+                                                 sub_dir=None,
+                                                 batch_size=batch_size
+                                                 )
 
-        if sub_dir is None:
-            sub_dir = ''
+            # Open each pixel mask and make sure the shape and values are valid.
+            for fov in fovs:
+                fov_name = fov + ".tiff"
+                pixel_mask = io.imread(os.path.join(temp_dir, 'cell_masks', fov_name))
+                assert pixel_mask.shape == (40, 40)
+                assert np.all(pixel_mask <= 5)
 
-        # Open each pixel mask and make sure the shape and values are valid.
-        for fov in fovs:
-            fov_name = fov + name_suffix + ".tiff"
-            pixel_mask = io.imread(os.path.join(temp_dir, 'cell_masks', sub_dir, fov_name))
-            assert pixel_mask.shape == (40, 40)
-            assert np.all(pixel_mask <= 5)
+
+def test_download_example_data():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        download_example_data(save_dir=pathlib.Path(temp_dir) / "example_dataset")
+
+        fov_names = [f"fov{i}" for i in range(11)]
+        input_data_path = pathlib.Path(temp_dir) / "example_dataset/image_data"
+
+        # Get downloaded + moved fov names.
+        downloaded_fovs = list(input_data_path.glob("*"))
+        print(downloaded_fovs)
+        downloaded_fov_names = [f.stem for f in downloaded_fovs]
+
+        # Assert that all the fovs exist after copying the data to "image_data/input_data"
+        assert set(fov_names) == set(downloaded_fov_names)
+
+        channel_names = ["CD3", "CD4", "CD8", "CD14", "CD20", "CD31", "CD45", "CD68", "CD163",
+                         "CK17", "Collagen1", "ECAD", "Fibronectin", "GLUT1", "H3K9ac",
+                         "H3K27me3", "HLADR", "IDO", "Ki67", "PD1", "SMA", "Vim"]
+
+        # Assert that for each fov, all 22 channels exist
+        for fov in downloaded_fovs:
+            c_names = [c.stem for c in fov.rglob("*")]
+            assert set(channel_names) == set(c_names)

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -637,7 +637,7 @@ def test_download_example_data():
         print(downloaded_fovs)
         downloaded_fov_names = [f.stem for f in downloaded_fovs]
 
-        # Assert that all the fovs exist after copying the data to "image_data/input_data"
+        # Assert that all the fovs exist after copying the data to "image_data/image_data"
         assert set(fov_names) == set(downloaded_fov_names)
 
         channel_names = ["CD3", "CD4", "CD8", "CD14", "CD20", "CD31", "CD45", "CD68", "CD163",


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #719. The pixel mask generation function assumes square MIBI images, however we're now seeing cohorts being run on rectangular images that will make this assumption fail. This is a problem for pixel mask generation in particular, as it's flattening and reindexing method will throw an error under.

**How did you implement your changes**

We need to change the indexing multiplier to be the number of columns. Previously, we could assume the number of rows equalled the number of columns, so the row axis size was used for convenience sake of accessing the first available axis. 

**Remaining issues**

@jonhsussman may have additional input.
