### PR TITLE
Next Release `v0.6.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ After the Pixie Pipeline, the user can inspect and fine tune their results with 
 We recommend using the latest release of `ark`. You can find all the versions available in the [Releases Section](https://github.com/angelolab/ark-analysis/releases).
 Open terminal and navigate to where you want the code stored. 
 
-Currently, the latest release is `v0.6.0`.
+Currently, the latest release is `v0.6.1`.
 Then install the latest release with:
 
 ```
-git clone -b v0.6.0 https://github.com/angelolab/ark-analysis.git
+git clone -b v0.6.1 https://github.com/angelolab/ark-analysis.git
 ```
 
 Or head to [Releases]https://github.com/angelolab/ark-analysis/releases) and download the source code under the Assets' subsection of the latest release.

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # define the version number, this needs to be updated every new Docker release
-VERSION='v0.6.0'
+VERSION='v0.6.1'
 
 # check for template developer flag
 JUPYTER_DIR='scripts'


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

A new release was created last night, however the `start_docker.sh` and `README.md` files were not updated to include the latest version.

**How did you implement your changes**

- In `start_docker.sh` bumped `VERSION` to `v0.6.1`
- In `README.md` bumped the git clone instruction to `v0.6.1`

**Remaining issues**

None.