### PR TITLE
Mantis Directory with no segmentation files

### DIFF
--- a/src/ark/utils/plot_utils.py
+++ b/src/ark/utils/plot_utils.py
@@ -452,14 +452,16 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
             The folder containing all the masks of the fovs.
         mapping (Union[str, pathlib.Path, pd.DataFrame]):
             The location of the mapping file, or the mapping Pandas DataFrame itself.
-        seg_dir (Union[str, pathlib.Path]):
-            The location of the segmentation directory for the fovs.
+        seg_dir (Union[str, pathlib.Path], optional):
+            The location of the segmentation directory for the fovs. If None, then
+            the segmentation file will not be copied over.
         cluster_type (str):
             the type of clustering being done
         mask_suffix (str, optional):
             The suffix used to find the mask tiffs. Defaults to "_mask".
         seg_suffix_name (str, optional):
-            The suffix of the segmentation file and it's file extension.
+            The suffix of the segmentation file and it's file extension. If None, then
+            the segmentation file will not be copied over.
             Defaults to "_whole_cell.tiff".
         img_sub_folder (str, optional):
             The subfolder where the channels exist within the `img_data_path`.

--- a/tests/utils/plot_utils_test.py
+++ b/tests/utils/plot_utils_test.py
@@ -268,6 +268,18 @@ class _mantis:
 
 @pytest.fixture(scope="function")
 def mantis_data(tmp_path) -> Generator[_mantis, None, None]:
+    """Generates a mantis folder, saves images and segmentation labels to
+    an data folder to simulate moving data from the data folder to the mantis
+    folder.
+
+    Args:
+        tmp_path (pathlib.Path): The temporary path for the mantis data to
+        be stored in.
+
+    Yields:
+        Generator[_mantis, None, None]: Yields the `_mantis` dataclass which houses
+        paths, fovs and data for the mantis data.
+    """
 
     data_dir: pathlib.Path = tmp_path / "data"
     data_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/utils/plot_utils_test.py
+++ b/tests/utils/plot_utils_test.py
@@ -1,6 +1,9 @@
+from dataclasses import dataclass
 import os
+import pathlib
 import tempfile
 from pathlib import Path
+from typing import Generator, List
 
 import matplotlib.colors as colors
 import natsort
@@ -244,13 +247,35 @@ def test_set_minimum_color_for_colormap():
     assert new_color_map(0.0) == (0.1, 0.2, 0.5, 0.3)
 
 
-def test_create_mantis_dir():
+@dataclass
+class _mantis:
+    data_dir: pathlib.Path
+    segmentation_dir: str
+    mask_dir: str
+    cell_output_dir: str
+    fov_path: pathlib.Path
+    img_data_path: pathlib.Path
+    img_sub_folder: pathlib.Path
+    mantis_project_path: pathlib.Path
+    mask_output_dir: pathlib.Path
+    fovs: List[str]
+    mask_suffix: str
+    df: pd.DataFrame
+    mapping_path: pathlib.Path
+    data_xr: xr.DataArray
+    example_masks: xr.DataArray
+
+
+@pytest.fixture(scope="function")
+def mantis_data(tmp_path) -> Generator[_mantis, None, None]:
+
+    data_dir: pathlib.Path = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
 
     # Number of FOVs
-    fov_count = 6
+    fov_count = 4
 
     # Initial data
-
     example_labels = xr.DataArray([_generate_segmentation_labels((1024, 1024))
                                    for _ in range(fov_count)],
                                   coords=[range(fov_count), range(1024), range(1024)],
@@ -259,145 +284,176 @@ def test_create_mantis_dir():
                                  coords=[range(1024), range(1024), range(fov_count)],
                                  dims=["rows", "cols", "masks"])
 
-    # Misc paths used
-    segmentation_dir = "seg_dir"
-    mask_dir = "masks"
-    cell_output_dir = "cell_output"
-    img_data_path = "img_data"
-    img_sub_folder = "normalized"
+    # Paths used
+    segmentation_dir: str = "seg_dir"
+    mask_dir: str = "masks"
+    cell_output_dir: str = "cell_output"
+    img_data_path: str = "img_data"
+    img_sub_folder: str = "normalized"
+    mantis_project_path: str = "mantis"
 
-    with tempfile.TemporaryDirectory() as temp_dir:
+    for p in [segmentation_dir, cell_output_dir, img_data_path]:
+        (data_dir / p).mkdir(parents=True, exist_ok=True)
 
-        # create the folders
-        os.makedirs(os.path.join(temp_dir, cell_output_dir))
-        os.makedirs(os.path.join(temp_dir, segmentation_dir))
-        os.makedirs(os.path.join(temp_dir, cell_output_dir, mask_dir))
-        os.makedirs(os.path.join(temp_dir, img_data_path))
+    # mask output dir path
+    mask_output_dir: pathlib.Path = pathlib.Path(data_dir, cell_output_dir, mask_dir)
+    mask_output_dir.mkdir(parents=True, exist_ok=True)
 
-        # mantis project path
-        mantis_project_path = os.path.join(temp_dir, 'mantis')
+    # image data path, create 2 fovs, with 4 channels each
+    fovs, channels = test_utils.gen_fov_chan_names(num_fovs=fov_count, num_chans=4,
+                                                   use_delimiter=False, return_imgs=False)
 
-        # mask output dir path
-        mask_output_dir = os.path.join(temp_dir, cell_output_dir, mask_dir)
+    fov_path = data_dir / img_data_path
+    filelocs, data_xr = test_utils.create_paired_xarray_fovs(
+        fov_path, fovs, channels, img_shape=(10, 10), mode='tiff', delimiter=None,
+        sub_dir=img_sub_folder, fills=True, dtype=np.int16
+    )
 
-        # image data path, create 2 fovs, with 4 channels each
-        fovs, channels = test_utils.gen_fov_chan_names(num_fovs=fov_count, num_chans=4,
-                                                       use_delimiter=False, return_imgs=False)
+    # Loop over the xarray, save each fov's channels,
+    # segmentation label compartments, and sample masks
+    fovs = data_xr.fovs.values
 
-        fov_path = os.path.join(temp_dir, img_data_path)
-        filelocs, data_xr = test_utils.create_paired_xarray_fovs(
-            fov_path, fovs, channels, img_shape=(10, 10), mode='tiff', delimiter=None,
-            sub_dir=img_sub_folder, fills=True, dtype=np.int16
+    for idx, fov in enumerate(fovs):
+        # Save the segmentation label compartments for each fov
+        image_utils.save_image(
+            os.path.join(data_dir / segmentation_dir, f'{fov}_whole_cell_test.tiff'),
+            example_labels.loc[idx, ...].values
         )
 
-        # Loop over the xarray, save each fov's channels,
-        # segmentation label compartments, and sample masks
-        fovs = data_xr.fovs.values
-        fovs_subset = fovs[1:4]
+        # Save the sample masks
+        image_utils.save_image(
+            os.path.join(mask_output_dir, f'{fov}_mask.tiff'),
+            example_masks.loc[..., idx].values
+        )
 
-        for idx, fov in enumerate(fovs):
-            # Save the segmentation label compartments for each fov
+        # Save each channel per fov
+        for idx, chan in enumerate(channels):
             image_utils.save_image(
-                os.path.join(temp_dir, segmentation_dir, '%s_whole_cell_test.tiff' % fov),
-                example_labels.loc[idx, ...].values
+                filelocs[fov][idx] + ".tiff",
+                data_xr.loc[fov, :, :, chan].values
             )
 
-            # Save the sample masks
-            image_utils.save_image(
-                os.path.join(mask_output_dir, '%s_mask.tiff' % fov),
-                example_masks.loc[..., idx].values
-            )
+    # create the mapping path, and the sample mapping file
+    mapping_path = os.path.join(data_dir, cell_output_dir, 'sample_mapping_path.csv')
 
-            # Save each channel per fov
-            for idx, chan in enumerate(channels):
-                image_utils.save_image(
-                    filelocs[fov][idx] + ".tiff",
-                    data_xr.loc[fov, :, :, chan].values
-                )
+    df = pd.DataFrame.from_dict({
+        'pixel_som_cluster': np.arange(20),
+        'pixel_meta_cluster': np.repeat(np.arange(5), 4),
+        'pixel_meta_cluster_rename': ['meta' + str(i) for i in np.repeat(np.arange(5), 4)]
+    })
+    df.to_csv(mapping_path, index=False)
 
-        # create the mapping path, and the sample mapping file
-        mapping_path = os.path.join(temp_dir, cell_output_dir, 'sample_mapping_path.csv')
+    # The suffix for finding masks
+    mask_suffix = "_mask"
 
-        df = pd.DataFrame.from_dict({
-            'pixel_som_cluster': np.arange(20),
-            'pixel_meta_cluster': np.repeat(np.arange(5), 4),
-            'pixel_meta_cluster_rename': ['meta' + str(i) for i in np.repeat(np.arange(5), 4)]
-        })
-        df.to_csv(mapping_path, index=False)
+    md = _mantis(data_dir=data_dir,
+                 segmentation_dir=segmentation_dir,
+                 mask_dir=mask_dir,
+                 cell_output_dir=cell_output_dir,
+                 fov_path=fov_path,
+                 img_data_path=img_data_path,
+                 img_sub_folder=img_sub_folder,
+                 mantis_project_path=data_dir / mantis_project_path,
+                 mask_output_dir=mask_output_dir,
+                 fovs=fovs,
+                 mask_suffix=mask_suffix,
+                 df=df,
+                 mapping_path=mapping_path,
+                 data_xr=data_xr,
+                 example_masks=example_masks)
 
-        # The suffix for finding masks
-        mask_suffix = "_mask"
+    yield md
 
-        # Image segmentation full path
-        image_segmentation_full_path = os.path.join(temp_dir, segmentation_dir)
 
-        # Test mapping csv, and df
-        for mapping in [df, mapping_path]:
-            plot_utils.create_mantis_dir(
-                fovs=fovs_subset,
-                mantis_project_path=mantis_project_path,
-                img_data_path=fov_path,
-                mask_output_dir=mask_output_dir,
-                mask_suffix=mask_suffix,
-                mapping=mapping,
-                seg_dir=image_segmentation_full_path,
-                seg_suffix_name="_whole_cell_test.tiff",
-                img_sub_folder=img_sub_folder
-            )
+@pytest.mark.parametrize("_mapping", ["df", "mapping_path"])
+@pytest.mark.parametrize("_seg_none", [True, False])
+def test_create_mantis_dir(mantis_data: _mantis, _seg_none: bool, _mapping: str):
+    md = mantis_data
 
-            # Testing file existence and correctness
-            for idx, fov in enumerate(fovs_subset, start=1):
-                # output path for testing
-                output_path = os.path.join(mantis_project_path, fov)
+    # Image segmentation full path, and None
+    if _seg_none:
+        image_segmentation_full_path = None
+        seg_suffix_name = None
+    else:
+        image_segmentation_full_path = os.path.join(md.data_dir, md.segmentation_dir)
+        seg_suffix_name = "_whole_cell_test.tiff"
 
-                # 1. Mask tiff tests
-                mask_path = os.path.join(output_path, "population{}.tiff".format(mask_suffix))
-                original_mask_path = os.path.join(mask_output_dir, '%s_mask.tiff' % fov)
+    if _mapping == "df":
+        _m = md.df
+    else:
+        _m = md.mapping_path
 
-                # 1.a. Assert that the mast path exists
-                assert os.path.exists(mask_path)
-                mask_img = io.imread(mask_path)
-                # original_mask_img = io.imread(original_mask_path)
-                original_mask_img = example_masks.loc[..., idx].values
-                # 1.b. Assert that the mask is the same as the original mask
-                np.testing.assert_equal(mask_img, original_mask_img)
+    # Test mapping csv, and df
+    for mapping in [md.df, md.mapping_path]:
+        plot_utils.create_mantis_dir(
+            fovs=md.fovs,
+            mantis_project_path=md.mantis_project_path,
+            img_data_path=md.fov_path,
+            mask_output_dir=md.mask_output_dir,
+            mask_suffix=md.mask_suffix,
+            mapping=_m,
+            seg_dir=image_segmentation_full_path,
+            seg_suffix_name=seg_suffix_name,
+            img_sub_folder=md.img_sub_folder
+        )
 
-                # 2. Cell Segmentation tiff tests
-                cell_seg_path = os.path.join(output_path, "cell_segmentation.tiff")
-                # 2.a. Assert that the segmentation label compartments exist in the new directory
+        # Testing file existence and correctness
+        for idx, fov in enumerate(md.fovs):
+            # output path for testing
+            output_path = os.path.join(md.mantis_project_path, fov)
+
+            # 1. Mask tiff tests
+            mask_path = os.path.join(output_path, "population{}.tiff".format(md.mask_suffix))
+            original_mask_path: str = os.path.join(md.mask_output_dir, '%s_mask.tiff' % fov)
+
+            # 1.a. Assert that the mask path exists
+            assert os.path.exists(mask_path)
+            mask_img = io.imread(mask_path)
+            original_mask_img = md.example_masks.loc[..., idx].values
+            # 1.b. Assert that the mask is the same as the original mask
+            np.testing.assert_equal(mask_img, original_mask_img)
+
+            # 2. Cell Segmentation tiff tests
+            cell_seg_path = os.path.join(output_path, "cell_segmentation.tiff")
+            if _seg_none:
+                # 2.a Asser that the segmentation label tiff does not exist in the output dir
+                assert not os.path.exists(cell_seg_path)
+            else:
+                # 2.b.i. Assert that the segmentation label compartments exist in the new directory
                 assert os.path.exists(cell_seg_path)
-                original_cell_seg_path = os.path.join(temp_dir, segmentation_dir,
-                                                      '%s_whole_cell_test.tiff' % fov)
+
+                # 2.b.ii Assert that the `cell_segmentation` file is equal to `fov#_whole_cell`
                 cell_seg_img = io.imread(cell_seg_path)
+                original_cell_seg_path = os.path.join(md.data_dir, md.segmentation_dir,
+                                                      '%s_whole_cell_test.tiff' % fov)
                 original_cell_seg_img = io.imread(original_cell_seg_path)
-                # 2.b. Assert that the `cell_segmentation` file is equal to `fov#_whole_cell`
                 np.testing.assert_equal(cell_seg_img, original_cell_seg_img)
 
-                # 3. mapping csv tests
-                if type(mapping) is pd.DataFrame:
-                    original_mapping_df = df
-                else:
-                    original_mapping_df = pd.read_csv(mapping_path)
-                new_mapping_df = pd.read_csv(
-                    os.path.join(output_path, "population{}.csv".format(mask_suffix)))
+            # 3. mapping csv tests
+            if type(mapping) is pd.DataFrame:
+                original_mapping_df = md.df
+            else:
+                original_mapping_df = pd.read_csv(md.mapping_path)
+            new_mapping_df = pd.read_csv(
+                os.path.join(output_path, "population{}.csv".format(md.mask_suffix)))
 
-                # 3.a. Assert that metacluster col equals the region_id col
-                metacluster_col = original_mapping_df[["pixel_meta_cluster"]]
-                region_id_col = new_mapping_df[["region_id"]]
-                metacluster_col.eq(region_id_col)
+            # 3.a. Assert that metacluster col equals the region_id col
+            metacluster_col = original_mapping_df[["pixel_meta_cluster"]]
+            region_id_col = new_mapping_df[["region_id"]]
+            metacluster_col.eq(region_id_col)
 
-                # 3.b. Assert that mc_name col equals the region_name col
-                mc_name_col = original_mapping_df[["pixel_meta_cluster_rename"]]
-                region_name = new_mapping_df[["region_name"]]
-                mc_name_col.eq(region_name)
+            # 3.b. Assert that mc_name col equals the region_name col
+            mc_name_col = original_mapping_df[["pixel_meta_cluster_rename"]]
+            region_name = new_mapping_df[["region_name"]]
+            mc_name_col.eq(region_name)
 
-                mantis_fov_channels = natsort.natsorted(list(Path(output_path).glob("chan*.tiff")))
+            mantis_fov_channels = natsort.natsorted(list(Path(output_path).glob("chan*.tiff")))
 
-                # 4. Test that all fov channels exist and are correct
-                for chan_path in mantis_fov_channels:
-                    new_chan = io.imread(chan_path)
+            # 4. Test that all fov channels exist and are correct
+            for chan_path in mantis_fov_channels:
+                new_chan = io.imread(chan_path)
 
-                    # get the channel name
-                    chan, _ = chan_path.name.split('.')
-                    original_chan = data_xr.loc[fov, :, :, chan].values
-                    np.testing.assert_equal(new_chan, original_chan)
+                # get the channel name
+                chan, _ = chan_path.name.split(".")
+                original_chan = md.data_xr.loc[fov, :, :, chan].values
+                np.testing.assert_equal(new_chan, original_chan)

--- a/tests/utils/plot_utils_test.py
+++ b/tests/utils/plot_utils_test.py
@@ -254,14 +254,14 @@ class _mantis:
     mask_dir: str
     cell_output_dir: str
     fov_path: pathlib.Path
-    img_data_path: pathlib.Path
-    img_sub_folder: pathlib.Path
+    img_data_path: str
+    img_sub_folder: str
     mantis_project_path: pathlib.Path
     mask_output_dir: pathlib.Path
     fovs: List[str]
     mask_suffix: str
     df: pd.DataFrame
-    mapping_path: pathlib.Path
+    mapping_path: str
     data_xr: xr.DataArray
     example_masks: xr.DataArray
 
@@ -303,7 +303,7 @@ def mantis_data(tmp_path) -> Generator[_mantis, None, None]:
     fovs, channels = test_utils.gen_fov_chan_names(num_fovs=fov_count, num_chans=4,
                                                    use_delimiter=False, return_imgs=False)
 
-    fov_path = data_dir / img_data_path
+    fov_path: pathlib.Path = data_dir / img_data_path
     filelocs, data_xr = test_utils.create_paired_xarray_fovs(
         fov_path, fovs, channels, img_shape=(10, 10), mode='tiff', delimiter=None,
         sub_dir=img_sub_folder, fills=True, dtype=np.int16


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #969. Adds the ability to not move segmentation files.

**How did you implement your changes**

Added a flag to check and see if either `seg_dir` or `seg_suffix_name` are `None`.
Refactored the test to use a fixture, should make it easier to modify now.

**Remaining issues**

N/A.