### PR TITLE
Change os.rename to shutil.move

### DIFF
--- a/src/ark/phenotyping/pixel_meta_clustering.py
+++ b/src/ark/phenotyping/pixel_meta_clustering.py
@@ -2,7 +2,7 @@ import multiprocessing
 import os
 import random
 from functools import partial
-from shutil import rmtree
+from shutil import rmtree, move
 
 import feather
 import numpy as np
@@ -185,7 +185,7 @@ def pixel_consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
 
     # remove the data directory and rename the temp directory to the data directory
     rmtree(pixel_data_path)
-    os.rename(pixel_data_path + '_temp', pixel_data_path)
+    move(pixel_data_path + '_temp', pixel_data_path)
 
     return pixel_cc
 
@@ -435,7 +435,7 @@ def apply_pixel_meta_cluster_remapping(fovs, channels, base_dir,
 
     # remove the data directory and rename the temp directory to the data directory
     rmtree(pixel_data_path)
-    os.rename(pixel_data_path + '_temp', pixel_data_path)
+    move(pixel_data_path + '_temp', pixel_data_path)
 
 
 def generate_remap_avg_files(fovs, channels, base_dir, pixel_data_dir, pixel_remapped_name,

--- a/src/ark/phenotyping/pixel_som_clustering.py
+++ b/src/ark/phenotyping/pixel_som_clustering.py
@@ -1,7 +1,7 @@
 import multiprocessing
 import os
 from functools import partial
-from shutil import rmtree
+from shutil import rmtree, move
 
 import feather
 from pyarrow.lib import ArrowInvalid
@@ -269,7 +269,7 @@ def cluster_pixels(fovs, channels, base_dir, pixel_pysom, data_dir='pixel_mat_da
 
     # remove the data directory and rename the temp directory to the data directory
     rmtree(data_path)
-    os.rename(data_path + '_temp', data_path)
+    move(data_path + '_temp', data_path)
 
 
 def generate_som_avg_files(fovs, channels, base_dir, pixel_pysom, data_dir='pixel_data_dir',


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Apparently Windows doesn't like it when you try to `os.rename` something that is an "open process" (causing pixel clustering functions to fail). After much experimenting, seems like the fix is easy. `shutil.move` seems to do the trick.

**How did you implement your changes**

Change `os.rename` to `shutil.move`. Tested on my computer, Ben's, and MIBIAN.

**Remaining issues**

None