### PR TITLE
Set Kmeans parameter to prior default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 dependencies = [
-    "alpineer>=0.1.5",
+    "alpineer==0.1.5",
     "Cython>=0.29,<1",
     "datasets>=2.6,<3.0",
     "dill>=0.3.5,<0.4",

--- a/src/ark/analysis/spatial_analysis_utils.py
+++ b/src/ark/analysis/spatial_analysis_utils.py
@@ -588,7 +588,7 @@ def generate_cluster_labels(neighbor_mat_data, cluster_num, seed=42):
             the neighborhood cluster labels assigned to each cell in neighbor_mat_data
     """
 
-    cluster_fit = KMeans(n_clusters=cluster_num, random_state=seed, n_init='auto').\
+    cluster_fit = KMeans(n_clusters=cluster_num, random_state=seed, n_init=10).\
         fit(neighbor_mat_data)
     # Add 1 to avoid cluster number 0
     cluster_labels = cluster_fit.labels_ + 1


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Maybe fixes #968. 

**How did you implement your changes**

Changes `n_init` from 'auto' to 10, to keep the algorithm params consistent with the prior default value.

**Note:** I've pinned alpineer temporarily so that the new multiple tiled stitching adjustments made won't apply until a formal PR is opened. A few of the ark stitching functions will need to be tweaked.

**Remaining issues**

Unrelated to #967. I'm still not quite sure what's going on there.
