### PR TITLE
Kmeans notebook minor fixes

### DIFF
--- a/src/ark/analysis/neighborhood_analysis.py
+++ b/src/ark/analysis/neighborhood_analysis.py
@@ -15,7 +15,7 @@ from ark.analysis import spatial_analysis_utils
 def create_neighborhood_matrix(all_data, dist_mat_dir, included_fovs=None, distlim=50,
                                self_neighbor=False, fov_col=settings.FOV_ID,
                                cell_label_col=settings.CELL_LABEL,
-                               cluster_name_col=settings.CELL_TYPE):
+                               cell_type_col=settings.CELL_TYPE):
     """Calculates the number of neighbor phenotypes for each cell.
 
     Args:
@@ -33,7 +33,7 @@ def create_neighborhood_matrix(all_data, dist_mat_dir, included_fovs=None, distl
             column with the cell fovs.
         cell_label_col (str):
             column with the cell labels.
-        cluster_name_col (str):
+        cell_type_col (str):
             column with the cell types.
 
     Returns:
@@ -52,14 +52,14 @@ def create_neighborhood_matrix(all_data, dist_mat_dir, included_fovs=None, distl
 
     # Subset just the fov, label, and cell phenotype columns
     all_neighborhood_data = all_data[
-        [fov_col, cell_label_col, cluster_name_col]
+        [fov_col, cell_label_col, cell_type_col]
     ].reset_index(drop=True)
     # Extract the cell phenotypes
-    cluster_names = all_neighborhood_data[cluster_name_col].drop_duplicates()
+    cluster_names = all_neighborhood_data[cell_type_col].drop_duplicates()
     # Get the total number of phenotypes
     cluster_num = len(cluster_names)
 
-    included_columns = [fov_col, cell_label_col, cluster_name_col]
+    included_columns = [fov_col, cell_label_col, cell_type_col]
 
     # Initialize empty matrices for cell neighborhood data
     cell_neighbor_counts = pd.DataFrame(
@@ -81,7 +81,7 @@ def create_neighborhood_matrix(all_data, dist_mat_dir, included_fovs=None, distl
         current_fov_neighborhood_data = all_neighborhood_data[current_fov_idx]
 
         # Get the subset of phenotypes included in the current fov
-        fov_cluster_names = current_fov_neighborhood_data[cluster_name_col].drop_duplicates()
+        fov_cluster_names = current_fov_neighborhood_data[cell_type_col].drop_duplicates()
 
         # Retrieve fov-specific distance matrix from distance matrix dictionary
         dist_matrix = xr.load_dataarray(os.path.join(dist_mat_dir, str(fov) + '_dist_mat.xr'))
@@ -89,7 +89,7 @@ def create_neighborhood_matrix(all_data, dist_mat_dir, included_fovs=None, distl
         # Get cell_neighbor_counts and cell_neighbor_freqs for fovs
         counts, freqs = spatial_analysis_utils.compute_neighbor_counts(
             current_fov_neighborhood_data, dist_matrix, distlim, self_neighbor,
-            cell_label_col=cell_label_col, cluster_name_col=cluster_name_col)
+            cell_label_col=cell_label_col, cluster_name_col=cell_type_col)
 
         # Add to neighbor counts + freqs for only the matching phenos between fov and whole dataset
         cell_neighbor_counts.loc[current_fov_neighborhood_data.index, fov_cluster_names] = counts

--- a/src/ark/analysis/visualize.py
+++ b/src/ark/analysis/visualize.py
@@ -147,6 +147,8 @@ def draw_heatmap(data, x_labels, y_labels, dpi=None, center_val=None, min_val=No
     # ensure the y-axis labels are horizontal, will be misaligned if vertical
     _ = plt.setp(heatmap.ax_heatmap.get_yticklabels(), rotation=0)
 
+    plt.tight_layout()
+
     if save_dir is not None:
         misc_utils.save_figure(save_dir, save_file, dpi=dpi)
 

--- a/templates/Calculate_Mixing_Scores.ipynb
+++ b/templates/Calculate_Mixing_Scores.ipynb
@@ -221,7 +221,7 @@
     "cell_type_col = 'cell_meta_cluster'\n",
     "\n",
     "# determine number of each cell type in specified distance around each cell\n",
-    "neighbor_counts, _ = create_neighborhood_matrix(all_data, dist_mat_dir, distlim=pixel_radius, cluster_name_col=cell_type_col)\n",
+    "neighbor_counts, _ = create_neighborhood_matrix(all_data, dist_mat_dir, distlim=pixel_radius, cell_type_col=cell_type_col)\n",
     "\n",
     "# save the neighborhood matrix\n",
     "neighbor_counts.to_csv(os.path.join(neighbors_mat_dir, f\"neighborhood_counts-{cell_type_col}_radius{pixel_radius}.csv\"), index=False)"

--- a/templates/example_neighborhood_analysis_script.ipynb
+++ b/templates/example_neighborhood_analysis_script.ipynb
@@ -121,7 +121,9 @@
     "\n",
     "# Create output directory\n",
     "if not os.path.exists(spatial_analysis_dir):\n",
-    "    os.makedirs(spatial_analysis_dir)"
+    "    os.makedirs(spatial_analysis_dir)\n",
+    "if not os.path.exists(neighbors_mat_dir):\n",
+    "    os.makedirs(neighbors_mat_dir)"
    ]
   },
   {
@@ -228,7 +230,7 @@
     "else:\n",
     "    # Create new matrix with the radius and cell column specified above\n",
     "    neighbor_counts, neighbor_freqs = neighborhood_analysis.create_neighborhood_matrix(\n",
-    "        all_data, dist_mat_dir, distlim=pixel_radius)\n",
+    "        all_data, dist_mat_dir, distlim=pixel_radius, cell_type_col=cell_type_col)\n",
     "    \n",
     "    # Save neighbor matrices\n",
     "    neighbor_counts.to_csv(counts_path, index=False)\n",
@@ -335,7 +337,8 @@
     }
    ],
    "source": [
-    "neighbor_inertia = neighborhood_analysis.compute_cluster_metrics_inertia(input_features, min_k=min_k, max_k=max_k)\n",
+    "neighbor_inertia = neighborhood_analysis.compute_cluster_metrics_inertia(input_features, min_k=min_k, max_k=max_k, \n",
+    "                                                                         cell_col=cell_type_col)\n",
     "\n",
     "# Use the elbow curve method to choose the optimal k\n",
     "visualize.visualize_neighbor_cluster_metrics(neighbor_inertia, metric_name=\"inertia\")"
@@ -394,9 +397,9 @@
     "num_cells_per_cluster = 1000\n",
     "\n",
     "neighbor_silhouette_scores = neighborhood_analysis.compute_cluster_metrics_silhouette(input_features,\n",
-    "                                                                                 min_k=min_k,\n",
-    "                                                                                 max_k=max_k,\n",
-    "                                                                                 subsample=num_cells_per_cluster)\n",
+    "                                                                                      min_k=min_k, max_k=max_k,\n",
+    "                                                                                      subsample=num_cells_per_cluster, \n",
+    "                                                                                      cell_col=cell_type_col)\n",
     "\n",
     "# Use the elbow curve method to choose the optimal k\n",
     "visualize.visualize_neighbor_cluster_metrics(neighbor_silhouette_scores, metric_name=\"silhouette\")"
@@ -442,7 +445,7 @@
     "# k-means clustering\n",
     "all_data_cluster_labeled, num_cell_type_per_cluster, mean_marker_exp_per_cluster = \\\n",
     "    neighborhood_analysis.generate_cluster_matrix_results(\n",
-    "        all_data, input_features, cluster_num=k, excluded_channels=excluded_channels)"
+    "        all_data, input_features, cluster_num=k, excluded_channels=excluded_channels, cell_type_col=cell_type_col)"
    ]
   },
   {

--- a/templates/example_neighborhood_analysis_script.ipynb
+++ b/templates/example_neighborhood_analysis_script.ipynb
@@ -465,6 +465,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Directory to save kmeans output for the specified parameters\n",
+    "kmeans_out_dir = os.path.join(spatial_analysis_dir, f\"{neighborhood_method}_{cell_type_col}_radius{pixel_radius}\")\n",
+    "if not os.path.exists(kmeans_out_dir):\n",
+    "    os.makedirs(kmeans_out_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 15,
    "metadata": {
     "tags": []
@@ -494,7 +506,7 @@
     "visualize.draw_heatmap(data=mean_dat_values.apply(zscore).values,\n",
     "                       x_labels=[\"Cluster\"+str(x) for x in mean_dat[settings.KMEANS_CLUSTER].values],\n",
     "                       y_labels=mean_dat.drop(settings.KMEANS_CLUSTER, axis=1).columns.values,\n",
-    "                       center_val=0)"
+    "                       center_val=0, save_dir=kmeans_out_dir, save_file='neighbor_type_heatmap')"
    ]
   },
   {
@@ -527,7 +539,7 @@
     "visualize.draw_heatmap(data=num_cell_type_per_cluster.apply(zscore).values,\n",
     "                       x_labels=num_cell_type_per_cluster.index.values,\n",
     "                       y_labels=num_cell_type_per_cluster.columns.values,\n",
-    "                       center_val=0)"
+    "                       center_val=0, save_dir=kmeans_out_dir, save_file='cell_type_heatmap')"
    ]
   },
   {
@@ -560,7 +572,7 @@
     "visualize.draw_heatmap(data=mean_marker_exp_per_cluster.apply(zscore).values,\n",
     "                       x_labels=mean_marker_exp_per_cluster.index.values,\n",
     "                       y_labels=mean_marker_exp_per_cluster.columns.values,\n",
-    "                       center_val=0)"
+    "                       center_val=0, save_dir=kmeans_out_dir, save_file='marker_expression_heatmap')"
    ]
   },
   {
@@ -586,7 +598,7 @@
    "outputs": [],
    "source": [
     "# Directory to save overlays\n",
-    "overlay_out_dir = os.path.join(spatial_analysis_dir, \"overlays\")\n",
+    "overlay_out_dir = os.path.join(kmeans_out_dir, \"overlays\")\n",
     "if not os.path.exists(overlay_out_dir):\n",
     "    os.makedirs(overlay_out_dir)"
    ]
@@ -663,7 +675,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After running k-means using the optimal k, re-save the cell table with neighborhood cluster ID appended. If a cell has no other cells within the distance specfied by `dist_lim`, that cell is excluded from this table."
+    "After running k-means using the optimal k, re-save the cell table with neighborhood cluster ID appended. All cells from the original table are contained within the new one, even if they had no neighbors and were excluded from k-means clustering. "
    ]
   },
   {
@@ -673,13 +685,14 @@
    "outputs": [],
    "source": [
     "#  Save cell table\n",
-    "new_table_path = cell_table_path.replace(\".csv\", \"_kmeans_nh.csv\")\n",
+    "new_table_name = os.path.basename(cell_table_path).replace(\".csv\", \"_kmeans_nh.csv\")\n",
+    "new_table_path = os.path.join(kmeans_out_dir, new_table_name)\n",
     "cell_table_new = all_data.merge(all_data_cluster_labeled, on=list(all_data.columns), how='left')\n",
     "cell_table_new.to_csv(new_table_path, index=False)\n",
     "\n",
     "# Save number of each cell type and mean marker expression per neighborhood\n",
-    "num_cell_type_per_cluster.to_csv(os.path.join(spatial_analysis_dir, \"neighborhood_cell_type.csv\"), index=True, index_label=settings.KMEANS_CLUSTER)\n",
-    "mean_marker_exp_per_cluster.to_csv(os.path.join(spatial_analysis_dir, \"neighborhood_marker.csv\"), index=True, index_label=settings.KMEANS_CLUSTER)"
+    "num_cell_type_per_cluster.to_csv(os.path.join(kmeans_out_dir, \"neighborhood_cell_type.csv\"), index=True, index_label=settings.KMEANS_CLUSTER)\n",
+    "mean_marker_exp_per_cluster.to_csv(os.path.join(kmeans_out_dir, \"neighborhood_marker.csv\"), index=True, index_label=settings.KMEANS_CLUSTER)"
    ]
   },
   {

--- a/templates/example_neighborhood_analysis_script.ipynb
+++ b/templates/example_neighborhood_analysis_script.ipynb
@@ -470,7 +470,7 @@
    "outputs": [],
    "source": [
     "# Directory to save kmeans output for the specified parameters\n",
-    "kmeans_out_dir = os.path.join(spatial_analysis_dir, f\"{neighborhood_method}_{cell_type_col}_radius{pixel_radius}\")\n",
+    "kmeans_out_dir = os.path.join(spatial_analysis_dir, f\"{cell_type_col}_radius{pixel_radius}_{neighborhood_method}\")\n",
     "if not os.path.exists(kmeans_out_dir):\n",
     "    os.makedirs(kmeans_out_dir)"
    ]


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #963 and closes #964. 

**How did you implement your changes**

Passed the `cell_type_col`arg into the appropriate functions, renamed the arg in `create_neighborhood_matrix` from cluster_name_col --> cell_type_col for consistency.
Edited `visualize.draw_heatmap` to save images without cropping, and heatmaps are saved by default now.

Previously, the output files were saved with the same name each time the notebook was run, unless you manually changed them to indicate counts vs freq or a different cell column. Now, the results are saved to a subfolder within the `neighborhood_analysis` directory, indicated by the parameters specified by the user (i.e. `cell_meta_cluster_radius50_counts`)
The produced cell table updated with kmeans clusters now saves in this new subfolder, rather than `segmentation/cell_table`.

**Remaining issues**
NA

