### PR TITLE
Compressed `csv` Option in Notebook 1

### DIFF
--- a/ark/segmentation/fiber_segmentation.py
+++ b/ark/segmentation/fiber_segmentation.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict, Optional
 
 import numpy as np
 import pandas as pd
@@ -131,7 +132,8 @@ def plot_fiber_segmentation_steps(data_dir, fov_name, fiber_channel, img_sub_fol
         ax.axis('off')
 
 
-def run_fiber_segmentation(data_dir, fiber_channel, out_dir, img_sub_folder=None, **kwargs):
+def run_fiber_segmentation(data_dir, fiber_channel, out_dir, img_sub_folder=None,
+                           csv_compression: Optional[Dict[str, str]] = None, **kwargs):
     """Segments fibers one FOV at a time
 
     Args:
@@ -143,6 +145,8 @@ def run_fiber_segmentation(data_dir, fiber_channel, out_dir, img_sub_folder=None
             Directory to save fiber object labels and table.
         img_sub_folder (str | NoneType):
             Image subfolder name in `data_dir`. If there is not subfolder, set this to None.
+        csv_compression (Optional[Dict[str, str]]): Dictionary of compression arguments to pass
+            when saving csvs. See :meth:`to_csv <pandas.DataFrame.to_csv>` for details.
         **kwargs:
             Keyword arguments for `segment_fibers`
 
@@ -174,7 +178,8 @@ def run_fiber_segmentation(data_dir, fiber_channel, out_dir, img_sub_folder=None
         fiber_object_table.append(subtable)
 
     fiber_object_table = pd.concat(fiber_object_table)
-    fiber_object_table.to_csv(os.path.join(out_dir, 'fiber_object_table.csv'), index=False)
+    fiber_object_table.to_csv(os.path.join(out_dir, 'fiber_object_table.csv'), index=False,
+                              compression=csv_compression)
 
     return fiber_object_table
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ tifffile>=2022.8.12,<2023
 umap-learn>=0.5.3,<1
 xarray>=2022.6.0,<2023
 tqdm>=4.64.0,<5
+zstandard>=0.19.0,<1

--- a/templates/1_Segment_Image_Data.ipynb
+++ b/templates/1_Segment_Image_Data.ipynb
@@ -365,19 +365,18 @@
    },
    "outputs": [],
    "source": [
-    "# save extracted data as csv for downstream analysis\n",
+    "# Set the compression level if desired, ZSTD compression can offer up to a 60-70% reduction in file size.\n",
+    "# NOTE: Compressed `csv` files cannot be opened in Excel. They must be uncompressed beforehand.\n",
+    "compression = None\n",
+    "\n",
+    "# Uncomment the line below to allow for compressed `csv` files.\n",
+    "# compression = {\"method\": \"zstd\", \"level\": 3}\n",
+    "\n",
     "cell_table_size_normalized.to_csv(os.path.join(cell_table_dir, 'cell_table_size_normalized.csv'),\n",
-    "                                 index=False)\n",
+    "                                  compression=compression, index=False)\n",
     "cell_table_arcsinh_transformed.to_csv(os.path.join(cell_table_dir, 'cell_table_arcsinh_transformed.csv'),\n",
-    "                                     index=False)"
+    "                                      compression=compression, index=False)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #775. Adds csv compression.

**How did you implement your changes**

Adds an option in Notebook 1 and fiber segmentation notebook for saving the csvs with ZSTD Compression.

**Remaining issues**

None ATM.
