### PR TITLE
Pin to scikit-image to v0.19.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pillow>=9,<10",
     "pyFlowSOM>=0.1.15",
     "requests>=2.20,<3",
-    "scikit-image>=0.21",
+    "scikit-image==0.19.3",
     "scikit-learn>=1.1,<2",
     "scipy>=1.7,<2",
     "seaborn>=0.12,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pillow>=9,<10",
     "pyFlowSOM>=0.1.15",
     "requests>=2.20,<3",
-    "scikit-image==0.19.3",
+    "scikit-image<=0.19.3",
     "scikit-learn>=1.1,<2",
     "scipy>=1.7,<2",
     "seaborn>=0.12,<1",


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #1055. Improves fiber segmentation results by pinning scikit-image to an older version.

**How did you implement your changes**

Update pyproject.toml.

**Remaining issues**

Short term solution. Should be looked into for a more permanent fix in the future.