### PR TITLE
Adjust load tiled imgs for toffy use

### DIFF
--- a/ark/utils/data_utils.py
+++ b/ark/utils/data_utils.py
@@ -650,11 +650,11 @@ def stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=None, channels
     os.makedirs(stitched_dir)
 
     file_ext = channel_imgs[0].split('.')[1]
-    _, num_rows, num_cols = load_utils.get_tiled_fov_names(fovs, return_dims=True)
+    expected_fovs, num_rows, num_cols = load_utils.get_tiled_fov_names(fovs, return_dims=True)
 
     # save new images to the stitched_images, one channel at a time
     for chan in channels:
-        image_data = load_tiled_img_data(data_dir, fovs, chan,
+        image_data = load_tiled_img_data(data_dir, fovs, expected_fovs, chan,
                                          single_dir=any([segmentation, clustering]),
                                          file_ext=file_ext, img_sub_folder=img_sub_folder)
         stitched_data = stitch_images(image_data, num_cols)

--- a/ark/utils/load_utils.py
+++ b/ark/utils/load_utils.py
@@ -394,15 +394,17 @@ def get_tiled_fov_names(fov_list, return_dims=False):
         return expected_fovs
 
 
-def load_tiled_img_data(data_dir, fov_list, channel, single_dir, file_ext='tiff',
+def load_tiled_img_data(data_dir, fovs, expected_fovs, channel, single_dir, file_ext='tiff',
                         img_sub_folder=''):
     """Takes a set of images from a directory structure and loads them into a tiled xarray.
 
     Args:
         data_dir (str):
             directory containing folders of images
-        fov_list (list):
-            list of fovs to load data for
+        fovs (list/dict):
+            list of fovs (or dictionary with folder and RnCm names) to load data for
+        expected_fovs (list):
+            list of all expected RnCm fovs names in the tiled grid
         channel (str):
             single image name to load
         single_dir (bool):
@@ -419,7 +421,13 @@ def load_tiled_img_data(data_dir, fov_list, channel, single_dir, file_ext='tiff'
 
     iou.validate_paths(data_dir, data_prefix=False)
 
-    expected_fovs = get_tiled_fov_names(fov_list)
+    # check for toffy fovs
+    if type(fovs) is dict:
+        fov_list = list(fovs.values())
+        tiled_names = list(fovs.keys())
+    else:
+        fov_list = fovs
+        tiled_names = []
 
     # no missing fov images, load data normally and return array
     if len(fov_list) == len(expected_fovs):
@@ -445,11 +453,19 @@ def load_tiled_img_data(data_dir, fov_list, channel, single_dir, file_ext='tiff'
         # load in fov data for images, leave missing fovs as zeros
         if fov_name in fov_list:
             if single_dir:
-                temp_img = io.imread(os.path.join(data_dir, expected_fovs[fov] + '_' +
+                temp_img = io.imread(os.path.join(data_dir, fov_name + '_' +
                                                   channel + '.' + file_ext))
             else:
-                temp_img = io.imread(os.path.join(data_dir, expected_fovs[fov], img_sub_folder,
+                temp_img = io.imread(os.path.join(data_dir, fov_name, img_sub_folder,
                                                   channel + '.' + file_ext))
+            # fill in specific spot in array
+            img_data[fov, :temp_img.shape[0], :temp_img.shape[1], 0] = temp_img
+
+        # check against tiled_names from dict for toffy dirs
+        elif fov_name in tiled_names:
+            folder_name = fovs[fov_name]
+            temp_img = io.imread(os.path.join(data_dir, folder_name, img_sub_folder,
+                                              channel + '.' + file_ext))
             # fill in specific spot in array
             img_data[fov, :temp_img.shape[0], :temp_img.shape[1], 0] = temp_img
 

--- a/ark/utils/load_utils_test.py
+++ b/ark/utils/load_utils_test.py
@@ -383,13 +383,16 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
         if not single_dir:
             toffy_fovs = {'R1C1': 'fov-1', 'R1C2': 'fov-3', 'R1C3': 'fov-2'}
             fovs = list(toffy_fovs.values())
+            expected_fovs = load_utils.get_tiled_fov_names(list(toffy_fovs.keys()))
+
             filelocs, data_xr = test_utils.create_paired_xarray_fovs(
                 temp_dir, fovs, ['chan1', 'chan2'], img_shape=(10, 10), fills=True,
                 sub_dir=img_sub_folder, dtype="int16", single_dir=single_dir
             )
 
             # check default loading of chan1 images
-            loaded_xr = load_utils.load_tiled_img_data(temp_dir, toffy_fovs, expected_fovs=fovs,
+            loaded_xr = load_utils.load_tiled_img_data(temp_dir, toffy_fovs,
+                                                       expected_fovs=expected_fovs,
                                                        channel='chan1', single_dir=single_dir,
                                                        img_sub_folder=img_sub_folder)
 
@@ -415,7 +418,6 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
         loaded_xr = \
             load_utils.load_tiled_img_data(temp_dir, ['R1C1', 'R1C2', 'R2C2'], fovs, 'chan1',
                                            single_dir=single_dir, img_sub_folder=img_sub_folder)
-
         assert loaded_xr.equals(data_xr[:, :, :, :-1])
         assert loaded_xr.shape == (4, 10, 10, 1)
 
@@ -423,18 +425,22 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
         if not single_dir:
             toffy_fovs = {'R1C1': 'fov-3', 'R1C2': 'fov-1', 'R2C1': 'fov-4', 'R2C2': 'fov-2'}
             fovs = list(toffy_fovs.values())
+            expected_fovs = load_utils.get_tiled_fov_names(list(toffy_fovs.keys()))
 
             filelocs, data_xr = test_utils.create_paired_xarray_fovs(
                 temp_dir, fovs, ['chan1', 'chan2'], img_shape=(10, 10), delimiter='_', fills=True,
                 sub_dir=img_sub_folder, dtype="int16", single_dir=single_dir
             )
+            data_xr['fovs'] = list(toffy_fovs.keys())
+
             # remove images and expected data for one fov
             data_xr[2, :, :, :] = np.zeros((10, 10, 1), dtype='int16')
             shutil.rmtree(os.path.join(temp_dir, 'fov-4'))
+            toffy_fovs.pop('R2C1')
 
             # check successful loading for one channel
             loaded_xr = \
-                load_utils.load_tiled_img_data(temp_dir, ['fov-3', 'fov-1', 'fov-2'], fovs,
+                load_utils.load_tiled_img_data(temp_dir, toffy_fovs, expected_fovs,
                                                'chan1', single_dir=single_dir,
                                                img_sub_folder=img_sub_folder)
 

--- a/ark/utils/load_utils_test.py
+++ b/ark/utils/load_utils_test.py
@@ -359,7 +359,7 @@ def test_get_tiled_fov_names():
 def test_load_tiled_img_data(single_dir, img_sub_folder):
     # invalid directory is provided
     with pytest.raises(ValueError):
-        loaded_xr = load_utils.load_tiled_img_data('not_a_dir', [], 'chan1',
+        loaded_xr = load_utils.load_tiled_img_data('not_a_dir', [], [], 'chan1',
                                                    single_dir=False,)
 
     # check with no missing FOVS
@@ -372,12 +372,29 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
         )
 
         # check default loading of chan1 images
-        loaded_xr = load_utils.load_tiled_img_data(temp_dir, fovs, 'chan1',
-                                                   single_dir=single_dir,
+        loaded_xr = load_utils.load_tiled_img_data(temp_dir, fovs, expected_fovs=fovs,
+                                                   channel='chan1', single_dir=single_dir,
                                                    img_sub_folder=img_sub_folder)
 
         assert loaded_xr.equals(data_xr[:, :, :, :-1])
         assert loaded_xr.shape == (3, 10, 10, 1)
+
+        # check toffy dict loading
+        if not single_dir:
+            toffy_fovs = {'R1C1': 'fov-1', 'R1C2': 'fov-3', 'R1C3': 'fov-2'}
+            fovs = list(toffy_fovs.values())
+            filelocs, data_xr = test_utils.create_paired_xarray_fovs(
+                temp_dir, fovs, ['chan1', 'chan2'], img_shape=(10, 10), fills=True,
+                sub_dir=img_sub_folder, dtype="int16", single_dir=single_dir
+            )
+
+            # check default loading of chan1 images
+            loaded_xr = load_utils.load_tiled_img_data(temp_dir, toffy_fovs, expected_fovs=fovs,
+                                                       channel='chan1', single_dir=single_dir,
+                                                       img_sub_folder=img_sub_folder)
+
+            assert loaded_xr.equals(data_xr[:, :, :, :-1])
+            assert loaded_xr.shape == (3, 10, 10, 1)
 
     # check loading with missing FOV images
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -396,11 +413,33 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
 
         # check successful loading for one channel
         loaded_xr = \
-            load_utils.load_tiled_img_data(temp_dir, ['R1C1', 'R1C2', 'R2C2'], 'chan1',
+            load_utils.load_tiled_img_data(temp_dir, ['R1C1', 'R1C2', 'R2C2'], fovs, 'chan1',
                                            single_dir=single_dir, img_sub_folder=img_sub_folder)
 
         assert loaded_xr.equals(data_xr[:, :, :, :-1])
         assert loaded_xr.shape == (4, 10, 10, 1)
+
+        # check toffy dict loading
+        if not single_dir:
+            toffy_fovs = {'R1C1': 'fov-3', 'R1C2': 'fov-1', 'R2C1': 'fov-4', 'R2C2': 'fov-2'}
+            fovs = list(toffy_fovs.values())
+
+            filelocs, data_xr = test_utils.create_paired_xarray_fovs(
+                temp_dir, fovs, ['chan1', 'chan2'], img_shape=(10, 10), delimiter='_', fills=True,
+                sub_dir=img_sub_folder, dtype="int16", single_dir=single_dir
+            )
+            # remove images and expected data for one fov
+            data_xr[2, :, :, :] = np.zeros((10, 10, 1), dtype='int16')
+            shutil.rmtree(os.path.join(temp_dir, 'fov-4'))
+
+            # check successful loading for one channel
+            loaded_xr = \
+                load_utils.load_tiled_img_data(temp_dir, ['fov-3', 'fov-1', 'fov-2'], fovs,
+                                               'chan1', single_dir=single_dir,
+                                               img_sub_folder=img_sub_folder)
+
+            assert loaded_xr.equals(data_xr[:, :, :, :-1])
+            assert loaded_xr.shape == (4, 10, 10, 1)
 
     # test loading with data_xr containing float values
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -417,8 +456,8 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
         else:
             shutil.rmtree(os.path.join(temp_dir, 'R2C1'))
 
-        loaded_xr = load_utils.load_tiled_img_data(temp_dir, ['R1C1', 'R1C2', 'R2C2'], 'chan1',
-                                                   single_dir=single_dir,
+        loaded_xr = load_utils.load_tiled_img_data(temp_dir, ['R1C1', 'R1C2', 'R2C2'], fovs,
+                                                   'chan1', single_dir=single_dir,
                                                    img_sub_folder=img_sub_folder)
         assert loaded_xr.shape == (4, 10, 10, 1)
         assert np.issubdtype(loaded_xr.dtype, np.floating)
@@ -440,7 +479,7 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
 
         loaded_xr = \
             load_utils.load_tiled_img_data(temp_dir, ['run_1_R1C1', 'run_1_R1C2', 'run_2_R2C2'],
-                                           'chan1', single_dir=single_dir,
+                                           fovs, 'chan1', single_dir=single_dir,
                                            img_sub_folder=img_sub_folder)
         assert loaded_xr.equals(data_xr)
         assert loaded_xr.shape == (4, 10, 10, 1)


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #795. Adjusts the tiled image loading function so we can stitch by shape even when loading from toffy fov folders that haven't been renamed to the RnCm format yet

**How did you implement your changes**

Detailed in design doc #795.

