### PR TITLE
Run `pytest` as a separate job to avoid `scripts` from getting overwritten

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ env:
 
 cache: pip
 
-# command to run tests
-script:
-  - python -m pip install --editable .
-  - python -m pytest --cov=ark --pycodestyle ark
-
 jobs:
   include:
+    - stage: pytest_run
+      python: 3.8
+      script:
+        - python -m pip install --editable .
+        - python -m pytest --cov=ark --pycodestyle ark
     - stage: test_pypi_deploy
       python: 3.8
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,10 @@ cache: pip
 jobs:
   include:
     - stage: pytest_run
-      python: 3.8
       script:
         - python -m pip install --editable .
         - python -m pytest --cov=ark --pycodestyle ark
     - stage: test_pypi_deploy
-      python: 3.8
       script:
         - "travis_wait 120 sleep 7200 &"
         - python setup.py bdist_wheel
@@ -40,7 +38,6 @@ jobs:
         - twine upload -r testpypi --skip-existing /home/travis/build/"$TRAVIS_REPO_SLUG"/wheelhouse/*.whl -u "$TEST_PYPI_USERNAME" -p "$TEST_PYPI_PASSWORD"
     - stage: pypi_deploy
       if: tag IS present
-      python: 3.8
       script:
         - "travis_wait 120 sleep 7200 &"
         - python setup.py bdist_wheel
@@ -50,7 +47,6 @@ jobs:
         - twine upload --skip-existing /home/travis/build/"$TRAVIS_REPO_SLUG"/wheelhouse/*.whl -u "$PYPI_USERNAME" -p "$PYPI_PASSWORD"
     - stage: docker_deploy
       if: tag IS present
-      python: 3.8
       script:
         - "travis_wait 120 sleep 7200 &"
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
**What is the purpose of this PR?**

Fixes a bug that can pop up when a separate `scripts` gets specified in a `job`. This can overwrite the global `script`, which in effect skips the `pytest` runs in the PR.

It's also better to separate `pytest` out into its own job, as it shouldn't be included with the deployment stages. This can help us isolate the `pytest` logs from the deployment logs.

**How did you implement your changes**

Include a separate `pytest_run` stage.