### PR TITLE
Fix zero pixels

### DIFF
--- a/src/ark/phenotyping/pixie_preprocessing.py
+++ b/src/ark/phenotyping/pixie_preprocessing.py
@@ -63,6 +63,9 @@ def create_fov_pixel_data(fov, channels, img_data, seg_labels,
         seg_labels_flat = seg_labels.flatten()
         pixel_mat['segmentation_label'] = seg_labels_flat
 
+    # remove any rows with channels that sum to zero prior to normalization
+    pixel_mat = pixel_mat.loc[(pixel_mat[channels] != 0).any(axis=1), :].reset_index(drop=True)
+
     # normalize the row sums of pixel mat
     pixel_mat = pixel_cluster_utils.normalize_rows(pixel_mat, channels, seg_labels is not None)
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

After removing the pixel thresholding step (to filter out low pixels), we never added back in the filter for pixels that were zero for all markers. Added that back in.

**How did you implement your changes**

Added one line to remove pixels that are 0 for all markers before row normalization.

**Remaining issues**

None
