### PR TITLE
Increase validate paths usage

### DIFF
--- a/ark/phenotyping/cell_cluster_utils.py
+++ b/ark/phenotyping/cell_cluster_utils.py
@@ -9,7 +9,7 @@ import pandas as pd
 import scipy.stats as stats
 
 from ark.analysis import visualize
-from ark.utils import misc_utils
+from ark.utils import misc_utils, io_utils
 
 
 def compute_cell_cluster_count_avg(cell_cluster_path, pixel_cluster_col_prefix,
@@ -96,10 +96,7 @@ def compute_cell_cluster_channel_avg(fovs, channels, base_dir,
     """
 
     # verify the cell table actually exists
-    if not os.path.exists(os.path.join(base_dir, weighted_cell_channel_name)):
-        raise FileNotFoundError(
-            "Weighted cell table %s not found in %s" % (weighted_cell_channel_name, base_dir)
-        )
+    io_utils.validate_paths(os.path.join(base_dir, weighted_cell_channel_name))
 
     # verify the cell cluster col specified is valid
     misc_utils.verify_in_list(
@@ -445,15 +442,8 @@ def train_cell_som(fovs, channels, base_dir, pixel_data_dir, cell_table_path,
     cluster_counts_norm_path = os.path.join(base_dir, cluster_counts_norm_name)
     weights_path = os.path.join(base_dir, weights_name)
 
-    # if the cell table path does not exist
-    if not os.path.exists(cell_table_path):
-        raise FileNotFoundError('Cell table path %s does not exist' %
-                                cell_table_path)
-
-    # if the pixel data with the SOM and meta labels path does not exist
-    if not os.path.exists(pixel_data_path):
-        raise FileNotFoundError('Pixel data dir %s does not exist in base_dir %s' %
-                                (pixel_data_path, base_dir))
+    # check the cell table path and pixel data path exist
+    io_utils.validate_paths([cell_table_path, pixel_data_path])
 
     # verify the cluster_col provided is valid
     misc_utils.verify_in_list(
@@ -550,17 +540,8 @@ def cluster_cells(base_dir, cluster_counts_norm_name='cluster_counts_norm.feathe
     weights_path = os.path.join(base_dir, weights_name)
     cell_data_path = os.path.join(base_dir, cell_data_name)
 
-    # if the path to the normalized pixel cluster counts per cell doesn't exist
-    if not os.path.exists(cluster_counts_norm_path):
-        raise FileNotFoundError(
-            'Normalized pixel cluster counts per cell file %s does not exist in base_dir %s' %
-            (cluster_counts_norm_name, base_dir)
-        )
-
-    # if the path to the weights file does not exist
-    if not os.path.exists(weights_path):
-        raise FileNotFoundError('Weights file %s does not exist in base_dir %s' %
-                                (weights_name, base_dir))
+    # check the path to the normalized pixel cluster counts per cell and weights file exists
+    io_utils.validate_paths([cluster_counts_norm_path, weights_path])
 
     # verify the pixel_cluster_col_prefix provided is valid
     misc_utils.verify_in_list(
@@ -678,26 +659,8 @@ def cell_consensus_cluster(fovs, channels, base_dir, pixel_cluster_col, max_k=20
     weighted_channel_path = os.path.join(base_dir, weighted_cell_channel_name)
     clust_to_meta_path = os.path.join(base_dir, clust_to_meta_name)
 
-    # if the path to the SOM clustered data doesn't exist
-    if not os.path.exists(cell_data_path):
-        raise FileNotFoundError(
-            'Cell data file %s does not exist in base_dir %s' %
-            (cell_data_name, base_dir)
-        )
-
-    # if the path to the average pixel cluster counts per cell cluster doesn't exist
-    if not os.path.exists(som_cluster_counts_avg_path):
-        raise FileNotFoundError(
-            'Average pix clust count per cell SOM cluster file %s does not exist in base_dir %s' %
-            (cell_som_cluster_count_avgs_name, base_dir)
-        )
-
-    # if the path to the weighted channel data doesn't exist
-    if not os.path.exists(weighted_channel_path):
-        raise FileNotFoundError(
-            'Weighted channel table %s does not exist in base_dir %s' %
-            (weighted_cell_channel_name, base_dir)
-        )
+    # check paths
+    io_utils.validate_paths([cell_data_path, som_cluster_counts_avg_path, weighted_channel_path])
 
     # verify the pixel_cluster_col provided is valid
     misc_utils.verify_in_list(
@@ -866,41 +829,10 @@ def apply_cell_meta_cluster_remapping(fovs, channels, base_dir, cell_consensus_n
     meta_cluster_channel_avgs_path = os.path.join(base_dir, cell_meta_cluster_channel_avg_name)
 
     # file path validation
-    if not os.path.exists(cell_consensus_path):
-        raise FileNotFoundError('Cell consensus file %s does not exist in base_dir %s' %
-                                (cell_consensus_name, base_dir))
-
-    if not os.path.exists(cell_remapped_path):
-        raise FileNotFoundError('Cell remapping file %s does not exist in base_dir %s' %
-                                (cell_remapped_name, base_dir))
-
-    if not os.path.exists(som_cluster_counts_avgs_path):
-        raise FileNotFoundError(
-            'Average pix clust count per cell SOM cluster file %s does not exist in base_dir %s' %
-            (cell_som_cluster_count_avgs_name, base_dir)
-        )
-
-    if not os.path.exists(meta_cluster_counts_avgs_path):
-        raise FileNotFoundError(
-            'Average pix clust count per cell meta cluster file %s does not exist in base_dir %s' %
-            (cell_meta_cluster_count_avgs_name, base_dir)
-        )
-
-    if not os.path.exists(weighted_channel_path):
-        raise FileNotFoundError('Weighted channel table %s does not exist in base_dir %s' %
-                                (weighted_cell_channel_name, base_dir))
-
-    if not os.path.exists(som_cluster_channel_avgs_path):
-        raise FileNotFoundError(
-            'Average weighted chan per cell SOM cluster file %s does not exist in base_dir %s' %
-            (cell_som_cluster_channel_avg_name, base_dir)
-        )
-
-    if not os.path.exists(meta_cluster_channel_avgs_path):
-        raise FileNotFoundError(
-            'Average weighted chan per cell meta cluster file %s does not exist in base_dir %s' %
-            (cell_meta_cluster_channel_avg_name, base_dir)
-        )
+    io_utils.validate_paths([cell_consensus_path, cell_remapped_path,
+                             som_cluster_counts_avgs_path, meta_cluster_counts_avgs_path,
+                             weighted_channel_path, som_cluster_channel_avgs_path,
+                             meta_cluster_channel_avgs_path])
 
     # verify the pixel_cluster_col provided is valid
     misc_utils.verify_in_list(
@@ -1061,9 +993,7 @@ def generate_weighted_channel_avg_heatmap(cell_cluster_channel_avg_path, cell_cl
     """
 
     # file path validation
-    if not os.path.exists(cell_cluster_channel_avg_path):
-        raise FileNotFoundError('Channel average path %s does not exist' %
-                                cell_cluster_channel_avg_path)
+    io_utils.validate_paths(cell_cluster_channel_avg_path)
 
     # verify the cell_cluster_col provided is valid
     misc_utils.verify_in_list(
@@ -1138,13 +1068,7 @@ def add_consensus_labels_cell_table(base_dir, cell_table_path, cell_data_name):
     cell_data_path = os.path.join(base_dir, cell_data_name)
 
     # file path validation
-    if not os.path.exists(cell_table_path):
-        raise FileNotFoundError('Cell table file %s does not exist' %
-                                cell_table_path)
-
-    if not os.path.exists(cell_data_path):
-        raise FileNotFoundError('Cell data file %s does not exist in base_dir %s' %
-                                (cell_data_name, base_dir))
+    io_utils.validate_paths([cell_data_path, cell_data_path])
 
     # read in the data, ensure sorted by FOV column just in case
     cell_table = pd.read_csv(cell_table_path)

--- a/ark/phenotyping/pixel_cluster_utils.py
+++ b/ark/phenotyping/pixel_cluster_utils.py
@@ -256,8 +256,7 @@ def filter_with_nuclear_mask(fovs, tiff_dir, seg_dir, channel,
         return
 
     # raise an error if the provided seg_dir does not exist
-    if not os.path.exists(seg_dir):
-        raise FileNotFoundError('seg_dir %s does not exist' % seg_dir)
+    io_utils.validate_paths(seg_dir)
 
     # convert to path-compatible format
     if img_sub_folder is None:
@@ -603,17 +602,8 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
     if subset_proportion <= 0 or subset_proportion > 1:
         raise ValueError('Invalid subset percentage entered: must be in (0, 1]')
 
-    # if the base directory doesn't exist
-    if not os.path.exists(base_dir):
-        raise FileNotFoundError("base_dir %s does not exist" % base_dir)
-
-    # if the tiff dir doesn't exist
-    if not os.path.exists(tiff_dir):
-        raise FileNotFoundError("tiff_dir %s does not exist" % tiff_dir)
-
-    # if the pixel output dir doesn't exist
-    if not os.path.exists(os.path.join(base_dir, pixel_output_dir)):
-        raise FileNotFoundError("pixel_output_dir %s does not exist" % pixel_output_dir)
+    # path validation
+    io_utils.validate_paths([base_dir, tiff_dir, os.path.join(base_dir, pixel_output_dir)])
 
     # create data_dir if it doesn't already exist
     if not os.path.exists(os.path.join(base_dir, data_dir)):
@@ -794,9 +784,7 @@ def find_fovs_missing_col(base_dir, data_dir, missing_col):
     temp_path = os.path.join(base_dir, data_dir + '_temp')
 
     # verify the data path exists
-    if not os.path.exists(data_path):
-        raise FileNotFoundError('Data directory %s does not exist in base_dir %s' %
-                                (data_dir, base_dir))
+    io_utils.validate_paths(data_path)
 
     # if the temp path does not exist, either all the FOVs need to be run or none of them do
     if not os.path.exists(temp_path):
@@ -883,9 +871,7 @@ def train_pixel_som(fovs, channels, base_dir,
         return
 
     # if path to the subsetted file does not exist
-    if not os.path.exists(subsetted_path):
-        raise FileNotFoundError('Pixel subsetted directory %s does not exist in base_dir %s' %
-                                (subset_dir, base_dir))
+    io_utils.validate_paths(subsetted_path)
 
     # verify that all provided fovs exist in the folder
     files = io_utils.list_files(subsetted_path, substrs='.feather')
@@ -959,20 +945,8 @@ def cluster_pixels(fovs, channels, base_dir, data_dir='pixel_mat_data',
     norm_vals_path = os.path.join(base_dir, norm_vals_name)
     weights_path = os.path.join(base_dir, weights_name)
 
-    # if path to the preprocessed directory does not exist
-    if not os.path.exists(data_path):
-        raise FileNotFoundError('Pixel data directory %s does not exist in base_dir %s' %
-                                (data_dir, base_dir))
-
-    # if path to the normalized values file does not exist
-    if not os.path.exists(norm_vals_path):
-        raise FileNotFoundError('Normalized values file %s does not exist in base_dir %s' %
-                                (norm_vals_path, base_dir))
-
-    # if path to the weights file does not exist
-    if not os.path.exists(weights_path):
-        raise FileNotFoundError('Weights file %s does not exist in base_dir %s' %
-                                (weights_name, base_dir))
+    # path validation
+    io_utils.validate_paths([data_path, norm_vals_path, weights_path])
 
     # verify that all provided fovs exist in the folder
     # NOTE: remove the channel and pixel normalization files as those are not pixel data
@@ -1126,19 +1100,8 @@ def pixel_consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
     som_cluster_avg_path = os.path.join(base_dir, pc_chan_avg_som_cluster_name)
     clust_to_meta_path = os.path.join(base_dir, clust_to_meta_name)
 
-    # if the path to the SOM clustered data doesn't exist
-    if not os.path.exists(data_path):
-        raise FileNotFoundError(
-            'Data dir %s does not exist in base_dir %s' %
-            (data_dir, base_dir)
-        )
-
-    # if the path to the average channel expression per SOM cluster doesn't exist
-    if not os.path.exists(som_cluster_avg_path):
-        raise FileNotFoundError(
-            'Channel avg per SOM cluster file %s does not exist in base_dir %s' %
-            (pc_chan_avg_som_cluster_name, base_dir)
-        )
+    # path validation
+    io_utils.validate_paths([data_path, som_cluster_avg_path])
 
     # if the path mapping SOM to meta clusters exists, don't re-run consensus clustering
     if os.path.exists(clust_to_meta_path):
@@ -1318,23 +1281,8 @@ def apply_pixel_meta_cluster_remapping(fovs, channels, base_dir,
     meta_cluster_avg_path = os.path.join(base_dir, pc_chan_avg_meta_cluster_name)
 
     # file path validation
-    if not os.path.exists(pixel_data_path):
-        raise FileNotFoundError('Pixel data dir %s does not exist in base_dir %s' %
-                                (pixel_data_dir, base_dir))
-
-    if not os.path.exists(pixel_remapped_path):
-        raise FileNotFoundError('Pixel remapping file %s does not exist in base_dir %s' %
-                                (pixel_remapped_name, base_dir))
-
-    if not os.path.exists(som_cluster_avg_path):
-        raise FileNotFoundError(
-            'Channel average per SOM cluster file %s does not exist in base_dir %s' %
-            (pc_chan_avg_meta_cluster_name, base_dir))
-
-    if not os.path.exists(meta_cluster_avg_path):
-        raise FileNotFoundError(
-            'Channel average per meta cluster file %s does not exist in base_dir %s' %
-            (pc_chan_avg_meta_cluster_name, base_dir))
+    io_utils.validate_paths([pixel_data_path, pixel_remapped_path, som_cluster_avg_path,
+                             meta_cluster_avg_path])
 
     # read in the remapping
     pixel_remapped_data = pd.read_csv(pixel_remapped_path)

--- a/ark/segmentation/fiber_segmentation_test.py
+++ b/ark/segmentation/fiber_segmentation_test.py
@@ -18,7 +18,7 @@ def test_plot_fiber_segmentation_steps():
             shutil.rmtree(os.path.join(temp_dir, 'image_data', fov))
 
         # bad directory should raise an errors
-        with pytest.raises(ValueError):
+        with pytest.raises(FileNotFoundError):
             _, _ = fiber_segmentation.plot_fiber_segmentation_steps('bad_dir', 'fov1', 'Collagen1')
 
         # bad channel should raise an errors
@@ -46,10 +46,10 @@ def test_run_fiber_segmentation():
         os.makedirs(out_dir)
 
         # bad directories should raise an error
-        with pytest.raises(ValueError):
+        with pytest.raises(FileNotFoundError):
             _ = fiber_segmentation.run_fiber_segmentation('bad_path', 'Collagen1', out_dir)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(FileNotFoundError):
             _ = fiber_segmentation.run_fiber_segmentation(img_dir, 'Collagen1', 'bad_path')
 
         # bad subdirectory should raise an errors

--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -570,7 +570,7 @@ def stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=None, channels
         stitched_dir (str):
             path to directory to save stitched images to
         img_sub_folder (str):
-            optional name of image sub-foldexr within each fov
+            optional name of image sub-folder within each fov
         channels (list):
             optional list of imgs to load, otherwise loads all imgs
         segmentation (bool):

--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -272,17 +272,8 @@ def generate_pixel_cluster_mask(fov, base_dir, tiff_dir, chan_file_path,
     """
 
     # path checking
-    if not os.path.exists(tiff_dir):
-        raise FileNotFoundError("tiff_dir %s does not exist")
-
-    if not os.path.exists(os.path.join(tiff_dir, chan_file_path)):
-        raise FileNotFoundError("chan_file_path %s does not exist in tiff_dir %s"
-                                % (chan_file_path, tiff_dir))
-
-    if not os.path.exists(os.path.join(base_dir, pixel_data_dir)):
-        raise FileNotFoundError(
-            "Pixel data dir %s does not exist in base_dir %s" % (pixel_data_dir, base_dir)
-        )
+    io_utils.validate_paths([tiff_dir, os.path.join(tiff_dir, chan_file_path),
+                             os.path.join(base_dir, pixel_data_dir)])
 
     # verify the pixel_cluster_col provided is valid
     verify_in_list(

--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -40,8 +40,7 @@ def save_fov_mask(fov, data_dir, mask_data, sub_dir=None, name_suffix=''):
     """
 
     # data_dir validation
-    if not os.path.exists(data_dir):
-        raise FileNotFoundError("data_dir %s does not exist" % data_dir)
+    io_utils.validate_paths(data_dir)
 
     # ensure None is handled correctly in file path generation
     if sub_dir is None:
@@ -161,12 +160,8 @@ def generate_cell_cluster_mask(fov, base_dir, seg_dir, cell_data_name,
     """
 
     # path checking
-    if not os.path.exists(seg_dir):
-        raise FileNotFoundError("seg_dir %s does not exist" % seg_dir)
-
-    if not os.path.exists(os.path.join(base_dir, cell_data_name)):
-        raise FileNotFoundError(
-            "Cell data file %s does not exist in base_dir %s" % (cell_data_name, base_dir))
+    cell_data_path = os.path.join(os.path.join(base_dir, cell_data_name))
+    io_utils.validate_paths([seg_dir, cell_data_path])
 
     # verify the cluster_col provided is valid
     verify_in_list(
@@ -584,7 +579,7 @@ def stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=None, channels
         stitched_dir (str):
             path to directory to save stitched images to
         img_sub_folder (str):
-            optional name of image sub-folder within each fov
+            optional name of image sub-foldexr within each fov
         channels (list):
             optional list of imgs to load, otherwise loads all imgs
         segmentation (bool):

--- a/ark/utils/data_utils_test.py
+++ b/ark/utils/data_utils_test.py
@@ -686,7 +686,7 @@ def test_stitch_images_by_shape(segmentation, clustering, subdir, fovs):
             os.makedirs(data_dir)
 
             # invalid directory is provided
-            with pytest.raises(ValueError):
+            with pytest.raises(FileNotFoundError):
                 data_utils.stitch_images_by_shape('not_a_dir', stitched_dir)
 
             # no fov dirs should raise an error

--- a/ark/utils/io_utils.py
+++ b/ark/utils/io_utils.py
@@ -24,7 +24,7 @@ def validate_paths(paths, data_prefix=False):
     for path in paths:
         # check data prefix
         if data_prefix and not str(path).startswith('../data'):
-            raise ValueError(
+            raise FileNotFoundError(
                 f'The path, {path}, is not prefixed with \'../data\'.\n'
                 f'Be sure to add all images/files/data to the \'data\' folder, '
                 f'and to reference as \'../data/path_to_data/myfile.tif\'')
@@ -32,10 +32,10 @@ def validate_paths(paths, data_prefix=False):
         if not os.path.exists(path):
             for parent in reversed(pathlib.Path(path).parents):
                 if not os.path.exists(parent):
-                    raise ValueError(
+                    raise FileNotFoundError(
                         f'A bad path, {path}, was provided.\n'
                         f'The folder, {parent.name}, could not be found...')
-            raise ValueError(
+            raise FileNotFoundError(
                 f'The file/path, {pathlib.Path(path).name}, could not be found...')
 
 

--- a/ark/utils/io_utils_test.py
+++ b/ark/utils/io_utils_test.py
@@ -42,22 +42,22 @@ def test_validate_paths():
                            data_prefix=True)
 
         # test out-of-scope
-        with pytest.raises(ValueError, match=r".*not_a_real_directory.*prefixed.*"):
+        with pytest.raises(FileNotFoundError, match=r".*not_a_real_directory.*prefixed.*"):
             iou.validate_paths(starts_out_of_scope, data_prefix=True)
 
         # test mid-directory existence
-        with pytest.raises(ValueError, match=r".*bad path.*not_a_real_subdirectory.*"):
+        with pytest.raises(FileNotFoundError, match=r".*bad path.*not_a_real_subdirectory.*"):
             iou.validate_paths(bad_middle_path, data_prefix=True)
 
         # test file existence
-        with pytest.raises(ValueError, match=r".*The file/path.*not_a_real_file.*"):
+        with pytest.raises(FileNotFoundError, match=r".*The file/path.*not_a_real_file.*"):
             iou.validate_paths(wrong_file, data_prefix=True)
 
     # make tempdir for testing outside of docker
     with tempfile.TemporaryDirectory() as valid_path:
 
         # check valid path but no data prefix
-        with pytest.raises(ValueError, match=r".*is not prefixed with.*"):
+        with pytest.raises(FileNotFoundError, match=r".*is not prefixed with.*"):
             iou.validate_paths(valid_path, data_prefix=True)
 
         # make valid subdirectory
@@ -68,10 +68,10 @@ def test_validate_paths():
         starts_out_of_scope = os.path.join(*valid_parts)
 
         # test out of scope when specifying out of scope
-        with pytest.raises(ValueError, match=r".*not_a_real_directory*"):
+        with pytest.raises(FileNotFoundError, match=r".*not_a_real_directory*"):
             iou.validate_paths(starts_out_of_scope, data_prefix=False)
 
-        with pytest.raises(ValueError, match=r".*is not prefixed with.*"):
+        with pytest.raises(FileNotFoundError, match=r".*is not prefixed with.*"):
             iou.validate_paths(starts_out_of_scope, data_prefix=True)
 
     # reset cwd after testing

--- a/ark/utils/load_utils_test.py
+++ b/ark/utils/load_utils_test.py
@@ -10,7 +10,7 @@ from ark.utils import load_utils, test_utils
 
 def test_load_imgs_from_mibitiff():
     # invalid directory is provided
-    with pytest.raises(ValueError):
+    with pytest.raises(FileNotFoundError):
         loaded_xr = \
             load_utils.load_imgs_from_mibitiff('not_a_dir', channels=None, delimiter='_')
 
@@ -70,7 +70,7 @@ def test_load_imgs_from_mibitiff():
 
 def test_load_imgs_from_tree():
     # invalid directory is provided
-    with pytest.raises(ValueError):
+    with pytest.raises(FileNotFoundError):
         loaded_xr = \
             load_utils.load_imgs_from_tree('not_a_dir', img_sub_folder="TIFs")
 
@@ -171,7 +171,7 @@ def test_load_imgs_from_tree():
 
 def test_load_imgs_from_dir():
     # invalid directory is provided
-    with pytest.raises(ValueError):
+    with pytest.raises(FileNotFoundError):
         loaded_xr = \
             load_utils.load_imgs_from_dir('not_a_dir', trim_suffix='_')
 
@@ -358,7 +358,7 @@ def test_get_tiled_fov_names():
 @pytest.mark.parametrize('single_dir, img_sub_folder', [(False, 'TIFs'), (True, '')])
 def test_load_tiled_img_data(single_dir, img_sub_folder):
     # invalid directory is provided
-    with pytest.raises(ValueError):
+    with pytest.raises(FileNotFoundError):
         loaded_xr = load_utils.load_tiled_img_data('not_a_dir', [], 'chan1',
                                                    single_dir=False,)
 

--- a/ark/utils/metacluster_remap_gui/colormap_helper.py
+++ b/ark/utils/metacluster_remap_gui/colormap_helper.py
@@ -6,7 +6,7 @@ import matplotlib
 import numpy as np
 import pandas as pd
 
-from ark.utils import misc_utils
+from ark.utils import misc_utils, io_utils
 
 
 def distinct_cmap(n=33):
@@ -80,9 +80,7 @@ def generate_meta_cluster_colormap_dict(meta_cluster_remap_path, cmap):
     """
 
     # file path validation
-    if not os.path.exists(meta_cluster_remap_path):
-        raise FileNotFoundError('Remapping path %s does not exist' %
-                                meta_cluster_remap_path)
+    io_utils.validate_paths(meta_cluster_remap_path)
 
     # read the remapping
     remapping = pd.read_csv(meta_cluster_remap_path)

--- a/ark/utils/metacluster_remap_gui/file_reader.py
+++ b/ark/utils/metacluster_remap_gui/file_reader.py
@@ -2,7 +2,7 @@ import os
 
 import pandas as pd
 
-from ark.utils import misc_utils
+from ark.utils import misc_utils, io_utils
 
 from .metaclusterdata import MetaClusterData
 
@@ -24,8 +24,8 @@ def metaclusterdata_from_files(cluster_path, cluster_type='pixel', prefix_trim=N
     """
 
     # assert the path to the data is valid if a string
-    if isinstance(cluster_path, str) and not os.path.exists(cluster_path):
-        raise FileNotFoundError('Path to clustering data %s does not exist' % cluster_path)
+    if isinstance(cluster_path, str):
+        io_utils.validate_paths(cluster_path)
 
     # assert the cluster type provided is valid
     misc_utils.verify_in_list(

--- a/ark/utils/misc_utils.py
+++ b/ark/utils/misc_utils.py
@@ -110,7 +110,11 @@ def save_figure(save_dir, save_file, dpi=None):
     """
 
     # path validation
-    io_utils.validate_paths([save_dir, save_file])
+    io_utils.validate_paths(save_dir)
+
+    # verify that if save_dir specified, save_file must also be specified
+    if save_file is None:
+        raise FileNotFoundError("save_dir specified but no save_file specified")
 
     plt.savefig(os.path.join(save_dir, save_file), dpi=dpi)
 

--- a/ark/utils/misc_utils.py
+++ b/ark/utils/misc_utils.py
@@ -7,6 +7,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 
+from ark.utils import io_utils
+
 
 def combine_xarrays(xarrays, axis):
     """Combines a number of xarrays together
@@ -107,13 +109,8 @@ def save_figure(save_dir, save_file, dpi=None):
             the resolution of the figure
     """
 
-    # verify save_dir exists
-    if not os.path.exists(save_dir):
-        raise FileNotFoundError("save_dir %s does not exist" % save_dir)
-
-    # verify that if save_dir specified, save_file must also be specified
-    if save_file is None:
-        raise FileNotFoundError("save_dir specified but no save_file specified")
+    # path validation
+    io_utils.validate_paths([save_dir, save_file])
 
     plt.savefig(os.path.join(save_dir, save_file), dpi=dpi)
 

--- a/ark/utils/plot_utils.py
+++ b/ark/utils/plot_utils.py
@@ -113,11 +113,7 @@ def plot_pixel_cell_cluster_overlay(img_xr, fovs, cluster_id_to_name_path, metac
     verify_in_list(fov_names=fovs, unique_fovs=img_xr.fovs.values)
 
     # verify cluster_id_to_name_path exists
-    if not os.path.exists(cluster_id_to_name_path):
-        raise FileNotFoundError(
-            'Metacluster id to renamed metacluster mapping %s does not exist' %
-            cluster_id_to_name_path
-        )
+    io_utils.validate_paths(cluster_id_to_name_path)
 
     # read the cluster to name mapping
     cluster_id_to_name = pd.read_csv(cluster_id_to_name_path)

--- a/ark/utils/spatial_analysis_utils_test.py
+++ b/ark/utils/spatial_analysis_utils_test.py
@@ -33,7 +33,7 @@ def test_calc_dist_matrix():
     assert np.array_equal(distance_mat["2"].loc[range(1, 4), range(1, 4)], real_mat)
 
     # file save testing
-    with pytest.raises(ValueError):
+    with pytest.raises(FileNotFoundError):
         # trying to save to a non-existent directory
         distance_mat = spatial_analysis_utils.calc_dist_matrix(test_mat, save_path="bad_path")
 

--- a/ark/utils/spatial_lda_utils.py
+++ b/ark/utils/spatial_lda_utils.py
@@ -12,6 +12,7 @@ from spatial_lda.visualization import _standardize_topics, plot_adjacency_graph
 
 from ark.settings import BASE_COLS, LDA_PLOT_TYPES, CELL_TYPE
 from ark.utils.misc_utils import verify_in_list
+from ark.utils.io_utils import validate_paths
 
 
 def check_format_cell_table_args(cell_table, markers, clusters):
@@ -250,8 +251,7 @@ def read_spatial_lda_file(dir, file_name, format="pkl"):
     """
     file_name += "." + format
     file_path = os.path.join(dir, file_name)
-    if not os.path.exists(file_path):
-        raise FileNotFoundError("No file named '{}'.".format(file_path))
+    validate_paths(file_path)
 
     if format == "pkl":
         with open(file_path, "rb") as f:

--- a/ark/utils/spatial_lda_utils_test.py
+++ b/ark/utils/spatial_lda_utils_test.py
@@ -160,7 +160,7 @@ def test_read_spatial_lda_file():
         file_path = os.path.join(temp_dir, "fake_file.txt")
         with open(file_path, "w") as f:
             f.write("content")
-        with pytest.raises(FileNotFoundError, match="No file named"):
+        with pytest.raises(FileNotFoundError):
             spu.read_spatial_lda_file(dir=temp_dir, file_name="bad_file")
         with pytest.raises(ValueError, match="format must be either"):
             spu.read_spatial_lda_file(dir=temp_dir, file_name="fake_file", format="txt")

--- a/ark/utils/test_utils.py
+++ b/ark/utils/test_utils.py
@@ -9,7 +9,7 @@ import skimage.io as io
 import xarray as xr
 
 import ark.settings as settings
-from ark.utils import synthetic_spatial_datagen
+from ark.utils import synthetic_spatial_datagen, io_utils
 from ark.utils.tiff_utils import write_mibitiff
 
 
@@ -428,8 +428,8 @@ def create_paired_xarray_fovs(base_dir, fov_names, channel_names, img_shape=(10,
           (num_fovs, im_shape[0], shape[1], num_channels)
     """
 
-    if not os.path.isdir(base_dir):
-        raise FileNotFoundError(f'{base_dir} is not a directory')
+    # validation checks
+    io_utils.validate_paths(base_dir)
 
     if fov_names is None or fov_names is []:
         raise ValueError('No fov names were given...')


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #777.
Change `validate_paths` to raise a FileNotFoundError instead of a ValueError, and use the function when appropriate throughout the repo.

**Remaining issues**

When we bump ark to toffy eventually, a lot of the tests will need to be changed to catch the new error type.
