### PR TITLE
Process distance matrices inside the neighborhood counts function

### DIFF
--- a/ark/analysis/spatial_analysis.py
+++ b/ark/analysis/spatial_analysis.py
@@ -456,8 +456,6 @@ def create_neighborhood_matrix(label_dir, all_data, suffix='_feature_0',
             Suffix for tif file names.
         xr_channel_name (str):
             Channel name for labeled data array.
-        dist_matrices_dict (dict):
-            contains a cells x cells centroid-distance matrix for every fov.  Keys are fov names
         included_fovs (list):
             fovs to include in analysis. If argument is none, default is all fovs used.
         distlim (int):

--- a/templates/example_neighborhood_analysis_script.ipynb
+++ b/templates/example_neighborhood_analysis_script.ipynb
@@ -122,7 +122,7 @@
    "outputs": [],
    "source": [
     "# Determine number of each cell type in specified distance limit around each cell\n",
-    "neighbor_counts, neighbor_freqs = spatial_analysis.create_neighborhood_matrix(seg_output, dist_mats, distlim=50)\n",
+    "neighbor_counts, neighbor_freqs = spatial_analysis.create_neighborhood_matrix(seg_output, all_data, distlim=50)\n",
     "\n",
     "# Save neighbor matrices\n",
     "neighbor_counts.to_csv(os.path.join(spatial_analysis_dir, \"neighborhood_counts.csv\"), index=False)\n",

--- a/templates/example_neighborhood_analysis_script.ipynb
+++ b/templates/example_neighborhood_analysis_script.ipynb
@@ -98,15 +98,7 @@
    "source": [
     "# Read cell table, only fovs in the cell table will be included in the analysis\n",
     "all_data = pd.read_csv(cell_table_path)\n",
-    "all_fovs = all_data[settings.FOV_ID].unique()\n",
-    "\n",
-    "# Load label maps from segmentation from which the distance matrix will be computed, change suffix if not \"_feature_0.tif\"\n",
-    "label_maps = load_utils.load_imgs_from_dir(data_dir=seg_output, files=[x+\"_feature_0.tiff\" for x in all_fovs],\n",
-    "                                           xr_channel_names=['segmentation_label'],\n",
-    "                                           trim_suffix='_feature_0')\n",
-    "\n",
-    "# Create dictionary object with the respective distance matrices for the fovs\n",
-    "dist_mats = spatial_analysis_utils.calc_dist_matrix(label_maps)"
+    "all_fovs = all_data[settings.FOV_ID].unique()"
    ]
   },
   {
@@ -130,7 +122,7 @@
    "outputs": [],
    "source": [
     "# Determine number of each cell type in specified distance limit around each cell\n",
-    "neighbor_counts, neighbor_freqs = spatial_analysis.create_neighborhood_matrix(all_data, dist_mats, distlim=50)\n",
+    "neighbor_counts, neighbor_freqs = spatial_analysis.create_neighborhood_matrix(seg_output, dist_mats, distlim=50)\n",
     "\n",
     "# Save neighbor matrices\n",
     "neighbor_counts.to_csv(os.path.join(spatial_analysis_dir, \"neighborhood_counts.csv\"), index=False)\n",

--- a/templates/example_pairwise_spatial_enrichment.ipynb
+++ b/templates/example_pairwise_spatial_enrichment.ipynb
@@ -127,11 +127,7 @@
    "outputs": [],
    "source": [
     "# This is the Xarray of label maps for multiple fovs from which the distance matrix will be computed\n",
-    "#label_maps = xr.load_dataarray(os.path.join(spatial_analysis_dir, \"segmentation_labels.xr\"))\n",
-    "label_maps = load_utils.load_imgs_from_dir(deepcell_output, xr_channel_names=['segmentation_label'], match_substring='_feature_0', trim_suffix='_feature_0')\n",
-    "\n",
-    "# Get dictionary object with the respective distance matrices for the fovs\n",
-    "dist_mats = spatial_analysis_utils.calc_dist_matrix(label_maps)"
+    "label_maps = load_utils.load_imgs_from_dir(deepcell_output, xr_channel_names=['segmentation_label'], match_substring='_feature_0', trim_suffix='_feature_0')"
    ]
   },
   {
@@ -179,7 +175,8 @@
    "source": [
     "values_channel, stats_channel = spatial_analysis.generate_channel_spatial_enrichment_stats(\n",
     "    deepcell_output, marker_thresholds, all_data, excluded_channels=excluded_channels,\n",
-    "    bootstrap_num=5)"
+    "    bootstrap_num=5\n",
+    ")"
    ]
   },
   {
@@ -213,7 +210,8 @@
    "outputs": [],
    "source": [
     "values_cluster, stats_cluster = spatial_analysis.generate_cluster_spatial_enrichment_stats(\n",
-    "    deepcell_output, all_data, bootstrap_num=5)"
+    "    deepcell_output, all_data, bootstrap_num=5\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses #720. Neighborhood analysis has an inefficiency where the distance matrices are all precomputed beforehand. This is unnecessary as we can just compute these as needed in the neighborhood analysis per-FOV loop.

**How did you implement your changes**

We remove any precomputing of distance matrices (including preloading of label maps) inside the notebooks. In addition to the neighborhood analysis notebook, there was one that existed in the spatial analysis notebook which needed addressing.

`compute_neighborhood_counts` now takes in similar arguments as the other spatial functions to load directly from `label_dir` and computing `dist_mats` on an as-needed per-FOV basis.