### PR TITLE
Update progress bars

### DIFF
--- a/src/ark/analysis/cell_neighborhood_stats.py
+++ b/src/ark/analysis/cell_neighborhood_stats.py
@@ -49,7 +49,8 @@ def compute_neighborhood_diversity(neighborhood_mat, cell_type_col):
 
     diversity_data = []
     fov_list = np.unique(neighborhood_mat[settings.FOV_ID])
-    with tqdm(total=len(fov_list), desc="Calculate Neighborhood Diversity") as diversity_progress:
+    with tqdm(total=len(fov_list), desc="Calculate Neighborhood Diversity", unit="FOVs") \
+            as diversity_progress:
         for fov in fov_list:
             diversity_progress.set_postfix(FOV=fov)
 
@@ -217,7 +218,8 @@ def generate_cell_distance_analysis(
     fov_list = np.unique(cell_table[fov_col])
 
     cell_dists = []
-    with tqdm(total=len(fov_list), desc="Calculate Average Distances") as distance_progress:
+    with tqdm(total=len(fov_list), desc="Calculate Average Distances", unit="FOVs") \
+            as distance_progress:
         for fov in fov_list:
             distance_progress.set_postfix(FOV=fov)
 

--- a/src/ark/analysis/cell_neighborhood_stats.py
+++ b/src/ark/analysis/cell_neighborhood_stats.py
@@ -51,6 +51,8 @@ def compute_neighborhood_diversity(neighborhood_mat, cell_type_col):
     fov_list = np.unique(neighborhood_mat[settings.FOV_ID])
     with tqdm(total=len(fov_list), desc="Calculate Neighborhood Diversity") as diversity_progress:
         for fov in fov_list:
+            diversity_progress.set_postfix(FOV=fov)
+
             fov_neighborhoods = neighborhood_mat[neighborhood_mat[settings.FOV_ID] == fov]
 
             diversity_scores = []
@@ -72,7 +74,6 @@ def compute_neighborhood_diversity(neighborhood_mat, cell_type_col):
             })
             diversity_data.append(fov_data)
 
-            diversity_progress.set_postfix(FOV=fov)
             diversity_progress.update(1)
 
     # dataframe containing all fovs
@@ -218,6 +219,8 @@ def generate_cell_distance_analysis(
     cell_dists = []
     with tqdm(total=len(fov_list), desc="Calculate Average Distances") as distance_progress:
         for fov in fov_list:
+            distance_progress.set_postfix(FOV=fov)
+
             fov_cell_table = cell_table[cell_table[fov_col] == fov]
             fov_dist_xr = xr.load_dataarray(os.path.join(dist_mat_dir, str(fov) + '_dist_mat.xr'))
 
@@ -231,7 +234,6 @@ def generate_cell_distance_analysis(
             fov_cell_dists.insert(2, cell_type_col, fov_cell_table[cell_type_col])
             cell_dists.append(fov_cell_dists)
 
-            distance_progress.set_postfix(FOV=fov)
             distance_progress.update(1)
 
     # combine data for all fovs and save to csv

--- a/src/ark/analysis/neighborhood_analysis.py
+++ b/src/ark/analysis/neighborhood_analysis.py
@@ -76,7 +76,7 @@ def create_neighborhood_matrix(all_data, dist_mat_dir, included_fovs=None, distl
 
     cell_neighbor_freqs = cell_neighbor_counts.copy(deep=True)
 
-    with tqdm(total=len(included_fovs), desc="Neighbors Matrix Generation") \
+    with tqdm(total=len(included_fovs), desc="Neighbors Matrix Generation", unit="FOVs") \
             as neighbor_mat_progress:
         for fov in included_fovs:
             neighbor_mat_progress.set_postfix(FOV=fov)

--- a/src/ark/analysis/neighborhood_analysis.py
+++ b/src/ark/analysis/neighborhood_analysis.py
@@ -79,6 +79,8 @@ def create_neighborhood_matrix(all_data, dist_mat_dir, included_fovs=None, distl
     with tqdm(total=len(included_fovs), desc="Neighbors Matrix Generation") \
             as neighbor_mat_progress:
         for fov in included_fovs:
+            neighbor_mat_progress.set_postfix(FOV=fov)
+
             # Subsetting expression matrix to only include patients with correct fov label
             current_fov_idx = all_neighborhood_data.loc[:, fov_col] == fov
             current_fov_neighborhood_data = all_neighborhood_data[current_fov_idx]
@@ -100,7 +102,6 @@ def create_neighborhood_matrix(all_data, dist_mat_dir, included_fovs=None, distl
             cell_neighbor_freqs.loc[current_fov_neighborhood_data.index, fov_cluster_names]\
                 = freqs
 
-            neighbor_mat_progress.set_postfix(FOV=fov)
             neighbor_mat_progress.update(1)
 
     # Remove cells that have no neighbors within the distlim

--- a/src/ark/analysis/spatial_analysis_utils.py
+++ b/src/ark/analysis/spatial_analysis_utils.py
@@ -39,7 +39,7 @@ def calc_dist_matrix(label_dir, save_path, prefix='_whole_cell'):
     # iterate for each fov
     with tqdm(total=len(fov_files), desc="Distance Matrix Generation") as dist_mat_progress:
         for fov_file in fov_files:
-            dist_mat_progress.set_postfix(FOV=fov_name)
+            dist_mat_progress.set_postfix(FOV=fov_file)
 
             # retrieve the fov name
             fov_name = fov_file.replace(prefix + '.tiff', '')

--- a/src/ark/analysis/spatial_analysis_utils.py
+++ b/src/ark/analysis/spatial_analysis_utils.py
@@ -37,7 +37,8 @@ def calc_dist_matrix(label_dir, save_path, prefix='_whole_cell'):
     fov_files = io_utils.list_files(label_dir, substrs=prefix + '.tiff')
 
     # iterate for each fov
-    with tqdm(total=len(fov_files), desc="Distance Matrix Generation") as dist_mat_progress:
+    with tqdm(total=len(fov_files), desc="Distance Matrix Generation", unit="FOVs") \
+            as dist_mat_progress:
         for fov_file in fov_files:
             dist_mat_progress.set_postfix(FOV=fov_file)
 

--- a/src/ark/analysis/spatial_analysis_utils.py
+++ b/src/ark/analysis/spatial_analysis_utils.py
@@ -39,6 +39,8 @@ def calc_dist_matrix(label_dir, save_path, prefix='_whole_cell'):
     # iterate for each fov
     with tqdm(total=len(fov_files), desc="Distance Matrix Generation") as dist_mat_progress:
         for fov_file in fov_files:
+            dist_mat_progress.set_postfix(FOV=fov_name)
+
             # retrieve the fov name
             fov_name = fov_file.replace(prefix + '.tiff', '')
 
@@ -66,7 +68,6 @@ def calc_dist_matrix(label_dir, save_path, prefix='_whole_cell'):
                 format='NETCDF3_64BIT'
             )
 
-            dist_mat_progress.set_postfix(FOV=fov_name)
             dist_mat_progress.update(1)
 
 

--- a/src/ark/analysis/spatial_enrichment.py
+++ b/src/ark/analysis/spatial_enrichment.py
@@ -70,7 +70,8 @@ def generate_channel_spatial_enrichment_stats(label_dir, dist_mat_dir, marker_th
     values = []
     stats_datasets = []
 
-    with tqdm(total=len(all_label_fovs), desc="Channel Spatial Enrichment") as chan_progress:
+    with tqdm(total=len(all_label_fovs), desc="Channel Spatial Enrichment", unit="FOVs") \
+            as chan_progress:
         for fov_name, label_file in zip(all_label_fovs, all_label_names):
             chan_progress.set_postfix(FOV=fov_name)
 
@@ -294,7 +295,8 @@ def generate_cluster_spatial_enrichment_stats(label_dir, dist_mat_dir, all_data,
     values = []
     stats_datasets = []
 
-    with tqdm(total=len(all_label_fovs), desc="Cluster Spatial Enrichment") as clust_progress:
+    with tqdm(total=len(all_label_fovs), desc="Cluster Spatial Enrichment", unit="FOVs") \
+            as clust_progress:
         for fov_name, label_file in zip(all_label_fovs, all_label_names):
             clust_progress.set_postfix(FOV=fov_name)
 

--- a/src/ark/analysis/spatial_enrichment.py
+++ b/src/ark/analysis/spatial_enrichment.py
@@ -72,6 +72,8 @@ def generate_channel_spatial_enrichment_stats(label_dir, dist_mat_dir, marker_th
 
     with tqdm(total=len(all_label_fovs), desc="Channel Spatial Enrichment") as chan_progress:
         for fov_name, label_file in zip(all_label_fovs, all_label_names):
+            chan_progress.set_postfix(FOV=fov_name)
+
             label_maps = load_utils.load_imgs_from_dir(label_dir, files=[label_file],
                                                        xr_channel_names=[xr_channel_name],
                                                        trim_suffix=suffix)
@@ -294,6 +296,8 @@ def generate_cluster_spatial_enrichment_stats(label_dir, dist_mat_dir, all_data,
 
     with tqdm(total=len(all_label_fovs), desc="Cluster Spatial Enrichment") as clust_progress:
         for fov_name, label_file in zip(all_label_fovs, all_label_names):
+            clust_progress.set_postfix(FOV=fov_name)
+
             label_maps = load_utils.load_imgs_from_dir(label_dir, files=[label_file],
                                                        xr_channel_names=[xr_channel_name],
                                                        trim_suffix=suffix)

--- a/src/ark/segmentation/fiber_segmentation.py
+++ b/src/ark/segmentation/fiber_segmentation.py
@@ -16,6 +16,7 @@ from skimage.filters import frangi, sobel, threshold_multiotsu
 from skimage.measure import regionprops_table
 from skimage.morphology import remove_small_objects
 from skimage.segmentation import watershed
+from tqdm.notebook import tqdm
 
 from ark import settings
 from ark.utils.plot_utils import set_minimum_color_for_colormap
@@ -176,14 +177,20 @@ def run_fiber_segmentation(data_dir, fiber_channel, out_dir, img_sub_folder=None
 
     fiber_object_table = []
 
-    for fov in fovs:
-        print(f'Processing FOV: {fov}')
-        subset_xr = load_utils.load_imgs_from_tree(
-            data_dir, img_sub_folder, fovs=fov, channels=[fiber_channel]
-        )
-        subtable = segment_fibers(subset_xr, fiber_channel, out_dir, fov, save_csv=False,
-                                  **kwargs)
-        fiber_object_table.append(subtable)
+    with tqdm(total=len(fovs), desc="Fiber Segmentation") as fibseg_progress:
+        for fov in fovs:
+            fibseg_progress.set_postfix(FOV=fov)
+
+            subset_xr = load_utils.load_imgs_from_tree(
+                data_dir, img_sub_folder, fovs=fov, channels=[fiber_channel]
+            )
+            # run fiber segmentation on the FOV
+            subtable = segment_fibers(subset_xr, fiber_channel, out_dir, fov, save_csv=False,
+                                      **kwargs)
+            fiber_object_table.append(subtable)
+
+            # update progress bar
+            fibseg_progress.update(1)
 
     fiber_object_table = pd.concat(fiber_object_table)
 

--- a/src/ark/segmentation/fiber_segmentation.py
+++ b/src/ark/segmentation/fiber_segmentation.py
@@ -16,7 +16,7 @@ from skimage.filters import frangi, sobel, threshold_multiotsu
 from skimage.measure import regionprops_table
 from skimage.morphology import remove_small_objects
 from skimage.segmentation import watershed
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 
 from ark import settings
 from ark.utils.plot_utils import set_minimum_color_for_colormap
@@ -177,7 +177,8 @@ def run_fiber_segmentation(data_dir, fiber_channel, out_dir, img_sub_folder=None
 
     fiber_object_table = []
 
-    with tqdm(total=len(fovs), desc="Fiber Segmentation") as fibseg_progress:
+    with tqdm(total=len(fovs), desc="Fiber Segmentation", unit="FOVs") \
+            as fibseg_progress:
         for fov in fovs:
             fibseg_progress.set_postfix(FOV=fov)
 

--- a/src/ark/utils/data_utils.py
+++ b/src/ark/utils/data_utils.py
@@ -331,6 +331,8 @@ def generate_and_save_cell_cluster_masks(
         total=len(fovs), desc="Cell Cluster Mask Generation", unit="FOVs"
     ) as pbar:
         for fov in fovs:
+            pbar.set_postfix(FOV=fov)
+
             # generate the cell mask for the FOV
             cell_mask: np.ndarray = generate_cell_cluster_mask(
                 fov=fov, seg_dir=seg_dir, ccmd=ccmd, seg_suffix=seg_suffix
@@ -463,6 +465,8 @@ def generate_and_save_pixel_cluster_masks(fovs: List[str],
     # create the pixel cluster masks across each fov
     with tqdm(total=len(fovs), desc="Pixel Cluster Mask Generation") as pixel_mask_progress:
         for fov in fovs:
+            pixel_mask_progress.set_postfix(FOV=fov)
+
             # define the path to provided channel file in the fov dir, used to calculate dimensions
             chan_file_path = os.path.join(fov, chan_file)
 
@@ -537,6 +541,8 @@ def generate_and_save_neighborhood_cluster_masks(
     ) as neigh_mask_progress:
         # generate the mask for each FOV
         for fov in fovs:
+            neigh_mask_progress.set_postfix(FOV=fov)
+
             # load in the label map for the FOV
             label_map = load_utils.load_imgs_from_dir(
                 seg_dir,

--- a/src/ark/utils/data_utils.py
+++ b/src/ark/utils/data_utils.py
@@ -327,9 +327,7 @@ def generate_and_save_cell_cluster_masks(
     )
 
     # create the pixel cluster masks across each fov
-    with tqdm(
-        total=len(fovs), desc="Cell Cluster Mask Generation", unit="FOVs"
-    ) as pbar:
+    with tqdm(total=len(fovs), desc="Cell Cluster Mask Generation", unit="FOVs") as pbar:
         for fov in fovs:
             pbar.set_postfix(FOV=fov)
 
@@ -463,7 +461,8 @@ def generate_and_save_pixel_cluster_masks(fovs: List[str],
     """
 
     # create the pixel cluster masks across each fov
-    with tqdm(total=len(fovs), desc="Pixel Cluster Mask Generation") as pixel_mask_progress:
+    with tqdm(total=len(fovs), desc="Pixel Cluster Mask Generation", unit="FOVs") \
+            as pixel_mask_progress:
         for fov in fovs:
             pixel_mask_progress.set_postfix(FOV=fov)
 
@@ -536,9 +535,8 @@ def generate_and_save_neighborhood_cluster_masks(
     )
 
     # create the neighborhood cluster masks across each fov
-    with tqdm(
-        total=len(fovs), desc="Neighborhood Cluster Mask Generation"
-    ) as neigh_mask_progress:
+    with tqdm(total=len(fovs), desc="Neighborhood Cluster Mask Generation", unit="FOVs") \
+            as neigh_mask_progress:
         # generate the mask for each FOV
         for fov in fovs:
             neigh_mask_progress.set_postfix(FOV=fov)

--- a/src/ark/utils/deepcell_service_utils.py
+++ b/src/ark/utils/deepcell_service_utils.py
@@ -296,13 +296,17 @@ def run_deepcell_direct(input_dir, output_dir, host='https://deepcell.org',
             }
         ).json()
         if redis_response['value'][0] == 'done':
+            # make sure progress bar shows 100%
+            pbar_next = int(redis_response['value'][1])
+            progress_bar.update(max(pbar_next - pbar_last, 0))
             break
 
         # update progress bar here
         if redis_response['value'][0] == 'waiting':
             pbar_next = int(redis_response['value'][1])
-            progress_bar.update(max(pbar_next - pbar_last, 0))
-            pbar_last = pbar_next
+            if pbar_next > pbar_last:
+                progress_bar.update(max(pbar_next - pbar_last, 0))
+                pbar_last = pbar_next
 
         if redis_response['value'][0] not in ['done', 'waiting', 'new']:
             print(redis_response['value'])

--- a/src/ark/utils/plot_utils.py
+++ b/src/ark/utils/plot_utils.py
@@ -686,6 +686,8 @@ def save_colored_masks(
 
     with tqdm(total=len(fovs), desc="Saving colored masks", unit="FOVs") as pbar:
         for fov in fovs:
+            pbar.set_postfix(FOV=fov, refresh=False)
+
             mask: xr.DataArray = load_utils.load_imgs_from_dir(
                 data_dir=mask_dir,
                 files=[f"{fov}_{cluster_type}_mask.tiff"],
@@ -705,5 +707,4 @@ def save_colored_masks(
                 fname=save_dir / f"{fov}_{cluster_type}_mask_colored.tiff",
                 data=colored_mask,)
 
-            pbar.set_postfix(FOV=fov, refresh=False)
             pbar.update(1)


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

1. Closes #1028. Add current processing FOV name to progress bar output in the ark notebooks.
2. Closes #970. Fix incorrect progress bars that show <100% even though the batch was processed fine.

**How did you implement your changes**

1. Update the FOV name at start of each code block using `progress_bar.set_postfix(FOV=fov)`.

2. I was able to replicate @HPiyadasa's issue, and it turns out two things could potentially happen with the current code:
- Since we only check the progress every 3 seconds, sometimes we don't always know that the last fov is in progress before getting a "done" response from the api and closing the progress bar. We simply need to ensure the progress bar gets updated for completion before breaking the batch loop and closing the progress bar.

<img width="450" alt="Screenshot 2023-08-01 at 1 58 49 PM (2)" src="https://github.com/angelolab/ark-analysis/assets/38049893/daf06d94-f088-49a6-944d-e3c88322b1d8">

- (This one is quirky) Sometimes deepcell.org/api/redis will return a lower completion rate than it had before.  When combined with the above issue, the math doesn't math to 100. We just need to account for this by only updating the progress bar status when it has increased.

<img width="350" alt="Screenshot 2023-08-01 at 12 35 06 PM (2)" src="https://github.com/angelolab/ark-analysis/assets/38049893/f3a1b038-f593-497a-87fb-43e8b4c85e48">



**Remaining issues**

Nothing, I've solved all issues forever.

<img width="450" alt="Screenshot 2023-08-01 at 2 27 44 PM (2)" src="https://github.com/angelolab/ark-analysis/assets/38049893/05b8e594-0cc1-44fa-bb1d-70b439b0021b">
