### PR TITLE
Remove cells that don't have any pixel clusters expressed prior to Pixie

### DIFF
--- a/src/ark/phenotyping/cell_cluster_utils.py
+++ b/src/ark/phenotyping/cell_cluster_utils.py
@@ -166,7 +166,7 @@ def create_c2pc_data(fovs, pixel_data_path, cell_table_path,
 
     # drop rows from the cell table that don't have any pixel clusters expressed
     count_cols = [c for c in cell_table.columns if '%s_' % pixel_cluster_col in c]
-    cell_table = cell_table.drop([count_cols])
+    cell_table = cell_table[cell_table[count_cols].sum(axis=1) != 0]
 
     # also produce a cell table with counts normalized by cell_size
     cell_table_norm = cell_table.copy()

--- a/src/ark/phenotyping/cell_cluster_utils.py
+++ b/src/ark/phenotyping/cell_cluster_utils.py
@@ -164,10 +164,12 @@ def create_c2pc_data(fovs, pixel_data_path, cell_table_path,
     # NaN means the cluster wasn't found in the specified fov-cell pair
     cell_table = cell_table.fillna(0)
 
+    # drop rows from the cell table that don't have any pixel clusters expressed
+    count_cols = [c for c in cell_table.columns if '%s_' % pixel_cluster_col in c]
+    cell_table = cell_table.drop([count_cols])
+
     # also produce a cell table with counts normalized by cell_size
     cell_table_norm = cell_table.copy()
-
-    count_cols = [c for c in cell_table_norm.columns if '%s_' % pixel_cluster_col in c]
     cell_table_norm[count_cols] = cell_table_norm[count_cols].div(cell_table_norm['cell_size'],
                                                                   axis=0)
 


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #1046. In certain cases, cells don't contain any pixel clusters. These should not contribute to the cell SOM training.

**How did you implement your changes**

In `create_c2pc_data`, after `cluster_counts` is fully computed for all FOVs, add a step that drops rows that sum to zero across the pixel cluster expression cols. This propagates over to `cluster_counts_size_norm` (the data that trains the SOM and receives the cluster assignments), since it depends on `cluster_counts`.