### PR TITLE
Release 0.6.6 without tables dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "seaborn>=0.12,<1",
     "spatial-lda>=0.1.3,<1",
     "statsmodels>=0.13.2,<1",
-    "tables>=3.7",
     "tifffile>=2022",
     "tqdm>=4,<5",
     "umap-learn>=0.5,<1.0",


### PR DESCRIPTION
**What is the purpose of this PR?**

The `tables` dependency is causing issues with pip installing `ark-analysis` and any repos that have it as a dependency (ex. `cell_classification`). This is a dependency we don't need anymore, so it should be removed.

**How did you implement your changes**

Remove the `tables` dependency.
