### PR TITLE
Add Read the Docs status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.com/angelolab/ark-analysis.svg?branch=main)](https://travis-ci.com/angelolab/ark-analysis)
 [![Coverage Status](https://coveralls.io/repos/github/angelolab/ark-analysis/badge.svg?branch=main)](https://coveralls.io/github/angelolab/ark-analysis?branch=main)
 ![Docker Image Version (latest by date)](https://img.shields.io/docker/v/angelolab/ark-analysis?arch=amd64&color=%23469ae5&label=Docker%20Version&sort=date)
+[![Read the Docs](https://readthedocs.org/projects/ark-analysis/badge/?version=stable)](https://ark-analysis.readthedocs.io/en/stable/)
 
 # ark-analysis
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.com/angelolab/ark-analysis.svg?branch=main)](https://travis-ci.com/angelolab/ark-analysis)
 [![Coverage Status](https://coveralls.io/repos/github/angelolab/ark-analysis/badge.svg?branch=main)](https://coveralls.io/github/angelolab/ark-analysis?branch=main)
 ![Docker Image Version (latest by date)](https://img.shields.io/docker/v/angelolab/ark-analysis?arch=amd64&color=%23469ae5&label=Docker%20Version&sort=date)
-[![Read the Docs](https://readthedocs.org/projects/ark-analysis/badge/?version=stable)](https://ark-analysis.readthedocs.io/en/stable/)
+[![Read the Docs](https://readthedocs.org/projects/ark-analysis/badge/?version=latest)](https://ark-analysis.readthedocs.io/en/latest/)
 
 # ark-analysis
 


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #750 and closes #751. We should have the status of our docs builds in our `README.md`.

**How did you implement your changes**

Copy the Read the Docs badge generated on its end to the `README.md`.

**Remaining issues**

We will also need to patch up the branch `latest` is pointing at. Currently, it's set to `master`, since we recently renamed `master` to `main`, the `latest` documentation is pointing to a dead branch.