### PR TITLE
Added Parameter for Seg Mask Suffix for Mantis

### DIFF
--- a/ark/phenotyping/post_cluster_utils.py
+++ b/ark/phenotyping/post_cluster_utils.py
@@ -50,7 +50,9 @@ def plot_hist_thresholds(cell_table, populations, marker, pop_col='cell_meta_clu
     plt.tight_layout()
 
 
-def create_mantis_project(cell_table, fovs, seg_dir, pop_col, mask_dir, image_dir, mantis_dir):
+def create_mantis_project(cell_table, fovs, seg_dir, pop_col,
+                          mask_dir, image_dir, mantis_dir,
+                          seg_suffix_name: str = "_whole_cell") -> None:
     """Create a complete Mantis project for viewing cell labels
 
     Args:
@@ -60,7 +62,10 @@ def create_mantis_project(cell_table, fovs, seg_dir, pop_col, mask_dir, image_di
         pop_col (str): the column containing the distinct cell populations
         mask_dir (path): path to the directory where the masks will be stored
         image_dir (path): path to the directory containing the raw image data
-        mantis_dir (path): path to the directory where the mantis project will be created """
+        mantis_dir (path): path to the directory where the mantis project will be created
+        seg_suffix_name (str, optional):
+            The suffix of the segmentation file. Defaults to "_whole_cell".
+    """
 
     if not os.path.exists(mask_dir):
         os.makedirs(mask_dir)
@@ -73,12 +78,12 @@ def create_mantis_project(cell_table, fovs, seg_dir, pop_col, mask_dir, image_di
 
     # label and save the cell mask for each FOV
     for fov in fovs:
-        whole_cell_file = [fov + '_whole_cell.tiff' for fov in fovs]
+        whole_cell_file = [fov + seg_suffix_name + '.tiff' for fov in fovs]
 
         # load the segmentation labels in for the FOV
         label_map = load_utils.load_imgs_from_dir(
             data_dir=seg_dir, files=whole_cell_file, xr_dim_name='compartments',
-            xr_channel_names=['whole_cell'], trim_suffix='_whole_cell'
+            xr_channel_names=[seg_suffix_name], trim_suffix=seg_suffix_name
         ).loc[fov, ...]
 
         # use label_cells_by_cluster to create cell masks
@@ -103,4 +108,5 @@ def create_mantis_project(cell_table, fovs, seg_dir, pop_col, mask_dir, image_di
     plot_utils.create_mantis_dir(fovs=fovs, mantis_project_path=mantis_dir,
                                  img_data_path=image_dir, mask_output_dir=mask_dir,
                                  mask_suffix='_cell_mask', mapping=mantis_df,
-                                 seg_dir=seg_dir, img_sub_folder='')
+                                 seg_dir=seg_dir, img_sub_folder='',
+                                 seg_suffix_name=seg_suffix_name)

--- a/ark/phenotyping/post_cluster_utils_test.py
+++ b/ark/phenotyping/post_cluster_utils_test.py
@@ -59,7 +59,7 @@ def test_create_mantis_project(tmp_path):
     # create random segmentation masks
     for fov in fovs:
         data = np.random.randint(0, 5, 100).reshape(10, 10)
-        io.imsave(os.path.join(seg_dir, fov + '_whole_cell.tiff'), data, check_contrast=False)
+        io.imsave(os.path.join(seg_dir, fov + '_whole_cell_test.tiff'), data, check_contrast=False)
 
     # create cell table with two clusters
     cell_label = np.tile(np.arange(1, 5), len(fovs))
@@ -72,7 +72,8 @@ def test_create_mantis_project(tmp_path):
     post_cluster_utils.create_mantis_project(cell_table=cell_table, fovs=fovs,
                                              seg_dir=seg_dir, pop_col='cell_meta_cluster',
                                              mask_dir=mask_dir, image_dir=image_dir,
-                                             mantis_dir=mantis_dir)
+                                             mantis_dir=mantis_dir,
+                                             seg_suffix_name="_whole_cell_test")
 
     # make sure that the mask found in each mantis directory is correct
     for fov in fovs:
@@ -81,5 +82,5 @@ def test_create_mantis_project(tmp_path):
         assert set(np.unique(mask)) == set([0, 1, 2])
 
         # mask should be non-zero in the same places as original
-        seg = io.imread(os.path.join(seg_dir, fov + '_whole_cell.tiff'))
+        seg = io.imread(os.path.join(seg_dir, fov + '_whole_cell_test.tiff'))
         assert np.array_equal(mask > 0, seg > 0)

--- a/ark/utils/plot_utils.py
+++ b/ark/utils/plot_utils.py
@@ -394,7 +394,9 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
                       mask_output_dir: Union[str, pathlib.Path],
                       mapping: Union[str, pathlib.Path, pd.DataFrame],
                       seg_dir: Union[str, pathlib.Path],
-                      mask_suffix: str = "_mask", img_sub_folder: str = ""):
+                      mask_suffix: str = "_mask",
+                      seg_suffix_name: str = "_whole_cell",
+                      img_sub_folder: str = ""):
     """Creates a mantis project directory so that it can be opened by the mantis viewer.
     Copies fovs, segmentation files, masks, and mapping csv's into a new directory structure.
     Here is how the contents of the mantis project folder will look like.
@@ -435,6 +437,8 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
             The location of the segmentation directory for the fovs.
         mask_suffix (str, optional):
             The suffix used to find the mask tiffs. Defaults to "_mask".
+        seg_suffix_name (str, optional):
+            The suffix of the segmentation file. Defaults to "_whole_cell".
         img_sub_folder (str, optional):
             The subfolder where the channels exist within the `img_data_path`.
             Defaults to "normalized".
@@ -490,12 +494,12 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
                 shutil.copy(os.path.join(img_source_dir, chan), os.path.join(output_dir, chan))
 
         # copy mask into new folder
-        mask_name = mn + mask_suffix + '.tiff'
+        mask_name: str = mn + mask_suffix + '.tiff'
         shutil.copy(os.path.join(mask_output_dir, mask_name),
                     os.path.join(output_dir, 'population{}.tiff'.format(mask_suffix)))
 
         # copy the segmentation files into the output directory
-        seg_name = fov + '_whole_cell.tiff'
+        seg_name: str = fov + seg_suffix_name + '.tiff'
         shutil.copy(os.path.join(seg_dir, seg_name),
                     os.path.join(output_dir, 'cell_segmentation.tiff'))
 

--- a/ark/utils/plot_utils_test.py
+++ b/ark/utils/plot_utils_test.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 from pathlib import Path
 
+import matplotlib.colors as colors
 import natsort
 import numpy as np
 import pandas as pd
@@ -9,7 +10,6 @@ import pytest
 import skimage.io as io
 import xarray as xr
 from skimage.draw import disk
-import matplotlib.colors as colors
 
 from ark.utils import plot_utils, test_utils
 
@@ -299,7 +299,7 @@ def test_create_mantis_dir():
 
         for idx, fov in enumerate(fovs):
             # Save the segmentation label compartments for each fov
-            io.imsave(os.path.join(temp_dir, segmentation_dir, '%s_whole_cell.tiff' % fov),
+            io.imsave(os.path.join(temp_dir, segmentation_dir, '%s_whole_cell_test.tiff' % fov),
                       example_labels.loc[idx, ...].values, check_contrast=False)
 
             # Save the sample masks
@@ -337,6 +337,7 @@ def test_create_mantis_dir():
                 mask_suffix=mask_suffix,
                 mapping=mapping,
                 seg_dir=image_segmentation_full_path,
+                seg_suffix_name="_whole_cell_test",
                 img_sub_folder=img_sub_folder
             )
 
@@ -362,7 +363,7 @@ def test_create_mantis_dir():
                 # 2.a. Assert that the segmentation label compartments exist in the new directory
                 assert os.path.exists(cell_seg_path)
                 original_cell_seg_path = os.path.join(temp_dir, segmentation_dir,
-                                                      '%s_whole_cell.tiff' % fov)
+                                                      '%s_whole_cell_test.tiff' % fov)
                 cell_seg_img = io.imread(cell_seg_path)
                 original_cell_seg_img = io.imread(original_cell_seg_path)
                 # 2.b. Assert that the `cell_segmentation` file is equal to `fov#_whole_cell`


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #809.

**How did you implement your changes**

Added a parameter to `ark.phenotyping.post_cluster_utils.create_mantis_project` and `ark.utils.plot_utils.create_mantis_dir` which lets users change the name of the segmentation mask suffix.

**Remaining issues**

N/A.
