### PR TITLE
Optional normalization for generic_cell_clustering.ipynb

### DIFF
--- a/src/ark/phenotyping/cell_som_clustering.py
+++ b/src/ark/phenotyping/cell_som_clustering.py
@@ -8,7 +8,7 @@ from ark.phenotyping import cell_cluster_utils, cluster_helpers
 def train_cell_som(fovs, base_dir, cell_table_path, cell_som_cluster_cols,
                    cell_som_input_data, som_weights_name='cell_som_weights.feather',
                    xdim=10, ydim=10, lr_start=0.05, lr_end=0.01, num_passes=1, seed=42,
-                   overwrite=False):
+                   overwrite=False, normalize=True):
     """Run the SOM training on the expression columns specified in `cell_som_cluster_cols`.
 
     Saves the SOM weights to `base_dir/som_weights_name`.
@@ -40,6 +40,8 @@ def train_cell_som(fovs, base_dir, cell_table_path, cell_som_cluster_cols,
             The random seed to use for training the SOM
         overwrite (bool):
             If set, force retrains the SOM and overwrites the weights
+        normalize (bool):
+            Whether to perform 99.9% percentile normalization, default to True.
 
     Returns:
         cluster_helpers.CellSOMCluster:
@@ -62,7 +64,7 @@ def train_cell_som(fovs, base_dir, cell_table_path, cell_som_cluster_cols,
     cell_pysom = cluster_helpers.CellSOMCluster(
         cell_som_input_data, som_weights_path, fovs, cell_som_cluster_cols,
         num_passes=num_passes, xdim=xdim, ydim=ydim, lr_start=lr_start, lr_end=lr_end,
-        seed=seed
+        seed=seed, normalize=normalize
     )
 
     # train the SOM weights

--- a/src/ark/phenotyping/cluster_helpers.py
+++ b/src/ark/phenotyping/cluster_helpers.py
@@ -282,7 +282,7 @@ class CellSOMCluster(PixieSOMCluster):
     def __init__(self, cell_data: pd.DataFrame, weights_path: pathlib.Path,
                  fovs: List[str], columns: List[str], num_passes: int = 1,
                  xdim: int = 10, ydim: int = 10, lr_start: float = 0.05, lr_end: float = 0.01,
-                 seed=42):
+                 seed=42, normalize=True):
         """Creates a cell SOM cluster object derived from the abstract PixieSOMCluster
 
         Args:
@@ -306,6 +306,9 @@ class CellSOMCluster(PixieSOMCluster):
                 The learning rate to decay to.
             seed (int):
                 The random seed to use.
+            normalize (bool):
+                Whether to perform 99.9% percentile normalization, default to True.
+
         """
         super().__init__(
             weights_path, columns, num_passes, xdim, ydim, lr_start, lr_end, seed
@@ -323,7 +326,8 @@ class CellSOMCluster(PixieSOMCluster):
         ].reset_index(drop=True)
 
         # since cell_data is the only dataset, we can just normalize it immediately
-        self.normalize_data()
+        if normalize:
+            self.normalize_data()
 
     def normalize_data(self):
         """Normalizes `cell_data` by the 99.9% value of each pixel cluster count column

--- a/templates/generic_cell_clustering.ipynb
+++ b/templates/generic_cell_clustering.ipynb
@@ -232,7 +232,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "normalize_param"
+    ]
+   },
    "outputs": [],
    "source": [
     "normalize = True"

--- a/templates/generic_cell_clustering.ipynb
+++ b/templates/generic_cell_clustering.ipynb
@@ -226,7 +226,7 @@
    "source": [
     "**99.9% Normalization**\n",
     "\n",
-    "Whether to normalize each of the `cell_som_cluster_cols` by their 99.9% value prior to training the data. Set to `False` to skip this normalization step."
+    "Whether to normalize each of the `cell_som_cluster_cols` by their 99.9% value prior to training FlowSOM. Set to `False` to skip this normalization step."
    ]
   },
   {

--- a/templates/generic_cell_clustering.ipynb
+++ b/templates/generic_cell_clustering.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -39,7 +38,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -67,7 +65,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -92,7 +89,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -102,7 +98,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -132,7 +127,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -168,7 +162,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -193,7 +186,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -229,7 +221,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -237,7 +228,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -245,11 +235,10 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Train the cell SOM on the expression values provided per cell (the data stored in `cell_som_input_name`).  Training is done using the `FlowSOM` algorithm. Note that each of the `cell_som_cluster_cols` are normalized by their 99.9% value prior to training.\n",
+    "Train the cell SOM on the expression values provided per cell (the data stored in `cell_som_input_name`).  Training is done using the `FlowSOM` algorithm. Note that each of the `cell_som_cluster_cols` are normalized by their 99.9% value prior to training; if you would like to exclude this normalization, set `normalize=False` below.\n",
     "\n",
     "For a full set of parameters you can customize for `train_cell_som`, please consult: <a href=https://ark-analysis.readthedocs.io/en/latest/_markdown/ark.phenotyping.html#ark.phenotyping.cell_cluster_utils.train_cell_som>cell training docs</a>."
    ]
@@ -272,12 +261,12 @@
     "    cell_som_cluster_cols,\n",
     "    cell_som_input_data,\n",
     "    som_weights_name=cell_som_weights_name,\n",
-    "    num_passes=1\n",
+    "    num_passes=1,\n",
+    "    normalize=True\n",
     ")"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -285,7 +274,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -321,7 +309,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -329,7 +316,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -344,7 +330,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -387,7 +372,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -395,7 +379,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -403,7 +386,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -455,7 +437,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -491,7 +472,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -516,7 +496,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -574,7 +553,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -602,7 +580,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -639,7 +616,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -647,7 +623,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -670,7 +645,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -678,7 +652,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -702,7 +675,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -750,7 +722,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/templates/generic_cell_clustering.ipynb
+++ b/templates/generic_cell_clustering.ipynb
@@ -224,6 +224,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**99.9% Normalization**\n",
+    "\n",
+    "Whether to normalize each of the `cell_some_cluster_cols` by their 99.9% value prior to training the data. Set to `False` to skip this normalization step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "normalize = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 2: Cell clustering"
    ]
   },
@@ -238,7 +256,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Train the cell SOM on the expression values provided per cell (the data stored in `cell_som_input_name`).  Training is done using the `FlowSOM` algorithm. Note that each of the `cell_som_cluster_cols` are normalized by their 99.9% value prior to training; if you would like to exclude this normalization, set `normalize=False` below.\n",
+    "Train the cell SOM on the expression values provided per cell (the data stored in `cell_som_input_name`).  Training is done using the `FlowSOM` algorithm.\n",
     "\n",
     "For a full set of parameters you can customize for `train_cell_som`, please consult: <a href=https://ark-analysis.readthedocs.io/en/latest/_markdown/ark.phenotyping.html#ark.phenotyping.cell_cluster_utils.train_cell_som>cell training docs</a>."
    ]
@@ -262,7 +280,7 @@
     "    cell_som_input_data,\n",
     "    som_weights_name=cell_som_weights_name,\n",
     "    num_passes=1,\n",
-    "    normalize=True\n",
+    "    normalize=normalize\n",
     ")"
    ]
   },

--- a/templates/generic_cell_clustering.ipynb
+++ b/templates/generic_cell_clustering.ipynb
@@ -226,7 +226,7 @@
    "source": [
     "**99.9% Normalization**\n",
     "\n",
-    "Whether to normalize each of the `cell_some_cluster_cols` by their 99.9% value prior to training the data. Set to `False` to skip this normalization step."
+    "Whether to normalize each of the `cell_som_cluster_cols` by their 99.9% value prior to training the data. Set to `False` to skip this normalization step."
    ]
   },
   {

--- a/tests/utils/notebooks_test.py
+++ b/tests/utils/notebooks_test.py
@@ -596,6 +596,9 @@ class Test_3b_Generic_Cell_Clustering:
     def test_cell_cluster_files(self):
         self.tb.execute_cell("cell_cluster_files")
 
+    def test_normalization(self):
+        self.tb.execute_cell("normalize_param")
+
     def test_train_cell_som(self):
         self.tb.execute_cell("train_cell_som")
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**
Closes #1000. Make the 99.9 percentile normalization in cell clustering optional.

**How did you implement your changes**
Adds a `normalize` flag to `train_cell_SOM` and in the CellSOMCluster class which is defaulted to True.
Changing this arg to False will not conduct 99.9 percentile normalization on the data before cell clustering.

**Remaining issues**
N/A
