### PR TITLE
Edit spatial enrichment notebook to only load in desired features

### DIFF
--- a/templates_ark/example_pairwise_spatial_enrichment.ipynb
+++ b/templates_ark/example_pairwise_spatial_enrichment.ipynb
@@ -128,7 +128,7 @@
    "source": [
     "# This is the Xarray of label maps for multiple fovs from which the distance matrix will be computed\n",
     "#label_maps = xr.load_dataarray(os.path.join(spatial_analysis_dir, \"segmentation_labels.xr\"))\n",
-    "label_maps = load_utils.load_imgs_from_dir(deepcell_output, xr_channel_names=['segmentation_label'], trim_suffix='_feature_0')\n",
+    "label_maps = load_utils.load_imgs_from_dir(deepcell_output, xr_channel_names=['segmentation_label'], match_substring='_feature_0', trim_suffix='_feature_0')\n",
     "\n",
     "# Get dictionary object with the respective distance matrices for the fovs\n",
     "dist_mats = spatial_analysis_utils.calc_dist_matrix(label_maps)"
@@ -236,7 +236,7 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -250,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #724. 

**How did you implement your changes**

Add the arg `match_substring` to the `load_imgs_from_dir()` call to make sure only the specified feature images are loaded. @cwalker8 tested and approved

