### PR TITLE
In k-means neighborhood notebook, fix excluded_channels=None

### DIFF
--- a/ark/analysis/spatial_analysis.py
+++ b/ark/analysis/spatial_analysis.py
@@ -584,8 +584,9 @@ def generate_cluster_matrix_results(all_data, neighbor_mat, cluster_num, exclude
                               unique_fovs=all_data[fov_col].unique())
 
     # check if all excluded column names found in all_data
-    misc_utils.verify_in_list(columns_to_exclude=excluded_channels,
-                              column_names=all_data.columns)
+    if excluded_channels is not None:
+        misc_utils.verify_in_list(columns_to_exclude=excluded_channels,
+                                  column_names=all_data.columns)
 
     # make sure number of clusters specified is valid
     if cluster_num < 2:
@@ -619,14 +620,17 @@ def generate_cluster_matrix_results(all_data, neighbor_mat, cluster_num, exclude
     num_cell_type_per_cluster.index = ["Cluster" + str(c)
                                        for c in num_cell_type_per_cluster.index]
 
-    # Subsets the expression matrix to only have channel columns
+    # subsets the expression matrix to only have channel columns
     channel_start = np.where(all_data_clusters.columns == pre_channel_col)[0][0] + 1
     channel_end = np.where(all_data_clusters.columns == post_channel_col)[0][0]
     cluster_label_colnum = np.where(all_data_clusters.columns == cluster_label_col)[0][0]
 
     all_data_markers_clusters = \
         all_data_clusters.iloc[:, list(range(channel_start, channel_end)) + [cluster_label_colnum]]
-    all_data_markers_clusters = all_data_markers_clusters.drop(excluded_channels, axis=1)
+
+    # drop excluded channels
+    if excluded_channels is not None:
+        all_data_markers_clusters = all_data_markers_clusters.drop(excluded_channels, axis=1)
 
     # create a mean pivot table with cluster_label_col as row and channels as column
     mean_marker_exp_per_cluster = all_data_markers_clusters.groupby([cluster_label_col]).mean()

--- a/ark/analysis/spatial_analysis_test.py
+++ b/ark/analysis/spatial_analysis_test.py
@@ -404,6 +404,13 @@ def test_generate_cluster_matrix_results():
     assert list(mean_marker_exp_per_cluster.columns.values) == \
         list(np.arange(2, 14)) + list(np.arange(15, 23))
 
+    # test excluded_channels=None
+    all_data_markers_clusters, num_cell_type_per_cluster, mean_marker_exp_per_cluster = \
+        spatial_analysis.generate_cluster_matrix_results(
+            all_data_pos, neighbor_counts, cluster_num=2, excluded_channels=None
+        )
+    assert all(x in mean_marker_exp_per_cluster.columns.values for x in excluded_channels)
+
 
 def test_compute_cluster_metrics_inertia():
     # get an example neighborhood matrix


### PR DESCRIPTION
Closes #787 

**What is the purpose of this PR?**

Fixes bug in kmeans neighborhood notebook if excluded_channels is None.

**How did you implement your changes**

Include check for excluded_channels is None before subsetting data table.