### PR TITLE
Ensure pixel SOM training reruns if new markers specified

### DIFF
--- a/ark/phenotyping/cluster_helpers.py
+++ b/ark/phenotyping/cluster_helpers.py
@@ -190,10 +190,15 @@ class PixelSOMCluster(PixieSOMCluster):
     def train_som(self):
         """Trains the SOM using `train_data`
         """
-        # do not train SOM if weights already exist
+
         if self.weights is not None:
-            warnings.warn('Pixel SOM already trained')
-            return
+            # do not train SOM if weights already exist and the same markers used to train
+            if set(self.weights.columns.values) == set(self.columns):
+                warnings.warn('Pixel SOM already trained on specified markers')
+                return
+
+            # notify the user that different markers specified
+            warnings.warn('New markers specified, retraining')
 
         super().train_som(self.train_data[self.columns])
 

--- a/ark/phenotyping/cluster_helpers.py
+++ b/ark/phenotyping/cluster_helpers.py
@@ -278,10 +278,14 @@ class CellSOMCluster(PixieSOMCluster):
     def train_som(self):
         """Trains the SOM using `cell_data`
         """
-        # do not train SOM if weights already exist
         if self.weights is not None:
-            warnings.warn('Cell SOM already trained')
-            return
+            # do not train SOM if weights already exist and the same columns used to train
+            if set(self.weights.columns.values) == set(self.columns):
+                warnings.warn('Cell SOM already trained on specified columns')
+                return
+
+            # notify the user that different columns specified
+            warnings.warn('New columns specified, retraining')
 
         super().train_som(self.cell_data[self.columns])
 

--- a/ark/phenotyping/cluster_helpers_test.py
+++ b/ark/phenotyping/cluster_helpers_test.py
@@ -303,7 +303,7 @@ class TestPixelSOMCluster:
             self.pixel_pysom_weights.train_som()
 
     def test_train_som_new_cols(self):
-        # store old weights, train data, and columns for safekeeping, need to assign back afterwards
+        # store old weights, train data, and columns, need to assign back afterwards
         old_weights = deepcopy(self.pixel_pysom_nonweights.weights)
         old_train_data = deepcopy(self.pixel_pysom_nonweights.train_data)
         old_columns = deepcopy(self.pixel_pysom_nonweights.columns)


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #887. It's currently not possible to re-run `2_Pixie_Cluster_Pixels` in case the user needs to specify a new subset of markers on the same cohort. This is a common occurrence and should be addressed.

**How did you implement your changes**

In `PixelSOMCluster.train_som`, add a check to verify the existing weights columns (if applicable) and the provided set of columns match. If they do not, this means a new set of columns was specified and `PixieSOMCluster.train_som` should re-run.
