### PR TITLE
Remove mibitiff option in notebooks

### DIFF
--- a/templates/1_Segment_Image_Data.ipynb
+++ b/templates/1_Segment_Image_Data.ipynb
@@ -188,7 +188,6 @@
     "    nucs,\n",
     "    mems,\n",
     "    fovs,\n",
-    "    is_mibitiff=False,\n",
     "    img_sub_folder=None\n",
     ")"
    ]
@@ -339,7 +338,6 @@
     "    marker_quantification.generate_cell_table(segmentation_dir=deepcell_output_dir,\n",
     "                                              tiff_dir=tiff_dir,\n",
     "                                              img_sub_folder=None,\n",
-    "                                              is_mibitiff=False,\n",
     "                                              fovs=fovs,\n",
     "                                              nuclear_counts=nuclear_counts)"
    ]

--- a/templates/2_Cluster_Pixels.ipynb
+++ b/templates/2_Cluster_Pixels.ipynb
@@ -53,9 +53,7 @@
     "* `tiff_dir`: the path to the directory containing your imaging data\n",
     "* `img_sub_folder`: if `tiff_dir` contains an additional subfolder structure, override `None` with the appropriate value\n",
     "* `segmentation_dir`: the path to the directory containing your segmentations (generated from `Segment_Image_Data.ipynb`). Set this argument to `None` if you do not have segmentation labels or wish to run pixel clustering without them. However, note that you will not be able to run cell clustering as that process is heavily dependent on them.\n",
-    "* `seg_suffix`: the suffix plus the file extension of the segmented images for each FOV. Note that these should be the same for all FOVs and that normally, the value should be `'_feature_0.tif'`. This argument will be ignored if `segmentation_dir` is set to `None`\n",
-    "* `MIBItiff`: if the images in `tiff_dir` are mibitiff or not\n",
-    "* `mibitiff_suffix` (required if `MIBItiff` is True): the file suffix all mibitiff images contain"
+    "* `seg_suffix`: the suffix plus the file extension of the segmented images for each FOV. Note that these should be the same for all FOVs and that normally, the value should be `'_feature_0.tif'`. This argument will be ignored if `segmentation_dir` is set to `None`"
    ]
   },
   {
@@ -72,9 +70,7 @@
     "tiff_dir = os.path.join(base_dir, \"TIFs\")\n",
     "img_sub_folder = None\n",
     "segmentation_dir = \"../data/granulomaCohort_allData\"\n",
-    "seg_suffix = '_feature_0.tif'\n",
-    "MIBItiff = False\n",
-    "mibitiff_suffix = '-MassCorrected-Filtered.tiff'"
+    "seg_suffix = '_feature_0.tif'"
    ]
   },
   {
@@ -95,10 +91,7 @@
    "outputs": [],
    "source": [
     "# either get all fovs in the folder...\n",
-    "if MIBItiff:\n",
-    "    fovs = io_utils.list_files(tiff_dir, substrs=MIBItiff_suffix)\n",
-    "else:\n",
-    "    fovs = io_utils.list_folders(tiff_dir)\n",
+    "fovs = io_utils.list_folders(tiff_dir)\n",
     "\n",
     "# ... or optionally, select a specific set of fovs manually\n",
     "# fovs = [\"fov14\"]"
@@ -300,7 +293,6 @@
     "    data_dir=pixel_data_dir,\n",
     "    subset_dir=pixel_subset_dir,\n",
     "    norm_vals_name=norm_vals_name,\n",
-    "    is_mibitiff=MIBItiff,\n",
     "    blur_factor=blur_factor,\n",
     "    subset_proportion=subset_proportion,\n",
     ")"


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #686.

**How did you implement your changes**
Remove mentions of MIBItiff in the notebooks and instead use the underlying default `is_mibitiff=False` in the functions.

