### PR TITLE
Pixel Clustering - Run without segmentaiton files

### DIFF
--- a/src/ark/phenotyping/pixie_preprocessing.py
+++ b/src/ark/phenotyping/pixie_preprocessing.py
@@ -132,12 +132,12 @@ def preprocess_fov(base_dir, tiff_dir, data_dir, subset_dir, seg_dir, seg_suffix
         pixel_mat_chans=img_xr.channels.values
     )
 
-    # if seg_dir is None, leave seg_labels as None
-    seg_labels = None
-
-    # otherwise, load segmentation labels in for fov
+    # if seg_dir is not None, load the segmentation labels in for the fov,
+    # otherwise leave seg_labels as None
     if seg_dir is not None:
         seg_labels = imread(os.path.join(seg_dir, fov + seg_suffix))
+    else:
+        seg_labels = None
 
     # subset for the channel data
     img_data = img_xr.loc[fov, :, :, channels].values.astype(np.float32)

--- a/templates/2_Pixie_Cluster_Pixels.ipynb
+++ b/templates/2_Pixie_Cluster_Pixels.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -43,6 +44,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -67,6 +69,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -91,6 +94,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -100,13 +104,15 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "* `tiff_dir`: path to the directory containing your imaging data. Images should be single-channel TIFFs.\n",
     "* `img_sub_folder`: if `tiff_dir` contains an additional subfolder structure, override `None` with the appropriate folder name\n",
     "* `segmentation_dir`: path to the directory containing your segmentations (which can be generated using `1_Segment_Image_Data.ipynb`). Set this argument to `None` if you do not have segmentation labels or wish to run pixel clustering without them (they are required for cell clustering)\n",
-    "* `seg_suffix`: the suffix plus the file extension of the segmented images for each FOV. Note that these should be the same for all FOVs. This argument will be ignored if `segmentation_dir` is set to `None`"
+    "* `seg_suffix`: the suffix plus the file extension of the segmented images for each FOV. Note that these should be the same for all FOVs. This argument will be ignored if `segmentation_dir` is set to `None`\n",
+    "* `pixie_seg_dir`: the created path from the `segmentation_dir`. Is `None` if `segmentation_dir` is `None`."
    ]
   },
   {
@@ -122,10 +128,16 @@
     "tiff_dir = os.path.join(base_dir, \"image_data\")\n",
     "img_sub_folder = None\n",
     "segmentation_dir = os.path.join(\"segmentation\", \"deepcell_output\")\n",
-    "seg_suffix = '_whole_cell.tiff'"
+    "seg_suffix = '_whole_cell.tiff'\n",
+    "\n",
+    "if segmentation_dir is not None:\n",
+    "    pixie_seg_dir = os.path.join(base_dir, segmentation_dir)\n",
+    "else:\n",
+    "    pixie_seg_dir = None"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -150,6 +162,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -157,6 +170,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -181,6 +195,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -190,6 +205,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -214,6 +230,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -247,6 +264,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -279,6 +297,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -314,6 +333,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -342,6 +362,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -371,7 +392,7 @@
     "    channels,\n",
     "    base_dir,\n",
     "    tiff_dir,\n",
-    "    os.path.join(base_dir, segmentation_dir),\n",
+    "    pixie_seg_dir,\n",
     "    img_sub_folder=img_sub_folder,\n",
     "    seg_suffix=seg_suffix,\n",
     "    pixel_output_dir=pixel_output_dir,\n",
@@ -386,6 +407,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -393,6 +415,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -400,6 +423,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -430,6 +454,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -462,6 +487,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -469,6 +495,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -512,6 +539,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -519,6 +547,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -533,6 +562,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -579,6 +609,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -586,6 +617,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -593,6 +625,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -644,6 +677,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -684,6 +718,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -707,6 +742,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -766,6 +802,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -801,6 +838,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -808,6 +846,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -851,6 +890,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -875,7 +915,7 @@
     "    img_data_path=tiff_dir,\n",
     "    mask_output_dir=os.path.join(base_dir, pixel_output_dir, \"pixel_masks\"),\n",
     "    mapping = os.path.join(base_dir, pixel_meta_cluster_remap_name),\n",
-    "    seg_dir=os.path.join(base_dir, segmentation_dir),\n",
+    "    seg_dir=pixie_seg_dir,\n",
     "    mask_suffix=\"_pixel_mask\",\n",
     "    seg_suffix_name=seg_suffix\n",
     ")"


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Allows pixel clustering without segmentation files.

**How did you implement your changes**

Added a variable called `pixie_seg_dir` which evaluates to the full path of the `segmentation_dir` if it exists, or `None` when `segmentation_dir` is `None`.

**Remaining issues**

None.