### PR TITLE
Pixie percentile saving

### DIFF
--- a/src/ark/phenotyping/cluster_helpers.py
+++ b/src/ark/phenotyping/cluster_helpers.py
@@ -149,6 +149,9 @@ class PixieSOMCluster(ABC):
                 ].values.astype(np.float64)
             )[0])
 
+        # if no pixels in the image, return empty array
+        if not cluster_labels:
+            return np.empty(0)
         # concat all the results together and return
         return np.concatenate(cluster_labels)
 

--- a/src/ark/phenotyping/pixie_preprocessing.py
+++ b/src/ark/phenotyping/pixie_preprocessing.py
@@ -244,7 +244,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
         os.mkdir(os.path.join(base_dir, subset_dir))
 
     # create variable for storing 99.9% values
-    quantile_path = os.path.join(base_dir, pixel_output_dir, "quantile_data.csv")
+    quantile_path = os.path.join(base_dir, data_dir, "quantile_data.csv")
 
     # find all the FOV files in the full data and subsetted directories
     # NOTE: this handles the case where the data file was written, but not the subset file

--- a/src/ark/phenotyping/pixie_preprocessing.py
+++ b/src/ark/phenotyping/pixie_preprocessing.py
@@ -357,3 +357,6 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
     feather.write_dataframe(mean_quant.T,
                             os.path.join(base_dir, norm_vals_name),
                             compression='uncompressed')
+
+    # delete quantile data file
+    os.remove(quantile_path)

--- a/src/ark/phenotyping/pixie_preprocessing.py
+++ b/src/ark/phenotyping/pixie_preprocessing.py
@@ -258,17 +258,17 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
     # NOTE: if an existing FOV is already corrupted, future steps will discard it
     fovs_list = list(set(fovs).difference(set(fovs_full)))
 
+    # if there are no FOVs left to preprocess don't run function
+    if len(fovs_list) == 0:
+        print("There are no more FOVs to preprocess, skipping")
+        return
+
     # check for missing quant data and add to the list of FOVs for processing
     quant_dat_all = pd.read_csv(quantile_path, index_col="channel") \
         if os.path.exists(quantile_path) else pd.DataFrame()
     quant_fov_list = quant_dat_all.columns
     quant_missing = list(set(fovs).difference(set(quant_fov_list)))
     fovs_list = list(set(fovs_list).union(set(quant_missing)))
-
-    # if there are no FOVs left to preprocess don't run function
-    if len(fovs_list) == 0:
-        print("There are no more FOVs to preprocess, skipping")
-        return
 
     # if the process is only partially complete, inform the user of restart
     if len(fovs_list) < len(fovs):

--- a/src/ark/phenotyping/pixie_preprocessing.py
+++ b/src/ark/phenotyping/pixie_preprocessing.py
@@ -244,7 +244,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
         os.mkdir(os.path.join(base_dir, subset_dir))
 
     # create variable for storing 99.9% values
-    quantile_path = os.path.join(base_dir, data_dir, "quantile_data.csv")
+    quantile_path = os.path.join(base_dir, pixel_output_dir, "quantile_data.csv")
 
     # find all the FOV files in the full data and subsetted directories
     # NOTE: this handles the case where the data file was written, but not the subset file
@@ -264,7 +264,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
     # check for missing quant data and add to the list of FOVs for processing
     quant_fov_list = pd.read_csv(quantile_path, index_col="channel").columns \
         if os.path.exists(quantile_path) else []
-    quant_missing = list(set(quant_fov_list).difference(set(fovs)))
+    quant_missing = list(set(fovs).difference(set(quant_fov_list)))
     fovs_list = list(set(fovs_list).union(set(quant_missing)))
 
     # if there are no FOVs left to preprocess don't run function

--- a/src/ark/phenotyping/pixie_preprocessing.py
+++ b/src/ark/phenotyping/pixie_preprocessing.py
@@ -262,7 +262,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
     fovs_list = list(set(fovs).difference(set(fovs_full)))
 
     # check for missing quant data and add to the list of FOVs for processing
-    quant_fov_list = pd.read_csv(quantile_path).columns
+    quant_fov_list = pd.read_csv(quantile_path).columns if os.path.exists(quantile_path) else []
     quant_missing = list(set(quant_fov_list).difference(set(fovs_full)))
     fovs_list = list(set(fovs_list).union(set(quant_missing)))
 

--- a/src/ark/phenotyping/pixie_preprocessing.py
+++ b/src/ark/phenotyping/pixie_preprocessing.py
@@ -157,7 +157,7 @@ def preprocess_fov(base_dir, tiff_dir, data_dir, subset_dir, seg_dir, seg_suffix
                                          fov + ".feather"),
                             compression='uncompressed')
 
-    # write subseted dataset to feather, needed for training
+    # write subsetted dataset to feather, needed for training
     feather.write_dataframe(pixel_mat_subset,
                             os.path.join(base_dir,
                                          subset_dir,

--- a/src/ark/phenotyping/pixie_preprocessing.py
+++ b/src/ark/phenotyping/pixie_preprocessing.py
@@ -6,7 +6,6 @@ import feather
 import numpy as np
 import pandas as pd
 import scipy.ndimage as ndimage
-from natsort import natsorted
 from alpineer import io_utils, load_utils, misc_utils
 from skimage.io import imread
 

--- a/src/ark/phenotyping/pixie_preprocessing.py
+++ b/src/ark/phenotyping/pixie_preprocessing.py
@@ -261,6 +261,11 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
     # NOTE: if an existing FOV is already corrupted, future steps will discard it
     fovs_list = list(set(fovs).difference(set(fovs_full)))
 
+    # check for missing quant data and add to the list of FOVs for processing
+    quant_fov_list = pd.read_csv(quantile_path).columns
+    quant_missing = list(set(quant_fov_list).difference(set(fovs_full)))
+    fovs_list = list(set(fovs_list).union(set(quant_missing)))
+
     # if there are no FOVs left to preprocess don't run function
     if len(fovs_list) == 0:
         print("There are no more FOVs to preprocess, skipping")
@@ -338,7 +343,7 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
             # read in previously processed fov quantile values or initialize new df
             quant_dat_all = pd.read_csv(quantile_path) if os.path.exists(quantile_path) \
                 else pd.DataFrame()
-            # update the file with the newly processed fov quantile value
+            # update the file with the newly processed fov quantile values
             quant_dat_all[fov] = quant_dat_fov
             quant_dat_all.to_csv(quantile_path)
 
@@ -351,8 +356,6 @@ def create_pixel_matrix(fovs, channels, base_dir, tiff_dir, seg_dir,
 
     # get mean 99.9% across all fovs for all markers, check that none are missing
     quant_dat = pd.read_csv(quantile_path)
-    if natsorted(quant_dat.columns) != natsorted(fovs):
-        raise ValueError("Missing some FOV quantile values.")
 
     mean_quant = pd.DataFrame(quant_dat.mean(axis=1))
 

--- a/tests/phenotyping/pixie_preprocessing_test.py
+++ b/tests/phenotyping/pixie_preprocessing_test.py
@@ -498,7 +498,8 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
             columns=['fov0', 'fov2']
         )
         sample_quant_data.index.name = 'channel'
-        sample_quant_data.to_csv(os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'))
+        sample_quant_data.to_csv(
+            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'))
 
         pixie_preprocessing.create_pixel_matrix(
             fovs=PIXEL_MATRIX_FOVS,
@@ -517,7 +518,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files+['quantile_data.csv']
+            written_files=fov_files+['channel_norm_post_rowsum_perfov.csv']
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),
@@ -526,7 +527,8 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
 
         # check fov1 added to quantile data file
         final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'), index_col='channel')
+            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'),
+            index_col='channel')
         assert "fov1" in final_quant_data.columns
 
         capsys.readouterr()
@@ -534,7 +536,8 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         # test the case where we've written a FOV to data but not subset
         # NOTE: in this case, the value in quant_dat will also not have been written
         os.remove(os.path.join(temp_dir, 'pixel_mat_subsetted', 'fov1.feather'))
-        sample_quant_data.to_csv(os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'))
+        sample_quant_data.to_csv(
+            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'))
 
         pixie_preprocessing.create_pixel_matrix(
             fovs=PIXEL_MATRIX_FOVS,
@@ -553,7 +556,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files+['quantile_data.csv']
+            written_files=fov_files+['channel_norm_post_rowsum_perfov.csv']
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),
@@ -562,13 +565,15 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
 
         # check fov1 added to quantile data file
         final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'), index_col='channel')
+            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'),
+            index_col='channel')
         assert "fov1" in final_quant_data.columns
 
         # test the case where we've written a FOV to subset but not data (very rare)
         # NOTE: in this case, the value in quantile_dat will also not have been written
         os.remove(os.path.join(temp_dir, 'pixel_mat_data', 'fov1.feather'))
-        sample_quant_data.to_csv(os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'))
+        sample_quant_data.to_csv(
+            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'))
 
         pixie_preprocessing.create_pixel_matrix(
             fovs=PIXEL_MATRIX_FOVS,
@@ -587,7 +592,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files+['quantile_data.csv']
+            written_files=fov_files+['channel_norm_post_rowsum_perfov.csv']
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),
@@ -596,7 +601,8 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
 
         # check fov1 added to quantile data file
         final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'), index_col='channel')
+            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'),
+            index_col='channel')
         assert "fov1" in final_quant_data.columns
 
 
@@ -622,7 +628,7 @@ def test_create_pixel_matrix_all_fovs(capsys):
         assert output_capture == "There are no more FOVs to preprocess, skipping\n"
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files+['quantile_data.csv']
+            written_files=fov_files+['channel_norm_post_rowsum_perfov.csv']
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),
@@ -631,6 +637,7 @@ def test_create_pixel_matrix_all_fovs(capsys):
 
         # check all fovs in quantile data file
         final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'), index_col='channel')
+            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'),
+            index_col='channel')
         assert misc_utils.verify_in_list(fovs=PIXEL_MATRIX_FOVS,
                                          quan_data_columns=final_quant_data.columns)

--- a/tests/phenotyping/pixie_preprocessing_test.py
+++ b/tests/phenotyping/pixie_preprocessing_test.py
@@ -518,18 +518,12 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files+['channel_norm_post_rowsum_perfov.csv']
+            written_files=fov_files
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),
             written_files=fov_files
         )
-
-        # check fov1 added to quantile data file
-        final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'),
-            index_col='channel')
-        assert "fov1" in final_quant_data.columns
 
         capsys.readouterr()
 
@@ -556,18 +550,12 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files+['channel_norm_post_rowsum_perfov.csv']
+            written_files=fov_files
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),
             written_files=fov_files
         )
-
-        # check fov1 added to quantile data file
-        final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'),
-            index_col='channel')
-        assert "fov1" in final_quant_data.columns
 
         # test the case where we've written a FOV to subset but not data (very rare)
         # NOTE: in this case, the value in quantile_dat will also not have been written
@@ -592,18 +580,12 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files+['channel_norm_post_rowsum_perfov.csv']
+            written_files=fov_files
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),
             written_files=fov_files
         )
-
-        # check fov1 added to quantile data file
-        final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'),
-            index_col='channel')
-        assert "fov1" in final_quant_data.columns
 
 
 def test_create_pixel_matrix_all_fovs(capsys):
@@ -628,16 +610,9 @@ def test_create_pixel_matrix_all_fovs(capsys):
         assert output_capture == "There are no more FOVs to preprocess, skipping\n"
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files+['channel_norm_post_rowsum_perfov.csv']
+            written_files=fov_files
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),
             written_files=fov_files
         )
-
-        # check all fovs in quantile data file
-        final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'channel_norm_post_rowsum_perfov.csv'),
-            index_col='channel')
-        assert misc_utils.verify_in_list(fovs=PIXEL_MATRIX_FOVS,
-                                         quan_data_columns=final_quant_data.columns)

--- a/tests/phenotyping/pixie_preprocessing_test.py
+++ b/tests/phenotyping/pixie_preprocessing_test.py
@@ -499,7 +499,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         )
         feather.write_dataframe(
             sample_quant_data,
-            os.path.join(temp_dir, 'pixel_output_dir', 'quant_dat.feather')
+            os.path.join(temp_dir, 'pixel_output_dir', 'quantile_data.csv')
         )
 
         pixie_preprocessing.create_pixel_matrix(
@@ -533,7 +533,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         os.remove(os.path.join(temp_dir, 'pixel_mat_subsetted', 'fov1.feather'))
         feather.write_dataframe(
             sample_quant_data,
-            os.path.join(temp_dir, 'pixel_output_dir', 'quant_dat.feather')
+            os.path.join(temp_dir, 'pixel_output_dir', 'quantile_data.csv')
         )
 
         pixie_preprocessing.create_pixel_matrix(
@@ -561,11 +561,11 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         )
 
         # test the case where we've written a FOV to subset but not data (very rare)
-        # NOTE: in this case, the value in quant_dat will also not have been written
+        # NOTE: in this case, the value in quantile_dat will also not have been written
         os.remove(os.path.join(temp_dir, 'pixel_mat_data', 'fov1.feather'))
         feather.write_dataframe(
             sample_quant_data,
-            os.path.join(temp_dir, 'pixel_output_dir', 'quant_dat.feather')
+            os.path.join(temp_dir, 'pixel_output_dir', 'quantile_data.csv')
         )
 
         pixie_preprocessing.create_pixel_matrix(

--- a/tests/phenotyping/pixie_preprocessing_test.py
+++ b/tests/phenotyping/pixie_preprocessing_test.py
@@ -263,7 +263,7 @@ def mocked_preprocess_fov(base_dir, tiff_dir, data_dir, subset_dir, seg_dir, seg
     cases=CreatePixelMatrixBaseCases
 )
 @parametrize('multiprocess', [True, False])
-def test_create_pixel_matrix_base(fovs, chans, sub_dir, seg_dir_include,
+def test_create_pixel_matrix_missing_fov(fovs, chans, sub_dir, seg_dir_include,
                                   channel_norm_include, pixel_thresh_include,
                                   norm_diff_chan, multiprocess, mocker, capsys):
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -519,7 +519,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files
+            written_files=fov_files+['quantile_data.csv']
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),
@@ -615,7 +615,7 @@ def test_create_pixel_matrix_all_fovs(capsys):
         assert output_capture == "There are no more FOVs to preprocess, skipping\n"
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files
+            written_files=fov_files+['quantile_data.csv']
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),

--- a/tests/phenotyping/pixie_preprocessing_test.py
+++ b/tests/phenotyping/pixie_preprocessing_test.py
@@ -553,7 +553,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_data')),
-            written_files=fov_files
+            written_files=fov_files+['quantile_data.csv']
         )
         misc_utils.verify_same_elements(
             data_files=io_utils.list_files(os.path.join(temp_dir, 'pixel_mat_subsetted')),

--- a/tests/phenotyping/pixie_preprocessing_test.py
+++ b/tests/phenotyping/pixie_preprocessing_test.py
@@ -497,6 +497,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
             index=PIXEL_MATRIX_CHANS,
             columns=['fov0', 'fov2']
         )
+        sample_quant_data.index.name = 'channel'
         sample_quant_data.to_csv(os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'))
 
         pixie_preprocessing.create_pixel_matrix(
@@ -525,7 +526,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
 
         # check fov1 added to quantile data file
         final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'))
+            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'), index_col='channel')
         assert "fov1" in final_quant_data.columns
 
         capsys.readouterr()
@@ -561,7 +562,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
 
         # check fov1 added to quantile data file
         final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'))
+            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'), index_col='channel')
         assert "fov1" in final_quant_data.columns
 
         # test the case where we've written a FOV to subset but not data (very rare)
@@ -595,7 +596,7 @@ def test_create_pixel_matrix_missing_fov(multiprocess, capsys):
 
         # check fov1 added to quantile data file
         final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'))
+            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'), index_col='channel')
         assert "fov1" in final_quant_data.columns
 
 
@@ -630,5 +631,6 @@ def test_create_pixel_matrix_all_fovs(capsys):
 
         # check all fovs in quantile data file
         final_quant_data = pd.read_csv(
-            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'))
-        assert PIXEL_MATRIX_FOVS in final_quant_data.columns
+            os.path.join(temp_dir, 'pixel_mat_data', 'quantile_data.csv'), index_col='channel')
+        assert misc_utils.verify_in_list(fovs=PIXEL_MATRIX_FOVS,
+                                         quan_data_columns=final_quant_data.columns)

--- a/tests/phenotyping/pixie_preprocessing_test.py
+++ b/tests/phenotyping/pixie_preprocessing_test.py
@@ -413,45 +413,6 @@ def test_create_pixel_matrix_base(fovs, chans, sub_dir, seg_dir_include,
             # NOTE: need to account for rounding if multiplying by 0.1 leads to non-int
             assert round(flowsom_data_fov.shape[0] * 0.1) == flowsom_sub_fov.shape[0]
 
-        # check that correct values are passed to helper function
-        mocker.patch(
-            'ark.phenotyping.pixie_preprocessing.preprocess_fov',
-            mocked_preprocess_fov
-        )
-
-        if sub_dir is None:
-            sub_dir = ''
-
-        # create fake data where all channels in each fov are the same
-        new_tiff_dir = os.path.join(temp_dir, 'new_tiff_dir')
-        os.makedirs(new_tiff_dir)
-        for fov in fovs:
-            img = (np.random.rand(100) * 100).reshape((10, 10))
-            fov_dir = os.path.join(new_tiff_dir, fov, sub_dir)
-            os.makedirs(fov_dir)
-            for chan in chans:
-                image_utils.save_image(os.path.join(fov_dir, chan + '.tiff'), img)
-
-        # recreate the output directory
-        rmtree(sample_pixel_output_dir)
-        os.mkdir(sample_pixel_output_dir)
-
-        # create normalization file
-        data_dir = os.path.join(temp_dir, 'pixel_mat_data')
-
-        # generate the data
-        mults = [(1 / 2) ** i for i in range(len(chans))]
-
-        pixie_preprocessing.create_pixel_matrix(
-            fovs=fovs,
-            channels=chans,
-            base_dir=temp_dir,
-            tiff_dir=new_tiff_dir,
-            img_sub_folder=sub_dir,
-            seg_dir=seg_dir,
-            multiprocess=multiprocess
-        )
-
 
 # TODO: clean up the following tests
 def generate_create_pixel_matrix_test_data(temp_dir):

--- a/tests/phenotyping/pixie_preprocessing_test.py
+++ b/tests/phenotyping/pixie_preprocessing_test.py
@@ -263,9 +263,9 @@ def mocked_preprocess_fov(base_dir, tiff_dir, data_dir, subset_dir, seg_dir, seg
     cases=CreatePixelMatrixBaseCases
 )
 @parametrize('multiprocess', [True, False])
-def test_create_pixel_matrix_missing_fov(fovs, chans, sub_dir, seg_dir_include,
-                                         channel_norm_include, pixel_thresh_include,
-                                         norm_diff_chan, multiprocess, mocker, capsys):
+def test_create_pixel_matrix_base(fovs, chans, sub_dir, seg_dir_include,
+                                  channel_norm_include, pixel_thresh_include,
+                                  norm_diff_chan, multiprocess, mocker, capsys):
     with tempfile.TemporaryDirectory() as temp_dir:
         # create a directory to store the image data
         tiff_dir = os.path.join(temp_dir, 'sample_image_data')


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

1. Closes #1016. Implement intermediate saving of per image 99.9th percent values. 

In addition, two small corrections were made to the pixie code.

2. adds a new `channel_percentile_postnorm` argument to `create_pixel_matrix()`, rather than hard coding 0.999.
3. add fix for the edge case where an image has no positive pixels (previously would error out)
(@HPiyadasa ran into this issue when trying to pixels cluster only SMA+ pixels within a mask)
4. Should also close #900.

**How did you implement your changes**

1. Add image values to quantile_data.csv as they are processed. Also check the FOVs included in the file upon a restart, on the off chance a FOV had a feather file written, but the quantile data failed to be saved. Such images will be re-processed.
2. Set default `channel_percentile_postnorm=0.999`.
3. If there are no pixel cluster labels in an image, simply return an empty array rather than trying to concatenate an empty list (this causes an error).

**Remaining issues**
Long term, we could probably prevent zero positive pixel images from attempting to be processed at all, but that likely requires a more in depth fix and the above solution works fine for now.
