### PR TITLE
Include `img_sub_folder` as parameter in Mantis calls

### DIFF
--- a/.github/scripts/get_example_dataset.py
+++ b/.github/scripts/get_example_dataset.py
@@ -23,6 +23,7 @@ def load_dataset(cache_dir: pathlib.Path, name: str):
         cache_dir=cache_dir,
         name=name,
         use_auth_token=False,
+        revision="c38309e19d7eaae9f67e1cf8e08a3fd2b8a6f299"
     )
 
 # Make the cache directory if it doesn't exist.

--- a/src/ark/settings.py
+++ b/src/ark/settings.py
@@ -60,4 +60,4 @@ MIBITRACKER_BACKEND = 'https://backend-dot-mibitracker-angelolab.appspot.com'
 
 # Switch it from `main` to the commit ID on HuggingFace to test a
 # specific version of the Example Dataset
-EXAMPLE_DATASET_REVISION: str = "660b9d3262db1fdabd10ff22c1d49c0af6009f5f"
+EXAMPLE_DATASET_REVISION: str = "c38309e19d7eaae9f67e1cf8e08a3fd2b8a6f299"

--- a/src/ark/settings.py
+++ b/src/ark/settings.py
@@ -60,4 +60,4 @@ MIBITRACKER_BACKEND = 'https://backend-dot-mibitracker-angelolab.appspot.com'
 
 # Switch it from `main` to the commit ID on HuggingFace to test a
 # specific version of the Example Dataset
-EXAMPLE_DATASET_REVISION: str = "4e776625d85897cfec5f977e826dd913b3184c3a"
+EXAMPLE_DATASET_REVISION: str = "660b9d3262db1fdabd10ff22c1d49c0af6009f5f"

--- a/src/ark/settings.py
+++ b/src/ark/settings.py
@@ -60,4 +60,4 @@ MIBITRACKER_BACKEND = 'https://backend-dot-mibitracker-angelolab.appspot.com'
 
 # Switch it from `main` to the commit ID on HuggingFace to test a
 # specific version of the Example Dataset
-EXAMPLE_DATASET_REVISION: str = "main"
+EXAMPLE_DATASET_REVISION: str = "4e776625d85897cfec5f977e826dd913b3184c3a"

--- a/src/ark/utils/plot_utils.py
+++ b/src/ark/utils/plot_utils.py
@@ -571,6 +571,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
     if not os.path.exists(mantis_project_path):
         os.makedirs(mantis_project_path)
 
+    # account for non-sub folder channel file structures
     img_sub_folder = "" if not img_sub_folder else img_sub_folder
 
     # create key from cluster number to cluster name

--- a/src/ark/utils/plot_utils.py
+++ b/src/ark/utils/plot_utils.py
@@ -509,7 +509,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
                       cluster_type='pixel',
                       mask_suffix: str = "_mask",
                       seg_suffix_name: Optional[str] = "_whole_cell.tiff",
-                      img_sub_folder: str = ""):
+                      img_sub_folder: str = None):
     """Creates a mantis project directory so that it can be opened by the mantis viewer.
     Copies fovs, segmentation files, masks, and mapping csv's into a new directory structure.
     Here is how the contents of the mantis project folder will look like.
@@ -559,7 +559,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
             Defaults to "_whole_cell.tiff".
         img_sub_folder (str, optional):
             The subfolder where the channels exist within the `img_data_path`.
-            Defaults to "normalized".
+            Defaults to None.
     """
 
     # verify the type of clustering provided is valid
@@ -570,6 +570,8 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
 
     if not os.path.exists(mantis_project_path):
         os.makedirs(mantis_project_path)
+
+    img_sub_folder = "" if not img_sub_folder else img_sub_folder
 
     # create key from cluster number to cluster name
     if isinstance(mapping, (pathlib.Path, str)):

--- a/templates/2_Pixie_Cluster_Pixels.ipynb
+++ b/templates/2_Pixie_Cluster_Pixels.ipynb
@@ -863,6 +863,8 @@
     "cell_clustering_params = {\n",
     "    'fovs': io_utils.remove_file_extensions(io_utils.list_files(os.path.join(base_dir, pixel_data_dir), substrs='.feather')),\n",
     "    'channels': channels,\n",
+    "    'tiff_dir': tiff_dir,\n",
+    "    'img_sub_folder': img_sub_folder,\n",
     "    'segmentation_dir': segmentation_dir,\n",
     "    'seg_suffix': seg_suffix,\n",
     "    'pixel_data_dir': pixel_data_dir,\n",
@@ -902,7 +904,8 @@
     "    mapping = os.path.join(base_dir, pixel_meta_cluster_remap_name),\n",
     "    seg_dir=pixie_seg_dir,\n",
     "    mask_suffix=\"_pixel_mask\",\n",
-    "    seg_suffix_name=seg_suffix\n",
+    "    seg_suffix_name=seg_suffix,\n",
+    "    img_sub_folder=img_sub_folder\n",
     ")"
    ]
   }

--- a/templates/3_Pixie_Cluster_Cells.ipynb
+++ b/templates/3_Pixie_Cluster_Cells.ipynb
@@ -139,6 +139,8 @@
     "\n",
     "* `fovs`: subset of fovs used for pixel clustering\n",
     "* `channels`: subset of channels used for pixel clustering\n",
+    "* `tiff_dir`: path to the directory containing your imaging data. Images should be single-channel TIFFs.\n",
+    "* `img_sub_folder`: if `tiff_dir` contains an additional subfolder structure, set to the appropriate folder name (or `None` if no such structure present)\n",
     "* `segmentation_dir`: path to the directory containing your segmented images (can be generated from `1_Segment_Image_Data.ipynb`)\n",
     "* `seg_suffix`: suffix plus the file extension of the segmented images for each FOV\n",
     "* `pixel_data_dir`: name of the directory containing pixel data with the pixel SOM and meta cluster assignments\n",
@@ -940,7 +942,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.11.5"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/templates/3_Pixie_Cluster_Cells.ipynb
+++ b/templates/3_Pixie_Cluster_Cells.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -11,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -48,7 +46,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -76,7 +73,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -101,7 +97,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -111,7 +106,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -134,14 +128,10 @@
     "pixel_output_dir = 'example_pixel_output_dir'\n",
     "\n",
     "# define the name of the cell clustering params file\n",
-    "cell_clustering_params_name = 'cell_clustering_params.json'\n",
-    "\n",
-    "# define the name of the directory with the extracted image data\n",
-    "tiff_dir = os.path.join(base_dir, \"image_data\")"
+    "cell_clustering_params_name = 'cell_clustering_params.json'"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -177,6 +167,8 @@
     "# assign the params to variables\n",
     "fovs = cell_clustering_params['fovs']\n",
     "channels = cell_clustering_params['channels']\n",
+    "tiff_dir = cell_clustering_params['tiff_dir']\n",
+    "img_sub_folder = cell_clustering_params['img_sub_folder']\n",
     "segmentation_dir = cell_clustering_params['segmentation_dir']\n",
     "seg_suffix = cell_clustering_params['seg_suffix']\n",
     "pixel_data_dir = cell_clustering_params['pixel_data_dir']\n",
@@ -188,7 +180,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -196,7 +187,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -221,7 +211,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -267,7 +256,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -297,7 +285,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -345,7 +332,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -390,7 +376,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -398,7 +383,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -406,7 +390,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -439,7 +422,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -447,7 +429,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -490,7 +471,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -498,7 +478,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -517,7 +496,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -580,7 +558,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -588,7 +565,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -596,7 +572,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -649,7 +624,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -704,7 +678,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -729,7 +702,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -756,7 +728,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -783,7 +754,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -829,7 +799,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -857,7 +826,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -894,7 +862,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -902,7 +869,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -925,7 +891,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -953,7 +918,8 @@
     "    seg_dir=os.path.join(base_dir, segmentation_dir),\n",
     "    cluster_type='cell',\n",
     "    mask_suffix=\"_cell_mask\",\n",
-    "    seg_suffix_name=seg_suffix\n",
+    "    seg_suffix_name=seg_suffix,\n",
+    "    img_sub_folder=img_sub_folder\n",
     ")"
    ]
   }

--- a/tests/utils/example_dataset_test.py
+++ b/tests/utils/example_dataset_test.py
@@ -70,10 +70,10 @@ class TestExampleDataset:
                                       for j in ['whole_cell', 'nuclear']]
 
         self._example_pixel_output_dir_names = {
-            "root_files": ["cell_clustering_params", "channel_norm", "pixel_thresh",
+            "root_files": ["cell_clustering_params", "channel_norm_pre_rownorm", "pixel_thresh",
                            "pixel_channel_avg_meta_cluster", "pixel_channel_avg_som_cluster",
                            "pixel_meta_cluster_mapping", "pixel_som_weights",
-                           "channel_norm_post_rowsum"],
+                           "channel_norm_post_rownorm"],
             "pixel_mat_data": [f"fov{i}" for i in range(11)],
             "pixel_mat_subset": [f"fov{i}" for i in range(11)],
             "pixel_masks": [f"fov{i}_pixel_mask" for i in range(2)]


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #1045. Without this argument passed to `create_mantis_dir`, there isn't a way to copy the single-channel TIF files over.

**How did you implement your changes**

Added this as a parameter to the function. Additionally, updated `cell_clustering_params.json` to take in both `tiff_dir` and `img_sub_folder`. The former is purely QOL and the latter is to support the `img_sub_folder` param for the Mantis function in the cell clustering notebook.