### PR TITLE
Remove `batch_size` parameter from spatial analysis functions

### DIFF
--- a/ark/analysis/spatial_analysis.py
+++ b/ark/analysis/spatial_analysis.py
@@ -9,9 +9,8 @@ import ark.settings as settings
 from ark.utils import io_utils, load_utils, misc_utils, spatial_analysis_utils
 
 
-def batch_channel_spatial_enrichment(label_dir, marker_thresholds, all_data, batch_size=5,
-                                     suffix='_feature_0', xr_channel_name='segmentation_label',
-                                     **kwargs):
+def batch_channel_spatial_enrichment(label_dir, marker_thresholds, all_data, suffix='_feature_0',
+                                     xr_channel_name='segmentation_label', **kwargs):
     """Wrapper function for batching calls to `calculate_channel_spatial_enrichment` over fovs
 
     Args:
@@ -21,8 +20,6 @@ def batch_channel_spatial_enrichment(label_dir, marker_thresholds, all_data, bat
             threshold values for positive marker expression
         all_data (pandas.DataFrame):
             data including fovs, cell labels, and cell expression matrix for all markers
-        batch_size (int):
-            fov count to load into memory at a time
         suffix (str):
             suffix for tif file names
         xr_channel_name (str):
@@ -49,15 +46,12 @@ def batch_channel_spatial_enrichment(label_dir, marker_thresholds, all_data, bat
         all_label_names = \
             [all_label_names[i] for i, fov in enumerate(label_fovs) if fov in included_fovs]
 
-    batching_strategy = \
-        [all_label_names[i:i + batch_size] for i in range(0, len(all_label_names), batch_size)]
-
     # create containers for batched return values
     values = []
     stats_datasets = []
 
-    for batch_names in tqdm(batching_strategy, desc="Batch Completion", unit="batch"):
-        label_maps = load_utils.load_imgs_from_dir(label_dir, files=batch_names,
+    for label_name in tqdm(all_label_names, desc="Batch Completion", unit="batch"):
+        label_maps = load_utils.load_imgs_from_dir(label_dir, files=[label_name],
                                                    xr_channel_names=[xr_channel_name],
                                                    trim_suffix=suffix)
 
@@ -232,7 +226,7 @@ def calculate_channel_spatial_enrichment(dist_matrices_dict, marker_thresholds, 
     return values, stats
 
 
-def batch_cluster_spatial_enrichment(label_dir, all_data, batch_size=5, suffix='_feature_0',
+def batch_cluster_spatial_enrichment(label_dir, all_data, suffix='_feature_0',
                                      xr_channel_name='segmentation_label', **kwargs):
     """ Wrapper function for batching calls to `calculate_cluster_spatial_enrichment` over fovs
 
@@ -241,8 +235,6 @@ def batch_cluster_spatial_enrichment(label_dir, all_data, batch_size=5, suffix='
             directory containing labeled tiffs
         all_data (pandas.DataFrame):
             data including fovs, cell labels, and cell expression matrix for all markers
-        batch_size (int):
-            fov count to load into memory at a time
         suffix (str):
             suffix for tif file names
         xr_channel_name (str):
@@ -269,15 +261,12 @@ def batch_cluster_spatial_enrichment(label_dir, all_data, batch_size=5, suffix='
         all_label_names = \
             [all_label_names[i] for i, fov in enumerate(label_fovs) if fov in included_fovs]
 
-    batching_strategy = \
-        [all_label_names[i:i + batch_size] for i in range(0, len(all_label_names), batch_size)]
-
     # create containers for batched return values
     values = []
     stats_datasets = []
 
-    for batch_names in tqdm(batching_strategy, desc="Batch Completion", unit="batch"):
-        label_maps = load_utils.load_imgs_from_dir(label_dir, files=batch_names,
+    for label_name in tqdm(all_label_names, desc="Batch Completion", unit="batch"):
+        label_maps = load_utils.load_imgs_from_dir(label_dir, files=[label_name],
                                                    xr_channel_names=[xr_channel_name],
                                                    trim_suffix=suffix)
 

--- a/ark/analysis/spatial_analysis.py
+++ b/ark/analysis/spatial_analysis.py
@@ -9,8 +9,9 @@ import ark.settings as settings
 from ark.utils import io_utils, load_utils, misc_utils, spatial_analysis_utils
 
 
-def generate_channel_spatial_enrichment_stats(label_dir, marker_thresholds, all_data, suffix='_feature_0',
-                                              xr_channel_name='segmentation_label', **kwargs):
+def generate_channel_spatial_enrichment_stats(label_dir, marker_thresholds, all_data,
+                                              suffix='_feature_0', xr_channel_name='segmentation_label',
+                                              **kwargs):
     """Wrapper function for batching calls to `calculate_channel_spatial_enrichment` over fovs
 
     Args:

--- a/ark/analysis/spatial_analysis.py
+++ b/ark/analysis/spatial_analysis.py
@@ -10,8 +10,8 @@ from ark.utils import io_utils, load_utils, misc_utils, spatial_analysis_utils
 
 
 def generate_channel_spatial_enrichment_stats(label_dir, marker_thresholds, all_data,
-                                              suffix='_feature_0', xr_channel_name='segmentation_label',
-                                              **kwargs):
+                                              suffix='_feature_0',
+                                              xr_channel_name='segmentation_label', **kwargs):
     """Wrapper function for batching calls to `calculate_channel_spatial_enrichment` over fovs
 
     Args:

--- a/ark/analysis/spatial_analysis.py
+++ b/ark/analysis/spatial_analysis.py
@@ -9,8 +9,8 @@ import ark.settings as settings
 from ark.utils import io_utils, load_utils, misc_utils, spatial_analysis_utils
 
 
-def batch_channel_spatial_enrichment(label_dir, marker_thresholds, all_data, suffix='_feature_0',
-                                     xr_channel_name='segmentation_label', **kwargs):
+def generate_channel_spatial_enrichment_stats(label_dir, marker_thresholds, all_data, suffix='_feature_0',
+                                              xr_channel_name='segmentation_label', **kwargs):
     """Wrapper function for batching calls to `calculate_channel_spatial_enrichment` over fovs
 
     Args:
@@ -226,8 +226,8 @@ def calculate_channel_spatial_enrichment(dist_matrices_dict, marker_thresholds, 
     return values, stats
 
 
-def batch_cluster_spatial_enrichment(label_dir, all_data, suffix='_feature_0',
-                                     xr_channel_name='segmentation_label', **kwargs):
+def generate_cluster_spatial_enrichment_stats(label_dir, all_data, suffix='_feature_0',
+                                              xr_channel_name='segmentation_label', **kwargs):
     """ Wrapper function for batching calls to `calculate_cluster_spatial_enrichment` over fovs
 
     Args:

--- a/ark/analysis/spatial_analysis_test.py
+++ b/ark/analysis/spatial_analysis_test.py
@@ -34,9 +34,8 @@ list(map(
 
 
 def test_batch_channel_spatial_enrichment():
-
-    # since the functionality if channel spatial enrichment is tested later,
-    # only the batching needs to be tested
+    # since the functionality of channel spatial enrichment is tested later,
+    # only the number of elements returned and the included_fovs argument needs testing
     marker_thresholds = test_utils._make_threshold_mat(in_utils=False)
 
     with tempfile.TemporaryDirectory() as label_dir:
@@ -54,40 +53,29 @@ def test_batch_channel_spatial_enrichment():
         vals_pos, stats_pos = \
             spatial_analysis.calculate_channel_spatial_enrichment(
                 dist_mats, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
-                bootstrap_num=100, dist_lim=100)
-
-        vals_pos_batch, stats_pos_batch = \
-            spatial_analysis.batch_channel_spatial_enrichment(
-                label_dir, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
-                bootstrap_num=100, dist_lim=100, batch_size=5)
-
-        vals_pos_batch_2, stats_pos_batch_2 = \
-            spatial_analysis.batch_channel_spatial_enrichment(
-                label_dir, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
-                bootstrap_num=100, dist_lim=100, batch_size=1
+                bootstrap_num=100, dist_lim=100
             )
 
-        np.testing.assert_equal(vals_pos[0][0], vals_pos_batch[0][0])
-        np.testing.assert_equal(vals_pos[1][0], vals_pos_batch[1][0])
-
-        # batch function should match for multi batch process
-        np.testing.assert_equal(vals_pos[0][0], vals_pos_batch_2[0][0])
-        np.testing.assert_equal(vals_pos[1][0], vals_pos_batch_2[1][0])
+        # both fov8 and fov9 should be returned
+        assert len(vals_pos) == 2
 
         vals_pos_fov8, stats_pos_fov8 = \
             spatial_analysis.batch_channel_spatial_enrichment(
                 label_dir, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
-                bootstrap_num=100, dist_lim=100, batch_size=5, included_fovs=["fov8"]
+                bootstrap_num=100, dist_lim=100, included_fovs=["fov8"]
             )
 
+        # the fov8 values in vals_pos_fov8 should be the same as in vals_pos
         np.testing.assert_equal(vals_pos_fov8[0][0], vals_pos[0][0])
+
+        # only fov8 should be returned
         assert len(vals_pos_fov8) == 1
 
 
 def test_batch_cluster_spatial_enrichment():
 
     # since the functionality if channel spatial enrichment is tested later,
-    # only the batching needs to be tested
+    # only the number of elements returned and the included_fovs argument needs testing
     with tempfile.TemporaryDirectory() as label_dir:
         test_utils._write_labels(label_dir, ["fov8", "fov9"], ["segmentation_label"], (10, 10),
                                  '', True, np.uint8, suffix='_feature_0')
@@ -101,29 +89,21 @@ def test_batch_cluster_spatial_enrichment():
 
         vals_pos, stats_pos = \
             spatial_analysis.calculate_cluster_spatial_enrichment(
-                all_data, dist_mats, bootstrap_num=100, dist_lim=100)
+                all_data, dist_mats, bootstrap_num=100, dist_lim=100
+            )
 
-        vals_pos_batch, stats_pos_batch = \
-            spatial_analysis.batch_cluster_spatial_enrichment(
-                label_dir, all_data, bootstrap_num=100, dist_lim=100, batch_size=5)
-
-        vals_pos_batch_2, stats_pos_batch_2 = \
-            spatial_analysis.batch_cluster_spatial_enrichment(
-                label_dir, all_data, bootstrap_num=100, dist_lim=100, batch_size=1)
-
-        np.testing.assert_equal(vals_pos[0][0], vals_pos_batch[0][0])
-        np.testing.assert_equal(vals_pos[1][0], vals_pos_batch[1][0])
-
-        # batch function should match for multi batch process
-        np.testing.assert_equal(vals_pos[0][0], vals_pos_batch_2[0][0])
-        np.testing.assert_equal(vals_pos[1][0], vals_pos_batch_2[1][0])
+        # both fov8 and fov9 should be returned
+        assert len(vals_pos) == 2
 
         vals_pos_fov8, stats_pos_fov8 = \
             spatial_analysis.batch_cluster_spatial_enrichment(
-                label_dir, all_data, bootstrap_num=100, dist_lim=100, batch_size=5,
-                included_fovs=["fov8"])
+                label_dir, all_data, bootstrap_num=100, dist_lim=100, included_fovs=["fov8"]
+            )
 
+        # the fov8 values in vals_pos_fov8 should be the same as in vals_pos
         np.testing.assert_equal(vals_pos_fov8[0][0], vals_pos[0][0])
+
+        # only fov8 should be returned
         assert len(vals_pos_fov8) == 1
 
 

--- a/ark/analysis/spatial_analysis_test.py
+++ b/ark/analysis/spatial_analysis_test.py
@@ -33,7 +33,7 @@ list(map(
 ))
 
 
-def test_batch_channel_spatial_enrichment():
+def test_generate_channel_spatial_enrichment_stats():
     # since the functionality of channel spatial enrichment is tested later,
     # only the number of elements returned and the included_fovs argument needs testing
     marker_thresholds = test_utils._make_threshold_mat(in_utils=False)
@@ -51,7 +51,7 @@ def test_batch_channel_spatial_enrichment():
         all_data = test_utils.spoof_cell_table_from_labels(label_maps)
 
         vals_pos, stats_pos = \
-            spatial_analysis.calculate_channel_spatial_enrichment(
+            spatial_analysis.generate_channel_spatial_enrichment_stats(
                 dist_mats, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
                 bootstrap_num=100, dist_lim=100
             )
@@ -60,7 +60,7 @@ def test_batch_channel_spatial_enrichment():
         assert len(vals_pos) == 2
 
         vals_pos_fov8, stats_pos_fov8 = \
-            spatial_analysis.batch_channel_spatial_enrichment(
+            spatial_analysis.generate_channel_spatial_enrichment_stats(
                 label_dir, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
                 bootstrap_num=100, dist_lim=100, included_fovs=["fov8"]
             )
@@ -72,7 +72,7 @@ def test_batch_channel_spatial_enrichment():
         assert len(vals_pos_fov8) == 1
 
 
-def test_batch_cluster_spatial_enrichment():
+def test_generate_cluster_spatial_enrichment_stats():
 
     # since the functionality if channel spatial enrichment is tested later,
     # only the number of elements returned and the included_fovs argument needs testing
@@ -88,7 +88,7 @@ def test_batch_cluster_spatial_enrichment():
         all_data = test_utils.spoof_cell_table_from_labels(label_maps)
 
         vals_pos, stats_pos = \
-            spatial_analysis.calculate_cluster_spatial_enrichment(
+            spatial_analysis.generate_cluster_spatial_enrichment_stats(
                 all_data, dist_mats, bootstrap_num=100, dist_lim=100
             )
 
@@ -96,7 +96,7 @@ def test_batch_cluster_spatial_enrichment():
         assert len(vals_pos) == 2
 
         vals_pos_fov8, stats_pos_fov8 = \
-            spatial_analysis.batch_cluster_spatial_enrichment(
+            spatial_analysis.generate_cluster_spatial_enrichment_stats(
                 label_dir, all_data, bootstrap_num=100, dist_lim=100, included_fovs=["fov8"]
             )
 

--- a/ark/analysis/spatial_analysis_test.py
+++ b/ark/analysis/spatial_analysis_test.py
@@ -52,7 +52,7 @@ def test_generate_channel_spatial_enrichment_stats():
 
         vals_pos, stats_pos = \
             spatial_analysis.generate_channel_spatial_enrichment_stats(
-                dist_mats, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
+                label_dir, marker_thresholds, all_data, excluded_channels=EXCLUDE_CHANNELS,
                 bootstrap_num=100, dist_lim=100
             )
 
@@ -89,7 +89,7 @@ def test_generate_cluster_spatial_enrichment_stats():
 
         vals_pos, stats_pos = \
             spatial_analysis.generate_cluster_spatial_enrichment_stats(
-                all_data, dist_mats, bootstrap_num=100, dist_lim=100
+                label_dir, all_data, bootstrap_num=100, dist_lim=100
             )
 
         # both fov8 and fov9 should be returned

--- a/templates/example_pairwise_spatial_enrichment.ipynb
+++ b/templates/example_pairwise_spatial_enrichment.ipynb
@@ -177,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "values_channel, stats_channel = spatial_analysis.batch_channel_spatial_enrichment(\n",
+    "values_channel, stats_channel = spatial_analysis.generate_channel_spatial_enrichment_stats(\n",
     "    deepcell_output, marker_thresholds, all_data, excluded_channels=excluded_channels,\n",
     "    bootstrap_num=5)"
    ]
@@ -212,7 +212,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "values_cluster, stats_cluster = spatial_analysis.batch_cluster_spatial_enrichment(\n",
+    "values_cluster, stats_cluster = spatial_analysis.generate_cluster_spatial_enrichment_stats(\n",
     "    deepcell_output, all_data, bootstrap_num=5)"
    ]
   },


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses part 4 of #720.

**How did you implement your changes**

Remove `batch_size` as a parameter from both `batch_channel_spatial_enrichment` and `batch_cluster_spatial_enrichment`.

Since these functions are no longer being batched, their names were also changed from `batch_channel_spatial_enrichment` to `generate_channel_spatial_enrichment_stats`, and likewise for cluster enrichment. 