### PR TITLE
Speed up `relabel_segmentation`

### DIFF
--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -7,7 +7,9 @@ from typing import List, Union
 import datasets
 import feather
 import numpy as np
+import pandas as pd
 import skimage.io as io
+from skimage.measure import regionprops_table
 import xarray as xr
 from tqdm.notebook import tqdm_notebook as tqdm
 
@@ -393,14 +395,54 @@ def relabel_segmentation(labeled_image, labels_dict):
             The relabeled array.
     """
 
+    # print("Copying image")
+    # img = np.copy(labeled_image)
+    # print("Getting unique cell IDs")
+    # unique_cell_ids = np.unique(labeled_image)
+    # print("Keeping just non-zero cell IDs")
+    # unique_cell_ids = unique_cell_ids[np.nonzero(unique_cell_ids)]
+    # print("Generating regionprops_table")
+    # cell_props = pd.DataFrame(regionprops_table(labeled_image,
+    #                                             properties=['label', 'coords']))
+
+    # print("Assigning default_label")
+    # default_label = max(labels_dict.values()) + 1
+    # for cell_id in unique_cell_ids:
+    #     print("Processing cell_id %d" % cell_id)
+    #     coords = cell_props.loc[cell_props['label'] == cell_id, 'coords'].values[0]
+    #     img[coords] = labels_dict.get(cell_id, default_label)
+    #     img[labeled_image == cell_id] = labels_dict.get(cell_id, default_label)
+    # return img
+
+    # print("Copying image")
+    # img = np.copy(labeled_image)
+    # print("Getting unique cell IDs")
+    # unique_cell_ids = np.unique(labeled_image)
+    # print("Keeping just non-zero cell IDs")
+    # unique_cell_ids = unique_cell_ids[np.nonzero(unique_cell_ids)]
+
+    # print("Assigning default_label")
+    # default_label = max(labels_dict.values()) + 1
+    # for cell_id in unique_cell_ids:
+    #     print("Processing cell_id %d" % cell_id)
+    #     img[labeled_image == cell_id] = labels_dict.get(cell_id, default_label)
+    # return img
+
     img = np.copy(labeled_image)
     unique_cell_ids = np.unique(labeled_image)
     unique_cell_ids = unique_cell_ids[np.nonzero(unique_cell_ids)]
 
     default_label = max(labels_dict.values()) + 1
-    for cell_id in unique_cell_ids:
-        img[labeled_image == cell_id] = labels_dict.get(cell_id, default_label)
-    return img
+
+    def relabel(x):
+        return labels_dict.get(x, default_label)
+
+    relabeled_img = np.vectorize(relabel)(img)
+
+    # relabel_func = relabel
+    # relabeled_img = relabel_func(img)
+
+    return relabeled_img
 
 
 # TODO: Add metadata for channel name (eliminates need for fixed-order channels)

--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -395,39 +395,6 @@ def relabel_segmentation(labeled_image, labels_dict):
             The relabeled array.
     """
 
-    # print("Copying image")
-    # img = np.copy(labeled_image)
-    # print("Getting unique cell IDs")
-    # unique_cell_ids = np.unique(labeled_image)
-    # print("Keeping just non-zero cell IDs")
-    # unique_cell_ids = unique_cell_ids[np.nonzero(unique_cell_ids)]
-    # print("Generating regionprops_table")
-    # cell_props = pd.DataFrame(regionprops_table(labeled_image,
-    #                                             properties=['label', 'coords']))
-
-    # print("Assigning default_label")
-    # default_label = max(labels_dict.values()) + 1
-    # for cell_id in unique_cell_ids:
-    #     print("Processing cell_id %d" % cell_id)
-    #     coords = cell_props.loc[cell_props['label'] == cell_id, 'coords'].values[0]
-    #     img[coords] = labels_dict.get(cell_id, default_label)
-    #     img[labeled_image == cell_id] = labels_dict.get(cell_id, default_label)
-    # return img
-
-    # print("Copying image")
-    # img = np.copy(labeled_image)
-    # print("Getting unique cell IDs")
-    # unique_cell_ids = np.unique(labeled_image)
-    # print("Keeping just non-zero cell IDs")
-    # unique_cell_ids = unique_cell_ids[np.nonzero(unique_cell_ids)]
-
-    # print("Assigning default_label")
-    # default_label = max(labels_dict.values()) + 1
-    # for cell_id in unique_cell_ids:
-    #     print("Processing cell_id %d" % cell_id)
-    #     img[labeled_image == cell_id] = labels_dict.get(cell_id, default_label)
-    # return img
-
     img = np.copy(labeled_image)
     unique_cell_ids = np.unique(labeled_image)
     unique_cell_ids = unique_cell_ids[np.nonzero(unique_cell_ids)]
@@ -435,12 +402,12 @@ def relabel_segmentation(labeled_image, labels_dict):
     default_label = max(labels_dict.values()) + 1
 
     def relabel(x):
+        if x == 0:
+            return 0
+
         return labels_dict.get(x, default_label)
 
     relabeled_img = np.vectorize(relabel)(img)
-
-    # relabel_func = relabel
-    # relabeled_img = relabel_func(img)
 
     return relabeled_img
 

--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -394,13 +394,9 @@ def relabel_segmentation(labeled_image, labels_dict):
 
     default_label = max(labels_dict.values()) + 1
 
-    def relabel(x):
-        if x == 0:
-            return 0
-
-        return labels_dict.get(x, default_label)
-
-    relabeled_img = np.vectorize(relabel)(img)
+    relabeled_img = np.vectorize(
+        lambda x: labels_dict.get(x, default_label) if x != 0 else 0
+    )(img)
 
     return relabeled_img
 

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -246,21 +246,6 @@ def test_split_img_stack():
         assert np.array_equal(sample_chan_2, data_xr[0, :, :, 1].values)
 
 
-def test_relabel_segmentation_xtreme():
-    x = y = 10000
-    print("Generating img_arr")
-    img_arr = np.arange(1, x * y + 1).reshape((x, y))
-    print("Generating labels_dict")
-    d = {i: i + 1 for i in range(1, x * y + 1)}
-
-    import timeit
-    print("Starting relabeling")
-    start = timeit.default_timer()
-    res = relabel_segmentation(img_arr, d)
-    end = timeit.default_timer()
-    print("Total time to relabel: %.2f" % (end - start))
-
-
 def test_relabel_segmentation():
     x = y = 5
     img_arr = np.arange(1, x * y + 1).reshape((x, y))

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -244,6 +244,21 @@ def test_split_img_stack():
         assert np.array_equal(sample_chan_2, data_xr[0, :, :, 1].values)
 
 
+def test_relabel_segmentation_xtreme():
+    x = y = 10000
+    print("Generating img_arr")
+    img_arr = np.arange(1, x * y + 1).reshape((x, y))
+    print("Generating labels_dict")
+    d = {i: i + 1 for i in range(1, x * y + 1)}
+
+    import timeit
+    print("Starting relabeling")
+    start = timeit.default_timer()
+    res = relabel_segmentation(img_arr, d)
+    end = timeit.default_timer()
+    print("Total time to relabel: %.2f" % (end - start))
+
+
 def test_relabel_segmentation():
     x = y = 5
     img_arr = np.arange(1, x * y + 1).reshape((x, y))


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #722. With very large images with a high number of cells, `relabel_segmentation` will take hours to complete because of the way boolean indexing works. Additionally, very large 2-D NumPy arrays can cause cache misses due to the way they're non-contiguously stored in memory.

**How did you implement your changes**

Using `np.vectorize` provides a significant speed up.

**Remaining issues**

@jonhsussman can you check out this branch and verify that it runs efficiently? When I timed your looped version versus the `np.vectorize` version, the latter ran about 2-2.5x faster, but that was on test data (we unfortunately don't have images of your size on hand at our lab). I can convert this back to a looped version if you find the opposite to be true.