### PR TITLE
Drop 3rd dimension in segmentation masks

### DIFF
--- a/src/ark/utils/deepcell_service_utils.py
+++ b/src/ark/utils/deepcell_service_utils.py
@@ -157,7 +157,7 @@ def create_deepcell_output(deepcell_input_dir, deepcell_output_dir, fovs=None,
 
                 # read the file from the .zip file and save as segmentation mask
                 byte_repr = zipObj.read(name)
-                ranked_segmentation_mask = _convert_deepcell_seg_masks(byte_repr)
+                ranked_segmentation_mask = (_convert_deepcell_seg_masks(byte_repr)).squeeze()
                 image_utils.save_image(mask_path, ranked_segmentation_mask)
 
             # verify that all the files were extracted

--- a/tests/utils/deepcell_service_utils_test.py
+++ b/tests/utils/deepcell_service_utils_test.py
@@ -77,6 +77,11 @@ def test_create_deepcell_output(mocker: MockerFixture):
             assert os.path.exists(os.path.join(output_dir, 'fov2_whole_cell.tiff'))
             assert os.path.exists(os.path.join(output_dir, 'fov2_nuclear.tiff'))
 
+            # test for 2d shape
+            whole_cell_arr = io.imread(os.path.join(output_dir, 'fov1_whole_cell.tiff'))
+            nuclear_arr = io.imread(os.path.join(output_dir, 'fov1_nuclear.tiff'))
+            assert len(whole_cell_arr.shape) == len(nuclear_arr.shape) == 2
+
         with tempfile.TemporaryDirectory() as output_dir:
 
             # test parallel


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #1009. Changes shape of the segmentation masks from 3d to 2d.     (1, 1024, 1024) --> (1024, 1024)
This now allows the images to be stitched in `Image_Stitching.ipynb` without issue.

**How did you implement your changes**

Squeeze the `ranked_segmentation_mask` before saving it to a tiff. 

**Remaining issues**

- [x] Run segmentation notebook and check output mask shape
- [x] Run pixel clustering notebook to check for any issues
- [x] Run stitching notebook 