### PR TITLE
Include all fiber properties in stats generation

### DIFF
--- a/src/ark/segmentation/fiber_segmentation.py
+++ b/src/ark/segmentation/fiber_segmentation.py
@@ -419,8 +419,12 @@ def generate_tile_stats(fov_table, fov_fiber_img, fov_length, tile_length, min_f
 
     fov_table = fov_table.reset_index(drop=True)
     fov = fov_table.fov[0]
-    alignment, length, pixel_density, fiber_density = [], [], [], []
+    alignment, pixel_density, fiber_density, tile_stats = [], [], [], []
     fov_list, tile_x, tile_y = [], [], []
+
+    # other tile stats
+    properties = ["major_axis_length", "minor_axis_length", "orientation", "area",
+                  "eccentricity", "euler_number"]
 
     # create tiles based on provided tile_length
     for i, j in itertools.product(
@@ -447,26 +451,35 @@ def generate_tile_stats(fov_table, fov_fiber_img, fov_length, tile_length, min_f
             tile_table['centroid-1'] >= x_range[0], tile_table['centroid-1'] < x_range[1])]
 
         # tile must have a certain number of fibers to receive values, otherwise NaN
-        avg_alignment, avg_length, p_density, f_density = [np.nan]*4
+        avg_alignment, p_density, f_density = [np.nan]*3
+        tile_avgs = np.array([np.nan]*len(properties))
 
         if len(tile_table) >= min_fiber_num:
+            # alignment
             align_scores = tile_table['alignment_score'].values
             align_scores = align_scores[~np.isnan(align_scores)]
             avg_alignment = np.mean(align_scores) if len(align_scores) >= min_fiber_num else np.nan
 
-            avg_length = np.mean(tile_table['major_axis_length'].values)
+            # take the average of the properties
+            tile_avgs = fov_table[properties].mean().array
 
+            # density
             p_density, f_density = calculate_density(tile_table, tile_length ** 2)
 
         alignment.append(avg_alignment)
-        length.append(avg_length)
         pixel_density.append(p_density)
         fiber_density.append(f_density)
+        tile_stats.append(tile_avgs)
+
+    tile_stats = np.vstack(tile_stats)
 
     fov_tile_stats = pd.DataFrame(zip(
-        fov_list, tile_y, tile_x, alignment, length, pixel_density, fiber_density),
-        columns=['fov', 'tile_y', 'tile_x', 'alignment', 'avg_length',
-                 'pixel_density', 'fiber_density'])
+        fov_list, tile_y, tile_x, pixel_density, fiber_density, alignment),
+        columns=['fov', 'tile_y', 'tile_x', 'pixel_density', 'fiber_density',
+                 'avg_alignment_score'])
+
+    for i, metric in enumerate(properties):
+        fov_tile_stats[f"avg_{metric}"] = tile_stats.T[0]
 
     return fov_tile_stats
 
@@ -502,7 +515,11 @@ def generate_summary_stats(fiber_object_table, fibseg_dir, tile_length=512, min_
     save_dir = os.path.join(fibseg_dir, f'tile_stats_{tile_length}')
     fovs = np.unique(fiber_object_table.fov)
     fov_stats, tile_stats = [], []
-    fov_alignment, fov_avg_length, fov_pixel_density, fov_fiber_density = [], [], [], []
+    fov_alignment, fov_pixel_density, fov_fiber_density, fov_avg_stats = [], [], [], []
+
+    # stat list
+    properties = ["major_axis_length", "minor_axis_length", "orientation", "area",
+                  "eccentricity", "euler_number", "alignment_score"]
 
     # get fov level and tile level stats for each image
     for fov in fovs:
@@ -510,13 +527,8 @@ def generate_summary_stats(fiber_object_table, fibseg_dir, tile_length=512, min_
         fov_length = fov_fiber_img.shape[0]
         fov_table = fiber_object_table[fiber_object_table.fov == fov]
 
-        # fov level stats
-        # alignment
-        fov_align_scores = fov_table['alignment_score'].values
-        fov_alignment.append(np.mean(fov_align_scores[~np.isnan(fov_align_scores)]))
-
-        # length
-        fov_avg_length.append(np.mean(fov_table['major_axis_length'].values))
+        # take the average of the fov level properties
+        avg_stats = fov_table[properties].mean().array
 
         # density
         fov_p_density, fov_p_density = calculate_density(fov_table, fov_length**2)
@@ -527,15 +539,19 @@ def generate_summary_stats(fiber_object_table, fibseg_dir, tile_length=512, min_
         fov_tile_stats = generate_tile_stats(fov_table, fov_fiber_img, fov_length, tile_length,
                                              min_fiber_num, save_dir, save_tiles)
 
+        fov_avg_stats.append(avg_stats)
         tile_stats.append(fov_tile_stats)
 
     fov_stats = pd.DataFrame({
         'fov': fovs,
-        'alignment': fov_alignment,
-        'avg_length': fov_avg_length,
         'pixel_density': fov_pixel_density,
         'fiber_density': fov_fiber_density
         })
+
+    fov_prop_stats = np.vstack(fov_avg_stats)
+    for i, metric in enumerate(properties):
+        fov_stats[f"avg_{metric}"] = fov_prop_stats.T[0]
+
     fov_stats.to_csv(os.path.join(fibseg_dir, f'fiber_stats_table.csv'), index=False)
 
     tile_stats = pd.concat(tile_stats)

--- a/tests/segmentation/fiber_segmentation_test.py
+++ b/tests/segmentation/fiber_segmentation_test.py
@@ -169,11 +169,15 @@ def test_generate_tile_stats(min_fiber_num):
     fov_fiber_table = pd.DataFrame({
         'fov': ['fov1', 'fov1', 'fov1', 'fov1', 'fov1', 'fov1'],
         'label': [1, 2, 3, 4, 5, 6],
-        'alignment_score': random.sample(range(10, 40), 6),
         'centroid-0': [0, 1, 1, 0, 2, 9],
         'centroid-1': [0, 1, 0, 1, 2, 9],
         'major_axis_length': random.sample(range(1, 20), 6),
-        'area': [1] * 6
+        'minor_axis_length': random.sample(range(1, 10), 6),
+        'orientation': random.choice(range(-1.57, 1.57, 6)),
+        'area': [1] * 6,
+        'eccentricity': random.choice(range(0, 1.0, 6)),
+        'euler_number': random.sample(range(0, 1), 6),
+        'alignment_score': random.sample(range(10, 40), 6),
     })
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -207,6 +211,10 @@ def test_generate_tile_stats(min_fiber_num):
                 itertools.product(tile_corners, tile_corners, np.unique(fov_fiber_table.fov)):
             assert os.path.exists(os.path.join(temp_dir, fov, f'tile_{y},{x}.tiff'))
 
+        # check additional property averages are included
+        assert ["avg_major_axis_length", "avg_minor_axis_length", "avg_orientation", "avg_area",
+                "avg_eccentricity", "avg_euler_number"] in tile_stats.columns
+
 
 @pytest.mark.parametrize("min_fiber_num", [1, 5])
 def test_generate_summary_stats(mocker: MockerFixture, min_fiber_num):
@@ -217,11 +225,15 @@ def test_generate_summary_stats(mocker: MockerFixture, min_fiber_num):
         'fov': ['fov1', 'fov1', 'fov1', 'fov1', 'fov1', 'fov1',
                 'fov2', 'fov2', 'fov2', 'fov2', 'fov2', 'fov2'],
         'label': [1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6],
-        'alignment_score': random.sample(range(10, 40), 12),
         'centroid-0': random.sample(range(0, 15), 12),
         'centroid-1': random.sample(range(0, 15), 12),
         'major_axis_length': random.sample(range(1, 20), 12),
-        'area': [1]*12
+        'minor_axis_length': random.sample(range(1, 10), 12),
+        'orientation': random.choice(range(-1.57, 1.57, 12)),
+        'area': [1]*12,
+        'eccentricity': random.choice(range(0, 1.0, 12)),
+        'euler_number': random.sample(range(0, 1), 12),
+        'alignment_score': random.sample(range(10, 40), 12),
     })
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -240,9 +252,13 @@ def test_generate_summary_stats(mocker: MockerFixture, min_fiber_num):
                                            f'fiber_stats_table-tile_{tile_length}.csv'))
 
         # check fov-level values
-        # only confirm avg length and alignment, densities are tested above
-        assert fov_stats.avg_length[0] == np.mean(fiber_object_table.major_axis_length[0:6])
-        assert fov_stats.avg_length[1] == np.mean(fiber_object_table.major_axis_length[6:12])
+        # only confirm fiber property avg stats, densities are tested above
+        assert ["avg_major_axis_length", "avg_minor_axis_length", "avg_orientation", "avg_area",
+                "avg_eccentricity", "avg_euler_number", "avg_alignment_score"] in fov_stats.columns
+        assert fov_stats.avg_major_axis_length[0] ==\
+               np.mean(fiber_object_table.major_axis_length[0:6])
+        assert fov_stats.avg_major_axis_length[1] == \
+               np.mean(fiber_object_table.major_axis_length[6:12])
 
 
 def test_color_fibers_by_stat():


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

In addition to density measurements, only fiber alignment and length are averaged and stored in the summary stats and tile stats files. We would like to calculate averages for all stats included in the table.

**How did you implement your changes**

Compute and save averages for fiber width, orientation, area, eccentricity, euler number.

**Remaining issues**

N/A
