### PR TITLE
Make non-parallel loops canon for Pixie

### DIFF
--- a/ark/phenotyping/pixel_cluster_utils.py
+++ b/ark/phenotyping/pixel_cluster_utils.py
@@ -924,7 +924,7 @@ def cluster_pixels(fovs, channels, base_dir, data_dir='pixel_mat_data',
                    norm_vals_name='post_rowsum_chan_norm.feather',
                    weights_name='pixel_weights.feather',
                    pc_chan_avg_som_cluster_name='pixel_channel_avg_som_cluster.csv',
-                   batch_size=5, ncores=multiprocessing.cpu_count() - 1):
+                   multiprocess=False, batch_size=5, ncores=multiprocessing.cpu_count() - 1):
     """Uses trained weights to assign cluster labels on full pixel data
     Saves data with cluster labels to `cluster_dir`. Computes and saves the average channel
     expression across pixel SOM clusters.
@@ -944,10 +944,12 @@ def cluster_pixels(fovs, channels, base_dir, data_dir='pixel_mat_data',
             The name of the weights file created by `train_pixel_som`
         pc_chan_avg_som_cluster_name (str):
             The name of the file to save the average channel expression across all SOM clusters
+        multiprocess (bool):
+            Whether to use multiprocessing or not
         batch_size (int):
-            The number of FOVs to process in parallel
+            The number of FOVs to process in parallel, ignored if `multiprocess` is `False`
         ncores (int):
-            The number of cores desired for multiprocessing
+            The number of cores desired for multiprocessing, ignored if `multiprocess` is `False`
     """
 
     # define the paths to the data
@@ -1031,7 +1033,8 @@ def cluster_pixels(fovs, channels, base_dir, data_dir='pixel_mat_data',
 
     # run the trained SOM on the dataset, assigning clusters
     process_args = ['Rscript', '/run_pixel_som.R', ','.join(fovs_list),
-                    data_path, norm_vals_path, weights_path, str(batch_size), str(ncores)]
+                    data_path, norm_vals_path, weights_path, str(multiprocess),
+                    str(batch_size), str(ncores)]
 
     process = subprocess.Popen(process_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 

--- a/ark/phenotyping/pixel_cluster_utils.py
+++ b/ark/phenotyping/pixel_cluster_utils.py
@@ -1082,7 +1082,8 @@ def pixel_consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
                             pc_chan_avg_som_cluster_name='pixel_channel_avg_som_cluster.csv',
                             pc_chan_avg_meta_cluster_name='pixel_channel_avg_meta_cluster.csv',
                             clust_to_meta_name='pixel_clust_to_meta.feather',
-                            batch_size=5, ncores=multiprocessing.cpu_count() - 1, seed=42):
+                            multiprocess=False, batch_size=5, ncores=multiprocessing.cpu_count() - 1,
+                            seed=42):
     """Run consensus clustering algorithm on pixel-level summed data across channels
     Saves data with consensus cluster labels to `consensus_dir`. Computes and saves the
     average channel expression across pixel meta clusters. Assigns meta cluster labels
@@ -1108,10 +1109,12 @@ def pixel_consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
             Name of file to save the channel-averaged results across all meta clusters to
         clust_to_meta_name (str):
             Name of file storing the SOM cluster to meta cluster mapping
+        multiprocess (bool):
+            Whether to use multiprocessing or not
         batch_size (int):
-            The number of FOVs to process in parallel
+            The number of FOVs to process in parallel, ignored if `multiprocess` is `False`
         ncores (int):
-            The number of cores desired for multiprocessing
+            The number of cores desired for multiprocessing, ignored if `multiprocess` is `False`
         seed (int):
             The random seed to set for consensus clustering
     """
@@ -1158,7 +1161,8 @@ def pixel_consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
     process_args = ['Rscript', '/pixel_consensus_cluster.R',
                     ','.join(fovs_list), ','.join(channels),
                     str(max_k), str(cap), data_path, som_cluster_avg_path,
-                    clust_to_meta_path, str(batch_size), str(ncores), str(seed)]
+                    clust_to_meta_path, str(multiprocess), str(batch_size),
+                    str(ncores), str(seed)]
 
     process = subprocess.Popen(process_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 

--- a/ark/phenotyping/pixel_cluster_utils.py
+++ b/ark/phenotyping/pixel_cluster_utils.py
@@ -546,7 +546,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
                         subset_dir='pixel_mat_subsetted',
                         norm_vals_name='post_rowsum_chan_norm.feather', is_mibitiff=False,
                         blur_factor=2, subset_proportion=0.1, seed=42,
-                        channel_percentile=0.99, batch_size=5):
+                        channel_percentile=0.99, multiprocess=False, batch_size=5):
     """For each fov, add a Gaussian blur to each channel and normalize channel sums for each pixel
 
     Saves data to `data_dir` and subsetted data to `subset_dir`
@@ -593,8 +593,10 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
             The random seed to set for subsetting
         channel_percentile (float):
             Percentile used to normalize channels to same range
+        multiprocess (bool):
+            Whether to use multiprocessing or not
         batch_size (int):
-            The number of FOVs to process in parallel
+            The number of FOVs to process in parallel, ignored if `multiprocess` is `False`
     """
 
     # if the subset_proportion specified is out of range
@@ -712,42 +714,59 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
         subset_proportion, pixel_norm_val, seed, channel_norm_df
     )
 
-    # define the multiprocessing context
-    with multiprocessing.get_context('spawn').Pool(batch_size) as fov_data_pool:
-        # define variable to keep track of number of fovs processed
-        fovs_processed = 0
+    # define variable to keep track of number of fovs processed
+    fovs_processed = 0
 
-        # asynchronously generate and save the pixel matrices per FOV
-        # NOTE: fov_data_pool should NOT operate on quant_dat since that is a shared resource
-        for fov_batch in [fovs_list[i:(i + batch_size)]
-                          for i in range(0, len(fovs_list), batch_size)]:
-            fov_data_batch = fov_data_pool.map(fov_data_func, fov_batch)
+    # define the columns to drop for 99.9% normalization
+    cols_to_drop = ['fov', 'row_index', 'column_index']
 
-            # compute the 99.9% quantile values for each FOV
-            for pixel_mat_data in fov_data_batch:
-                # retrieve the FOV name, note that there will only be one per FOV DataFrame
-                fov = pixel_mat_data['fov'].unique()[0]
+    # account for segmentation_label if seg_dir is set
+    if seg_dir:
+        cols_to_drop.append('segmentation_label')
 
-                # before taking the 99.9% quantile, drop the unneeded metadata columns
-                cols_to_drop = ['fov', 'row_index', 'column_index']
-                if 'segmentation_label' in pixel_mat_data.columns.values:
-                    cols_to_drop.append('segmentation_label')
+    if multiprocess:
+        # define the multiprocessing context
+        with multiprocessing.get_context('spawn').Pool(batch_size) as fov_data_pool:
+            # asynchronously generate and save the pixel matrices per FOV
+            # NOTE: fov_data_pool should NOT operate on quant_dat since that is a shared resource
+            for fov_batch in [fovs_list[i:(i + batch_size)]
+                              for i in range(0, len(fovs_list), batch_size)]:
+                fov_data_batch = fov_data_pool.map(fov_data_func, fov_batch)
 
-                # drop the metadata columns and generate the 99.9% quantile values for the FOV
-                fov_full_pixel_data = pixel_mat_data.drop(columns=cols_to_drop)
-                quant_dat[fov] = fov_full_pixel_data.replace(0, np.nan).quantile(q=0.999, axis=0)
+                # compute the 99.9% quantile values for each FOV
+                for pixel_mat_data in fov_data_batch:
+                    # retrieve the FOV name, note that there will only be one per FOV DataFrame
+                    fov = pixel_mat_data['fov'].unique()[0]
+
+                    # drop the metadata columns and generate the 99.9% quantile values for the FOV
+                    fov_full_pixel_data = pixel_mat_data.drop(columns=cols_to_drop)
+                    quant_dat[fov] = fov_full_pixel_data.replace(0, np.nan).quantile(q=0.999, axis=0)
+
+                # update number of fovs processed
+                fovs_processed += len(fov_batch)
+                print("Processed %d fovs" % fovs_processed)
+    else:
+        for fov in fovs_list:
+            pixel_mat_data = fov_data_func(fov)
+
+            # drop the metadata columns and generate the 99.9% quantile values for the FOV
+            fov_full_pixel_data = pixel_mat_data.drop(columns=cols_to_drop)
+            quant_dat[fov] = fov_full_pixel_data.replace(0, np.nan).quantile(q=0.999, axis=0)
 
             # update number of fovs processed
-            fovs_processed += len(fov_batch)
-            print("Processed %d fovs" % fovs_processed)
+            fovs_processed += 1
 
-        # get mean 99.9% across all fovs for all markers
-        mean_quant = pd.DataFrame(quant_dat.mean(axis=1))
+            # update every 10 FOVs, or at the very end
+            if fovs_processed % 10 == 0 or fovs_processed == len(fovs_list):
+                print("Processed %d fovs" % fovs_processed)
 
-        # save 99.9% normalization values
-        feather.write_dataframe(mean_quant.T,
-                                os.path.join(base_dir, norm_vals_name),
-                                compression='uncompressed')
+    # get mean 99.9% across all fovs for all markers
+    mean_quant = pd.DataFrame(quant_dat.mean(axis=1))
+
+    # save 99.9% normalization values
+    feather.write_dataframe(mean_quant.T,
+                            os.path.join(base_dir, norm_vals_name),
+                            compression='uncompressed')
 
 
 def find_fovs_missing_col(base_dir, data_dir, missing_col):
@@ -1252,7 +1271,7 @@ def apply_pixel_meta_cluster_remapping(fovs, channels, base_dir,
                                        pixel_remapped_name,
                                        pc_chan_avg_som_cluster_name,
                                        pc_chan_avg_meta_cluster_name,
-                                       batch_size=5):
+                                       multiprocess=False, batch_size=5):
     """Apply the meta cluster remapping to the data in `pixel_consensus_dir`.
 
     Resave the re-mapped consensus data to `pixel_consensus_dir` and re-runs the
@@ -1277,6 +1296,8 @@ def apply_pixel_meta_cluster_remapping(fovs, channels, base_dir,
             Name of the file containing the channel-averaged results across all SOM clusters
         pc_chan_avg_meta_cluster_name (str):
             Name of the file containing the channel-averaged results across all meta clusters
+        multiprocess (bool):
+            Whether to use multiprocessing or not
         batch_size (int):
             The number of FOVs to process in parallel
     """
@@ -1357,28 +1378,43 @@ def apply_pixel_meta_cluster_remapping(fovs, channels, base_dir,
         print("Restarting meta cluster remapping assignment from %s, "
               "%d fovs left to process" % (fov_list[0], len(fov_list)))
 
-    # define the multiprocessing context
-    with multiprocessing.get_context('spawn').Pool(batch_size) as fov_data_pool:
-        # define variable to keep track of number of fovs processed
-        fovs_processed = 0
+    # define variable to keep track of number of fovs processed
+    fovs_processed = 0
 
-        # asynchronously generate and save the pixel matrices per FOV
-        print("Using re-mapping scheme to re-label pixel meta clusters")
-        for fov_batch in [fov_list[i:(i + batch_size)]
-                          for i in range(0, len(fov_list), batch_size)]:
-            # NOTE: we don't need a return value since we're just resaving
-            # and not computing intermediate data frames
-            fov_statuses = fov_data_pool.map(fov_data_func, fov_batch)
+    print("Using re-mapping scheme to re-label pixel meta clusters")
+    if multiprocess:
+        # define the multiprocessing context
+        with multiprocessing.get_context('spawn').Pool(batch_size) as fov_data_pool:
+            # asynchronously generate and save the pixel matrices per FOV
+            for fov_batch in [fov_list[i:(i + batch_size)]
+                              for i in range(0, len(fov_list), batch_size)]:
+                # NOTE: we don't need a return value since we're just resaving
+                # and not computing intermediate data frames
+                fov_statuses = fov_data_pool.map(fov_data_func, fov_batch)
 
-            for fs in fov_statuses:
-                if fs[1] == 1:
-                    print("The data for FOV %s has been corrupted, skipping" % fs[0])
-                    fovs_processed -= 1
+                for fs in fov_statuses:
+                    if fs[1] == 1:
+                        print("The data for FOV %s has been corrupted, skipping" % fs[0])
+                        fovs_processed -= 1
+
+                # update number of fovs processed
+                fovs_processed += len(fov_batch)
+
+                print("Processed %d fovs" % fovs_processed)
+    else:
+        for fov in fov_list:
+            fov_status = fov_data_func(fov)
+
+            if fov_status[1] == 1:
+                print("The data for FOV %s has been corrupted, skipping" % fov_status[0])
+                fovs_processed -= 1
 
             # update number of fovs processed
-            fovs_processed += len(fov_batch)
+            fovs_processed += 1
 
-            print("Processed %d fovs" % fovs_processed)
+            # update every 10 FOVs, or at the very end
+            if fovs_processed % 10 == 0 or fovs_processed == len(fov_list):
+                print("Processed %d fovs" % fovs_processed)
 
     # remove the data directory and rename the temp directory to the data directory
     rmtree(pixel_data_path)

--- a/ark/phenotyping/pixel_cluster_utils.py
+++ b/ark/phenotyping/pixel_cluster_utils.py
@@ -740,7 +740,9 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
 
                     # drop the metadata columns and generate the 99.9% quantile values for the FOV
                     fov_full_pixel_data = pixel_mat_data.drop(columns=cols_to_drop)
-                    quant_dat[fov] = fov_full_pixel_data.replace(0, np.nan).quantile(q=0.999, axis=0)
+                    quant_dat[fov] = fov_full_pixel_data.replace(
+                        0, np.nan
+                    ).quantile(q=0.999, axis=0)
 
                 # update number of fovs processed
                 fovs_processed += len(fov_batch)
@@ -1082,8 +1084,8 @@ def pixel_consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
                             pc_chan_avg_som_cluster_name='pixel_channel_avg_som_cluster.csv',
                             pc_chan_avg_meta_cluster_name='pixel_channel_avg_meta_cluster.csv',
                             clust_to_meta_name='pixel_clust_to_meta.feather',
-                            multiprocess=False, batch_size=5, ncores=multiprocessing.cpu_count() - 1,
-                            seed=42):
+                            multiprocess=False, batch_size=5,
+                            ncores=multiprocessing.cpu_count() - 1, seed=42):
     """Run consensus clustering algorithm on pixel-level summed data across channels
     Saves data with consensus cluster labels to `consensus_dir`. Computes and saves the
     average channel expression across pixel meta clusters. Assigns meta cluster labels

--- a/ark/phenotyping/pixel_cluster_utils_test.py
+++ b/ark/phenotyping/pixel_cluster_utils_test.py
@@ -839,9 +839,10 @@ def test_preprocess_fov(mocker):
     'fovs,chans,sub_dir,seg_dir_include,channel_norm_include,pixel_norm_include,norm_diff_chan',
     cases=CreatePixelMatrixBaseCases
 )
+@parametrize('multiprocess', [True, False])
 def test_create_pixel_matrix_base(fovs, chans, sub_dir, seg_dir_include,
                                   channel_norm_include, pixel_norm_include,
-                                  norm_diff_chan, mocker, capsys):
+                                  norm_diff_chan, multiprocess, mocker, capsys):
     with tempfile.TemporaryDirectory() as temp_dir:
         # create a directory to store the image data
         tiff_dir = os.path.join(temp_dir, 'sample_image_data')
@@ -967,7 +968,8 @@ def test_create_pixel_matrix_base(fovs, chans, sub_dir, seg_dir_include,
             tiff_dir=tiff_dir,
             img_sub_folder=sub_dir,
             seg_dir=seg_dir,
-            pixel_cluster_prefix='test'
+            pixel_cluster_prefix='test',
+            multiprocess=multiprocess
         )
 
         # assert we overwrote the original channel_norm and pixel_norm files
@@ -1072,7 +1074,8 @@ def test_create_pixel_matrix_base(fovs, chans, sub_dir, seg_dir_include,
             tiff_dir=new_tiff_dir,
             img_sub_folder=sub_dir,
             seg_dir=seg_dir,
-            pixel_cluster_prefix='test'
+            pixel_cluster_prefix='test',
+            multiprocess=multiprocess
         )
 
 
@@ -1102,7 +1105,8 @@ def generate_create_pixel_matrix_test_data(temp_dir):
     )
 
 
-def test_create_pixel_matrix_missing_fov(capsys):
+@parametrize('multiprocess', [True, False])
+def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
     fov_files = [fov + '.feather' for fov in PIXEL_MATRIX_FOVS]
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -1130,7 +1134,8 @@ def test_create_pixel_matrix_missing_fov(capsys):
             base_dir=temp_dir,
             tiff_dir=tiff_dir,
             img_sub_folder=None,
-            seg_dir=None
+            seg_dir=None,
+            multiprocess=multiprocess
         )
 
         output_capture = capsys.readouterr().out
@@ -1163,7 +1168,8 @@ def test_create_pixel_matrix_missing_fov(capsys):
             base_dir=temp_dir,
             tiff_dir=tiff_dir,
             img_sub_folder=None,
-            seg_dir=None
+            seg_dir=None,
+            multiprocess=multiprocess
         )
 
         output_capture = capsys.readouterr().out
@@ -1732,7 +1738,8 @@ def generate_test_apply_pixel_meta_cluster_remapping_data(temp_dir, fovs, chans,
 
 
 # TODO: split up this test function
-def test_apply_pixel_meta_cluster_remapping_base():
+@parametrize('multiprocess', [True, False])
+def test_apply_pixel_meta_cluster_remapping_base(multiprocess):
     with tempfile.TemporaryDirectory() as temp_dir:
         # basic error check: bad path to pixel consensus dir
         with pytest.raises(FileNotFoundError):
@@ -1835,7 +1842,8 @@ def test_apply_pixel_meta_cluster_remapping_base():
             'pixel_mat_data',
             'sample_pixel_remapping.csv',
             'sample_pixel_som_cluster_chan_avgs.csv',
-            'sample_pixel_meta_cluster_chan_avgs.csv'
+            'sample_pixel_meta_cluster_chan_avgs.csv',
+            multiprocess=multiprocess
         )
 
         # assert _temp dir no longer exists (pixel_mat_data_temp should be renamed pixel_mat_data)
@@ -1933,7 +1941,8 @@ def test_apply_pixel_meta_cluster_remapping_base():
         ].values == np.array(['meta' + str(i) for i in np.repeat(np.arange(20), repeats=5)]))
 
 
-def test_apply_pixel_meta_cluster_remapping_temp_corrupt(capsys):
+@parametrize('multiprocess', [True, False])
+def test_apply_pixel_meta_cluster_remapping_temp_corrupt(multiprocess, capsys):
     with tempfile.TemporaryDirectory() as temp_dir:
         # define fovs and channels
         fovs = ['fov0', 'fov1', 'fov2']
@@ -1958,16 +1967,17 @@ def test_apply_pixel_meta_cluster_remapping_temp_corrupt(capsys):
             'pixel_mat_data',
             'sample_pixel_remapping.csv',
             'sample_pixel_som_cluster_chan_avgs.csv',
-            'sample_pixel_meta_cluster_chan_avgs.csv'
+            'sample_pixel_meta_cluster_chan_avgs.csv',
+            multiprocess=multiprocess
         )
 
         # assert the _temp folder is now gone
         assert not os.path.exists(os.path.join(temp_dir, 'pixel_mat_data_temp'))
 
         output = capsys.readouterr().out
+        print(output)
         desired_status_updates = "Using re-mapping scheme to re-label pixel meta clusters\n"
         desired_status_updates += "The data for FOV fov1 has been corrupted, skipping\n"
-        desired_status_updates += "Processed 1 fovs\n"
         assert desired_status_updates in output
 
         # verify that the FOVs in pixel_mat_data are correct

--- a/ark/phenotyping/pixel_consensus_cluster.R
+++ b/ark/phenotyping/pixel_consensus_cluster.R
@@ -21,6 +21,36 @@ suppressPackageStartupMessages({
     library(stringi)
 })
 
+# helper function for assigning meta cluster labels
+assignMetaLabels <- function(fov, pixelMatDir, matPath) {
+    status <- tryCatch(
+        {
+            # generate the meta cluster labels
+            fovPixelData <- arrow::read_feather(matPath)
+
+            # assign hierarchical cluster labels
+            fovPixelData$pixel_meta_cluster <- som_to_meta_map[as.character(fovPixelData$pixel_som_cluster)]
+
+            # write data with consensus labels
+            tempPath <- file.path(paste0(pixelMatDir, '_temp'), fileName)
+            arrow::write_feather(as.data.table(fovPixelData), tempPath, compression='uncompressed')
+
+            # this won't be displayed to the user but is used as a helper to break out
+            # in the rare first FOV hang issue
+            print(paste('Done writing fov', fov))
+            c(0, '')
+        },
+        error=function(cond) {
+            # this won't be displayed to the user but is used as a helper to break out
+            # in the rare first FOV hang issue
+            print(paste('Error encountered for fov', fov))
+            c(1, cond)
+        }
+    )
+
+    return(status)
+}
+
 # get the number of cores
 nCores <- parallel::detectCores() - 1
 
@@ -48,14 +78,17 @@ clusterAvgPath <- args[6]
 # get the clust to meta write path
 clustToMetaPath <- args[7]
 
+# define if multiprocessing should be turned on
+multiprocess <- strtoi(args[8])
+
 # retrieve the batch size to determine number of threads to run in parallel
-batchSize <- strtoi(args[8])
+batchSize <- strtoi(args[9])
 
 # get the number of cores
-nCores <- strtoi(args[9])
+nCores <- strtoi(args[10])
 
 # set the random seed
-seed <- strtoi(args[10])
+seed <- strtoi(args[11])
 set.seed(seed)
 
 # read cluster averaged data
@@ -81,86 +114,92 @@ fovsProcessed <- 0
 
 # append pixel_meta_cluster to each fov's data
 print("Mapping pixel data to consensus cluster labels")
-for (batchStart in seq(1, length(fovs), batchSize)) {
-    # define the parallel cluster for this batch of fovs
-    # NOTE: to prevent the occassional hanging first FOV issue, we need to log to an outfile
-    # to "force" a return out of the foreach loop in this case
-    parallelStatus <- tryCatch(
-        {
-            parallelCluster <- parallel::makeCluster(nCores, type="FORK", outfile='log.txt')
-            0
-        },
-        error=function(cond) {
-            1
-        }
-    )
 
-    if (parallelStatus == 1) {
-        print(paste0("Too many cores (", nCores, ") specifed, reduce this using the ncores parameter"))
-        quit(status=1)
-    }
-
-    # register parallel cluster for dopar
-    doParallel::registerDoParallel(cl=parallelCluster)
-
-    # need to prevent overshooting end of fovs list when batching
-    batchEnd <- min(batchStart + batchSize - 1, length(fovs))
-
-    # run the multithreaded batch process for mapping to SOM labels and saving
-    fovStatuses <- foreach(
-        i=batchStart:batchEnd,
-        .combine=rbind
-    ) %dopar% {
-        fileName <- paste0(fovs[i], '.feather')
-        matPath <- file.path(pixelMatDir, fileName)
-
-        status <- tryCatch(
+# handle multiprocess passed in as a string argument
+if (isTrue(multiprocess)) {
+    for (batchStart in seq(1, length(fovs), batchSize)) {
+        # define the parallel cluster for this batch of fovs
+        # NOTE: to prevent the occassional hanging first FOV issue, we need to log to an outfile
+        # to "force" a return out of the foreach loop in this case
+        parallelStatus <- tryCatch(
             {
-                fovPixelData <- arrow::read_feather(matPath)
-
-                # assign hierarchical cluster labels
-                fovPixelData$pixel_meta_cluster <- som_to_meta_map[as.character(fovPixelData$pixel_som_cluster)]
-
-                # write data with consensus labels
-                tempPath <- file.path(paste0(pixelMatDir, '_temp'), fileName)
-                arrow::write_feather(as.data.table(fovPixelData), tempPath, compression='uncompressed')
-
-                # this won't be displayed to the user but is used as a helper to break out
-                # in the rare first FOV hang issue
-                print(paste('Done writing fov', fovs[i]))
-                c(0, '')
+                parallelCluster <- parallel::makeCluster(nCores, type="FORK", outfile='log.txt')
+                0
             },
             error=function(cond) {
-                # this won't be displayed to the user but is used as a helper to break out
-                # in the rare first FOV hang issue
-                print(paste('Error encountered for fov', fovs[i]))
-                c(1, cond)
+                1
             }
         )
 
-        data.frame(fov=fovs[i], status=status[1], errCond=status[2])
-    }
+        if (parallelStatus == 1) {
+            print(paste0("Too many cores (", nCores, ") specifed, reduce this using the ncores parameter"))
+            quit(status=1)
+        }
 
-    # report any erroneous feather files
-    for (i in 1:nrow(fovStatuses)) {
-        if (fovStatuses[i, 'status'] == 1) {
-            print(paste("Processing for FOV", fovStatuses[i, 'fov'], "failed, removing from pipeline. Error message:"))
-            print(fovStatuses[i, 'errCond'])
+        # register parallel cluster for dopar
+        doParallel::registerDoParallel(cl=parallelCluster)
+
+        # need to prevent overshooting end of fovs list when batching
+        batchEnd <- min(batchStart + batchSize - 1, length(fovs))
+
+        # run the multithreaded batch process for mapping to meta cluster labels and saving
+        fovStatuses <- foreach(
+            i=batchStart:batchEnd,
+            .combine=rbind
+        ) %dopar% {
+            fileName <- paste0(fovs[i], '.feather')
+            matPath <- file.path(pixelMatDir, fileName)
+
+            # generate the SOM cluster labels
+            status <- assignMetaLabels(fovs[i], pixelMatDir, matPath)
+
+            data.frame(fov=fovs[i], status=status[1], errCond=status[2])
+        }
+
+        # report any erroneous feather files
+        for (i in 1:nrow(fovStatuses)) {
+            if (fovStatuses[i, 'status'] == 1) {
+                print(paste("Processing for FOV", fovStatuses[i, 'fov'], "failed, removing from pipeline. Error message:"))
+                print(fovStatuses[i, 'errCond'])
+                fovsProcessed <- fovsProcessed - 1
+            }
+        }
+
+        # unregister the parallel cluster
+        parallel::stopCluster(cl=parallelCluster)
+
+        # update number of fovs processed
+        fovsProcessed <- fovsProcessed + (batchEnd - batchStart + 1)
+
+        # inform user that batchSize fovs have been processed
+        print(paste("Processed", as.character(fovsProcessed), "fovs"))
+
+        # remove log.txt
+        unlink('log.txt')
+    }
+} else {
+    for (i in 1:len(fovs)) {
+        fileName <- paste0(fovs[i], ".feather")
+        matPath <- file.path(pixelMatDir, fileName)
+
+        # generate the SOM cluster labels
+        status <- assignMetaLabels(fovs[i], pixelMatDir, matPath)
+
+        # report any erroneous feather files
+        if (status[1] == 1) {
+            print(paste("Processing for FOV", fovs[i], "failed, removing from pipeline. Error message:"))
+            print(status[2])
             fovsProcessed <- fovsProcessed - 1
         }
+
+        # update number of fovs processed
+        fovsProcessed <- fovsProcessed + 1
+
+        # inform user every 10 fovs that get processed
+        if (fovsProcessed %% 10 == 0) {
+            print(paste("Processed", as.character(fovsProcessed), "fovs"))
+        }
     }
-
-    # unregister the parallel cluster
-    parallel::stopCluster(cl=parallelCluster)
-
-    # update number of fovs processed
-    fovsProcessed <- fovsProcessed + (batchEnd - batchStart + 1)
-
-    # inform user that batchSize fovs have been processed
-    print(paste("Processed", as.character(fovsProcessed), "fovs"))
-
-    # remove log.txt
-    unlink('log.txt')
 }
 
 # save the mapping from pixel_som_cluster to pixel_meta_cluster

--- a/ark/phenotyping/pixel_consensus_cluster.R
+++ b/ark/phenotyping/pixel_consensus_cluster.R
@@ -37,13 +37,11 @@ assignMetaLabels <- function(fov, pixelMatDir, matPath) {
 
             # this won't be displayed to the user but is used as a helper to break out
             # in the rare first FOV hang issue
-            print(paste('Done writing fov', fov))
             c(0, '')
         },
         error=function(cond) {
             # this won't be displayed to the user but is used as a helper to break out
             # in the rare first FOV hang issue
-            print(paste('Error encountered for fov', fov))
             c(1, cond)
         }
     )
@@ -79,7 +77,7 @@ clusterAvgPath <- args[6]
 clustToMetaPath <- args[7]
 
 # define if multiprocessing should be turned on
-multiprocess <- strtoi(args[8])
+multiprocess <- args[8]
 
 # retrieve the batch size to determine number of threads to run in parallel
 batchSize <- strtoi(args[9])
@@ -116,7 +114,7 @@ fovsProcessed <- 0
 print("Mapping pixel data to consensus cluster labels")
 
 # handle multiprocess passed in as a string argument
-if (isTrue(multiprocess)) {
+if (isTRUE(multiprocess)) {
     for (batchStart in seq(1, length(fovs), batchSize)) {
         # define the parallel cluster for this batch of fovs
         # NOTE: to prevent the occassional hanging first FOV issue, we need to log to an outfile
@@ -178,7 +176,7 @@ if (isTrue(multiprocess)) {
         unlink('log.txt')
     }
 } else {
-    for (i in 1:len(fovs)) {
+    for (i in 1:length(fovs)) {
         fileName <- paste0(fovs[i], ".feather")
         matPath <- file.path(pixelMatDir, fileName)
 

--- a/ark/phenotyping/pixel_consensus_cluster.R
+++ b/ark/phenotyping/pixel_consensus_cluster.R
@@ -114,7 +114,7 @@ fovsProcessed <- 0
 print("Mapping pixel data to consensus cluster labels")
 
 # handle multiprocess passed in as a string argument
-if (isTRUE(multiprocess)) {
+if (multiprocess == "True") {
     for (batchStart in seq(1, length(fovs), batchSize)) {
         # define the parallel cluster for this batch of fovs
         # NOTE: to prevent the occassional hanging first FOV issue, we need to log to an outfile

--- a/ark/phenotyping/run_pixel_som.R
+++ b/ark/phenotyping/run_pixel_som.R
@@ -16,6 +16,44 @@ suppressPackageStartupMessages({
     library(parallel)
 })
 
+# helper function for processing fov data
+assignSOMLabels <- function(pixelMatDir, fileName, matPath, markers, normVals, somWeights) {
+    status <- tryCatch(
+        {
+            fovPixelData_all <- data.table(arrow::read_feather(matPath))
+            fovPixelData <- fovPixelData_all[,..markers]
+            fovPixelData <- fovPixelData[,Map(`/`,.SD,normVals)]
+
+            # map FlowSOM data
+            clusters <- FlowSOM:::MapDataToCodes(somWeights, as.matrix(fovPixelData))
+
+            # add back other columns
+            to_add <- colnames(fovPixelData_all)[!colnames(fovPixelData_all) %in% markers]
+            fovPixelData <- cbind(fovPixelData_all[,..to_add], fovPixelData)
+
+            # assign cluster labels column to pixel data
+            fovPixelData$pixel_som_cluster <- as.integer(clusters[,1])
+
+            # write data with SOM labels
+            tempPath <- file.path(paste0(pixelMatDir, '_temp'), fileName)
+            arrow::write_feather(as.data.table(fovPixelData), tempPath, compression='uncompressed')
+
+            # this won't be displayed to the user but is used as a helper to break out
+            # in the rare first FOV hang issue
+            print(paste('Done writing fov', fovs[i]))
+            c(0, '')
+        },
+        error=function(cond) {
+            # this won't be displayed to the user but is used as a helper to break out
+            # in the rare first FOV hang issue
+            print(paste('Error encountered for fov', fovs[i]))
+            c(1, cond)
+        }
+    )
+
+    return(status)
+}
+
 # get the command line arguments
 args <- commandArgs(trailingOnly=TRUE)
 
@@ -31,11 +69,14 @@ normValsPath <- args[3]
 # get path to the weights
 pixelWeightsPath <- args[4]
 
+# define if multiprocessing should be turned on
+multiprocess <- strtoi(args[5])
+
 # retrieve the batch size to determine number of threads to run in parallel
-batchSize <- strtoi(args[5])
+batchSize <- strtoi(args[6])
 
 # get the number of cores
-nCores <- strtoi(args[6])
+nCores <- strtoi(args[7])
 
 # read the weights
 somWeights <- as.matrix(arrow::read_feather(pixelWeightsPath))
@@ -54,93 +95,91 @@ fovsProcessed <- 0
 
 # using trained SOM, assign SOM labels to each fov
 print("Mapping pixel data to SOM cluster labels")
-for (batchStart in seq(1, length(fovs), batchSize)) {
-    # define the parallel cluster for this batch of fovs
-    # NOTE: to prevent the occassional hanging first FOV issue, we need to log to an outfile
-    # to "force" a return out of the foreach loop in this case
-    parallelStatus <- tryCatch(
-        {
-            parallelCluster <- parallel::makeCluster(nCores, type="FORK", outfile='log.txt')
-            0
-        },
-        error=function(cond) {
-            1
-        }
-    )
 
-    if (parallelStatus == 1) {
-        print(paste0("Too many cores (", nCores, ") specified, reduce this using the ncores parameter"))
-        quit(status=1)
-    }
-
-    # register parallel cluster for dopar
-    doParallel::registerDoParallel(cl=parallelCluster)
-
-    # need to prevent overshooting end of fovs list when batching
-    batchEnd <- min(batchStart + batchSize - 1, length(fovs))
-
-    # run the multithreaded batch process for mapping to SOM labels and saving
-    fovStatuses <- foreach(
-        i=batchStart:batchEnd,
-        .combine=rbind
-    ) %dopar% {
-        fileName <- paste0(fovs[i], ".feather")
-        matPath <- file.path(pixelMatDir, fileName)
-
-        status <- tryCatch(
+# handle multiprocess passed in as a string argument
+if (isTrue(multiprocess)) {
+    for (batchStart in seq(1, length(fovs), batchSize)) {
+        # define the parallel cluster for this batch of fovs
+        # NOTE: to prevent the occassional hanging first FOV issue, we need to log to an outfile
+        # to "force" a return out of the foreach loop in this case
+        parallelStatus <- tryCatch(
             {
-                fovPixelData_all <- data.table(arrow::read_feather(matPath))
-                fovPixelData <- fovPixelData_all[,..markers]
-                fovPixelData <- fovPixelData[,Map(`/`,.SD,normVals)]
-
-                # map FlowSOM data
-                clusters <- FlowSOM:::MapDataToCodes(somWeights, as.matrix(fovPixelData))
-
-                # add back other columns
-                to_add <- colnames(fovPixelData_all)[!colnames(fovPixelData_all) %in% markers]
-                fovPixelData <- cbind(fovPixelData_all[,..to_add], fovPixelData)
-
-                # assign cluster labels column to pixel data
-                fovPixelData$pixel_som_cluster <- as.integer(clusters[,1])
-
-                # write data with SOM labels
-                tempPath <- file.path(paste0(pixelMatDir, '_temp'), fileName)
-                arrow::write_feather(as.data.table(fovPixelData), tempPath, compression='uncompressed')
-
-                # this won't be displayed to the user but is used as a helper to break out
-                # in the rare first FOV hang issue
-                print(paste('Done writing fov', fovs[i]))
-                c(0, '')
+                parallelCluster <- parallel::makeCluster(nCores, type="FORK", outfile='log.txt')
+                0
             },
             error=function(cond) {
-                # this won't be displayed to the user but is used as a helper to break out
-                # in the rare first FOV hang issue
-                print(paste('Error encountered for fov', fovs[i]))
-                c(1, cond)
+                1
             }
         )
 
-        data.frame(fov=fovs[i], status=status[1], errCond=status[2])
-    }
+        if (parallelStatus == 1) {
+            print(paste0("Too many cores (", nCores, ") specified, reduce this using the ncores parameter"))
+            quit(status=1)
+        }
 
-    # report any erroneous feather files
-    for (i in 1:nrow(fovStatuses)) {
-        if (fovStatuses[i, 'status'] == 1) {
-            print(paste("Processing for FOV", fovStatuses[i, 'fov'], "failed, removing from pipeline. Error message:"))
-            print(fovStatuses[i, 'errCond'])
+        # register parallel cluster for dopar
+        doParallel::registerDoParallel(cl=parallelCluster)
+
+        # need to prevent overshooting end of fovs list when batching
+        batchEnd <- min(batchStart + batchSize - 1, length(fovs))
+
+        # run the multithreaded batch process for mapping to SOM labels and saving
+        fovStatuses <- foreach(
+            i=batchStart:batchEnd,
+            .combine=rbind
+        ) %dopar% {
+            fileName <- paste0(fovs[i], ".feather")
+            matPath <- file.path(pixelMatDir, fileName)
+
+            # generate the SOM labels
+            status <- assignSOMLabels(pixelMatDir, fileName, matPath, markers, normVals, somWeights)
+
+            # append to data frame status checker
+            data.frame(fov=fovs[i], status=status[1], errCond=status[2])
+        }
+
+        # report any erroneous feather files
+        for (i in 1:nrow(fovStatuses)) {
+            if (fovStatuses[i, 'status'] == 1) {
+                print(paste("Processing for FOV", fovStatuses[i, 'fov'], "failed, removing from pipeline. Error message:"))
+                print(fovStatuses[i, 'errCond'])
+                fovsProcessed <- fovsProcessed - 1
+            }
+        }
+
+        # unregister the parallel cluster
+        parallel::stopCluster(cl=parallelCluster)
+
+        # update number of fovs processed
+        fovsProcessed <- fovsProcessed + (batchEnd - batchStart + 1)
+
+        # inform user that batchSize fovs have been processed
+        print(paste("Processed", as.character(fovsProcessed), "fovs"))
+
+        # remove log.txt
+        unlink('log.txt')
+    }
+} else {
+    for (i in 1:len(fovs)) {
+        fileName <- paste0(fovs[i], ".feather")
+        matPath <- file.path(pixelMatDir, fileName)
+
+        # generate the SOM labels
+        status <- assignSOMLabels(pixelMatDir, fileName, matPath, markers, normVals, somWeights)
+
+        # report any erroneous feather files
+        if (status[1] == 1) {
+            print(paste("Processing for FOV", fovs[i], "failed, removing from pipeline. Error message:"))
+            print(status[2])
             fovsProcessed <- fovsProcessed - 1
         }
+
+        # update number of fovs processed
+        fovsProcessed <- fovsProcessed + 1
+
+        # inform user every 10 fovs that get processed
+        if (fovsProcessed %% 10 == 0) {
+            print(paste("Processed", as.character(fovsProcessed), "fovs"))
+        }
     }
-
-    # unregister the parallel cluster
-    parallel::stopCluster(cl=parallelCluster)
-
-    # update number of fovs processed
-    fovsProcessed <- fovsProcessed + (batchEnd - batchStart + 1)
-
-    # inform user that batchSize fovs have been processed
-    print(paste("Processed", as.character(fovsProcessed), "fovs"))
-
-    # remove log.txt
-    unlink('log.txt')
 }

--- a/ark/phenotyping/run_pixel_som.R
+++ b/ark/phenotyping/run_pixel_som.R
@@ -43,13 +43,13 @@ assignSOMLabels <- function(fov, pixelMatDir, fileName, matPath, markers, normVa
 
             # this won't be displayed to the user but is used as a helper to break out
             # in the rare first FOV hang issue
-            print(paste('Done writing fov', fov))
+            # print(paste('Done writing fov', fov))
             c(0, '')
         },
         error=function(cond) {
             # this won't be displayed to the user but is used as a helper to break out
             # in the rare first FOV hang issue
-            print(paste('Error encountered for fov', fov))
+            # print(paste('Error encountered for fov', fov))
             c(1, cond)
         }
     )
@@ -73,7 +73,7 @@ normValsPath <- args[3]
 pixelWeightsPath <- args[4]
 
 # define if multiprocessing should be turned on
-multiprocess <- strtoi(args[5])
+multiprocess <- args[5]
 
 # retrieve the batch size to determine number of threads to run in parallel
 batchSize <- strtoi(args[6])
@@ -100,7 +100,7 @@ fovsProcessed <- 0
 print("Mapping pixel data to SOM cluster labels")
 
 # handle multiprocess passed in as a string argument
-if (isTrue(multiprocess)) {
+if (isTRUE(multiprocess)) {
     for (batchStart in seq(1, length(fovs), batchSize)) {
         # define the parallel cluster for this batch of fovs
         # NOTE: to prevent the occassional hanging first FOV issue, we need to log to an outfile
@@ -163,7 +163,7 @@ if (isTrue(multiprocess)) {
         unlink('log.txt')
     }
 } else {
-    for (i in 1:len(fovs)) {
+    for (i in 1:length(fovs)) {
         fileName <- paste0(fovs[i], ".feather")
         matPath <- file.path(pixelMatDir, fileName)
 
@@ -181,7 +181,7 @@ if (isTrue(multiprocess)) {
         fovsProcessed <- fovsProcessed + 1
 
         # inform user every 10 fovs that get processed
-        if (fovsProcessed %% 10 == 0) {
+        if (fovsProcessed %% 10 == 0 | fovsProcessed == length(fovs)) {
             print(paste("Processed", as.character(fovsProcessed), "fovs"))
         }
     }

--- a/ark/phenotyping/run_pixel_som.R
+++ b/ark/phenotyping/run_pixel_som.R
@@ -100,7 +100,8 @@ fovsProcessed <- 0
 print("Mapping pixel data to SOM cluster labels")
 
 # handle multiprocess passed in as a string argument
-if (isTRUE(multiprocess)) {
+if (multiprocess == "True") {
+    print("Running multiprocessing")
     for (batchStart in seq(1, length(fovs), batchSize)) {
         # define the parallel cluster for this batch of fovs
         # NOTE: to prevent the occassional hanging first FOV issue, we need to log to an outfile

--- a/ark/utils/notebooks_test_utils.py
+++ b/ark/utils/notebooks_test_utils.py
@@ -210,6 +210,9 @@ def flowsom_pixel_setup(tb, flowsom_dir, create_seg_dir=True, img_shape=(50, 50)
         # handles the case when the user allows list_files or list_folders to do the fov loading
         tb.execute_cell('load_fovs')
 
+    # set the multiprocess variables
+    tb.execute_cell('set_multi')
+
     # define the pixel cluster prefix
     tb.inject("pixel_cluster_prefix = '%s'" % pixel_prefix, after='pixel_prefix')
 

--- a/templates/2_Cluster_Pixels.ipynb
+++ b/templates/2_Cluster_Pixels.ipynb
@@ -127,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Turning on multiprocessing provides a speed boost, however it is not always  cross-platform compatible."
+    "Turning on multiprocessing provides a speed boost, however it is not always cross-platform compatible. If you receive errors such as hanging cells without progress updates, `ncores` set to `NA`, or `fovStatuses` of length 0, try setting `multiprocess` back to `False`."
    ]
   },
   {

--- a/templates/2_Cluster_Pixels.ipynb
+++ b/templates/2_Cluster_Pixels.ipynb
@@ -118,6 +118,37 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define multiprocessing parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Turning on multiprocessing provides a speed boost, however it is not always  cross-platform compatible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "set_multi"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# set to True to turn on multiprocessing\n",
+    "multiprocess = False\n",
+    "\n",
+    "# define the number of FOVs to process in parallel, ignored if multiprocessing is set to False\n",
+    "batch_size = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "tags": []
    },
@@ -314,6 +345,8 @@
     "    norm_vals_name=norm_vals_name,\n",
     "    blur_factor=blur_factor,\n",
     "    subset_proportion=subset_proportion,\n",
+    "    multiprocess=multiprocess,\n",
+    "    batch_size=batch_size\n",
     ")"
    ]
   },
@@ -430,7 +463,9 @@
     "    data_dir=pixel_data_dir,\n",
     "    norm_vals_name=norm_vals_name,\n",
     "    weights_name=pixel_weights_name,\n",
-    "    pc_chan_avg_som_cluster_name=pc_chan_avg_som_cluster_name\n",
+    "    pc_chan_avg_som_cluster_name=pc_chan_avg_som_cluster_name,\n",
+    "    multiprocess=multiprocess,\n",
+    "    batch_size=batch_size\n",
     ")"
    ]
   },
@@ -486,7 +521,9 @@
     "    data_dir=pixel_data_dir,\n",
     "    pc_chan_avg_som_cluster_name=pc_chan_avg_som_cluster_name,\n",
     "    pc_chan_avg_meta_cluster_name=pc_chan_avg_meta_cluster_name,\n",
-    "    clust_to_meta_name=pixel_som_to_meta_name\n",
+    "    clust_to_meta_name=pixel_som_to_meta_name,\n",
+    "    multiprocess=multiprocess,\n",
+    "    batch_size=batch_size\n",
     ")"
    ]
   },
@@ -579,7 +616,9 @@
     "    pixel_data_dir,\n",
     "    pixel_meta_cluster_remap_name,\n",
     "    pc_chan_avg_som_cluster_name,\n",
-    "    pc_chan_avg_meta_cluster_name\n",
+    "    pc_chan_avg_meta_cluster_name,\n",
+    "    multiprocess=multiprocess,\n",
+    "    batch_size=batch_size\n",
     ")"
    ]
   },


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #771. Adds option to run a non-parallel version of Pixie preprocessing, SOM and meta cluster assignment, and meta cluster renaming.

**How did you implement your changes**

Add control flow statements handled by a dedicated `multiprocess` argument.