### PR TITLE
Single mantis directory

### DIFF
--- a/src/ark/phenotyping/post_cluster_utils.py
+++ b/src/ark/phenotyping/post_cluster_utils.py
@@ -150,7 +150,7 @@ def create_mantis_project(
         )
         # save the cell mask for each FOV -- (saves with ".tiff" extension)
         data_utils.save_fov_mask(
-            fov, mask_dir, mask_data, sub_dir=None, name_suffix="_cell_mask"
+            fov, mask_dir, mask_data, sub_dir=None, name_suffix="_post_clustering_cell_mask"
         )
 
     # rename the columns of small_table
@@ -168,7 +168,7 @@ def create_mantis_project(
         mantis_project_path=mantis_dir,
         img_data_path=image_dir,
         mask_output_dir=mask_dir,
-        mask_suffix="_cell_mask",
+        mask_suffix="_post_clustering_cell_mask",
         mapping=mantis_df,
         seg_dir=seg_dir,
         cluster_type=cluster_type,

--- a/src/ark/utils/plot_utils.py
+++ b/src/ark/utils/plot_utils.py
@@ -508,7 +508,6 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
                       seg_dir: Optional[Union[str, pathlib.Path]],
                       cluster_type='pixel',
                       mask_suffix: str = "_mask",
-                      mask_prefix: str = None,
                       seg_suffix_name: Optional[str] = "_whole_cell.tiff",
                       img_sub_folder: str = None,
                       new_mask_suffix: str = None):
@@ -555,8 +554,6 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
             the type of clustering being done
         mask_suffix (str, optional):
             The suffix used to find the mask tiffs. Defaults to "_mask".
-        mask_prefix (str, optional):
-            The prefix used to find the mask tiffs. Defaults to None".
         seg_suffix_name (str, optional):
             The suffix of the segmentation file and it's file extension. If None, then
             the segmentation file will not be copied over.
@@ -595,8 +592,6 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
     # if no new suffix specified, copy over with original mask name
     if not new_mask_suffix:
         new_mask_suffix = mask_suffix
-    if not mask_prefix:
-        mask_prefix = ""
 
     map_df = map_df.loc[:, [f'{cluster_type}_meta_cluster', f'{cluster_type}_meta_cluster_rename']]
     # remove duplicates from df
@@ -621,8 +616,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
     # use `fovs`, a subset of the FOVs in `total_fov_names` which
     # is a list of FOVs in `img_data_path`
     fovs = natsort.natsorted(fovs)
-    fov_check = [mask_prefix + fov for fov in fovs]
-    misc_utils.verify_in_list(fovs=fov_check, img_data_fovs=mask_names_delimited)
+    misc_utils.verify_in_list(fovs=fovs, img_data_fovs=mask_names_delimited)
 
     # Filter out the masks that do not have an associated FOV.
     mask_names = filter(lambda mn: any(contains(mn, f) for f in fovs), mask_names_sorted)
@@ -645,7 +639,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
         # copy mask into new folder
         mask_name: str = mn + mask_suffix + ".tiff"
         shutil.copy(os.path.join(mask_output_dir, mask_name),
-                    os.path.join(output_dir, f'{mask_prefix}population{new_mask_suffix}.tiff'))
+                    os.path.join(output_dir, 'population{}.tiff'.format(new_mask_suffix)))
 
         # copy the segmentation files into the output directory
         # if `seg_dir` or `seg_name` is none, then skip copying
@@ -656,7 +650,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
                             os.path.join(output_dir, 'cell_segmentation.tiff'))
 
         # copy mapping into directory
-        map_df.to_csv(os.path.join(output_dir, f'{mask_prefix}population{new_mask_suffix}.csv'),
+        map_df.to_csv(os.path.join(output_dir, 'population{}.csv'.format(new_mask_suffix)),
                       index=False)
 
 

--- a/src/ark/utils/plot_utils.py
+++ b/src/ark/utils/plot_utils.py
@@ -508,6 +508,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
                       seg_dir: Optional[Union[str, pathlib.Path]],
                       cluster_type='pixel',
                       mask_suffix: str = "_mask",
+                      mask_prefix: str = None,
                       seg_suffix_name: Optional[str] = "_whole_cell.tiff",
                       img_sub_folder: str = None,
                       new_mask_suffix: str = None):
@@ -554,6 +555,8 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
             the type of clustering being done
         mask_suffix (str, optional):
             The suffix used to find the mask tiffs. Defaults to "_mask".
+        mask_prefix (str, optional):
+            The prefix used to find the mask tiffs. Defaults to None".
         seg_suffix_name (str, optional):
             The suffix of the segmentation file and it's file extension. If None, then
             the segmentation file will not be copied over.
@@ -589,6 +592,12 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
     # Save the segmentation tiff or not
     save_seg_tiff: bool = all(v is not None for v in [seg_dir, seg_suffix_name])
 
+    # if no new suffix specified, copy over with original mask name
+    if not new_mask_suffix:
+        new_mask_suffix = mask_suffix
+    if not mask_prefix:
+        mask_prefix = ""
+
     map_df = map_df.loc[:, [f'{cluster_type}_meta_cluster', f'{cluster_type}_meta_cluster_rename']]
     # remove duplicates from df
     map_df = map_df.drop_duplicates()
@@ -612,14 +621,11 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
     # use `fovs`, a subset of the FOVs in `total_fov_names` which
     # is a list of FOVs in `img_data_path`
     fovs = natsort.natsorted(fovs)
-    misc_utils.verify_in_list(fovs=fovs, img_data_fovs=mask_names_delimited)
+    fov_check = [mask_prefix + fov for fov in fovs]
+    misc_utils.verify_in_list(fovs=fov_check, img_data_fovs=mask_names_delimited)
 
     # Filter out the masks that do not have an associated FOV.
     mask_names = filter(lambda mn: any(contains(mn, f) for f in fovs), mask_names_sorted)
-
-    # if no new suffix specified, copy over with original mask name
-    if not new_mask_suffix:
-        new_mask_suffix = mask_suffix
 
     # create a folder with image data, pixel masks, and segmentation mask
     for fov, mn in zip(fovs, mask_names):
@@ -639,7 +645,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
         # copy mask into new folder
         mask_name: str = mn + mask_suffix + ".tiff"
         shutil.copy(os.path.join(mask_output_dir, mask_name),
-                    os.path.join(output_dir, 'population{}.tiff'.format(new_mask_suffix)))
+                    os.path.join(output_dir, f'{mask_prefix}population{new_mask_suffix}.tiff'))
 
         # copy the segmentation files into the output directory
         # if `seg_dir` or `seg_name` is none, then skip copying
@@ -650,7 +656,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
                             os.path.join(output_dir, 'cell_segmentation.tiff'))
 
         # copy mapping into directory
-        map_df.to_csv(os.path.join(output_dir, 'population{}.csv'.format(new_mask_suffix)),
+        map_df.to_csv(os.path.join(output_dir, f'{mask_prefix}population{new_mask_suffix}.csv'),
                       index=False)
 
 

--- a/src/ark/utils/plot_utils.py
+++ b/src/ark/utils/plot_utils.py
@@ -509,7 +509,8 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
                       cluster_type='pixel',
                       mask_suffix: str = "_mask",
                       seg_suffix_name: Optional[str] = "_whole_cell.tiff",
-                      img_sub_folder: str = None):
+                      img_sub_folder: str = None,
+                      new_mask_suffix: str = None):
     """Creates a mantis project directory so that it can be opened by the mantis viewer.
     Copies fovs, segmentation files, masks, and mapping csv's into a new directory structure.
     Here is how the contents of the mantis project folder will look like.
@@ -560,6 +561,8 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
         img_sub_folder (str, optional):
             The subfolder where the channels exist within the `img_data_path`.
             Defaults to None.
+        new_mask_suffix (str, optional):
+            The new suffix added to the copied mask tiffs.
     """
 
     # verify the type of clustering provided is valid
@@ -614,6 +617,10 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
     # Filter out the masks that do not have an associated FOV.
     mask_names = filter(lambda mn: any(contains(mn, f) for f in fovs), mask_names_sorted)
 
+    # if no new suffix specified, copy over with original mask name
+    if not new_mask_suffix:
+        new_mask_suffix = mask_suffix
+
     # create a folder with image data, pixel masks, and segmentation mask
     for fov, mn in zip(fovs, mask_names):
         # set up paths
@@ -632,7 +639,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
         # copy mask into new folder
         mask_name: str = mn + mask_suffix + ".tiff"
         shutil.copy(os.path.join(mask_output_dir, mask_name),
-                    os.path.join(output_dir, 'population{}.tiff'.format(mask_suffix)))
+                    os.path.join(output_dir, 'population{}.tiff'.format(new_mask_suffix)))
 
         # copy the segmentation files into the output directory
         # if `seg_dir` or `seg_name` is none, then skip copying
@@ -643,7 +650,7 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
                             os.path.join(output_dir, 'cell_segmentation.tiff'))
 
         # copy mapping into directory
-        map_df.to_csv(os.path.join(output_dir, 'population{}.csv'.format(mask_suffix)),
+        map_df.to_csv(os.path.join(output_dir, 'population{}.csv'.format(new_mask_suffix)),
                       index=False)
 
 

--- a/src/ark/utils/plot_utils.py
+++ b/src/ark/utils/plot_utils.py
@@ -637,9 +637,10 @@ def create_mantis_dir(fovs: List[str], mantis_project_path: Union[str, pathlib.P
         # copy the segmentation files into the output directory
         # if `seg_dir` or `seg_name` is none, then skip copying
         if save_seg_tiff:
-            seg_name: str = fov + seg_suffix_name
-            shutil.copy(os.path.join(seg_dir, seg_name),
-                        os.path.join(output_dir, 'cell_segmentation.tiff'))
+            if not os.path.exists(os.path.join(output_dir, 'cell_segmentation.tiff')):
+                seg_name: str = fov + seg_suffix_name
+                shutil.copy(os.path.join(seg_dir, seg_name),
+                            os.path.join(output_dir, 'cell_segmentation.tiff'))
 
         # copy mapping into directory
         map_df.to_csv(os.path.join(output_dir, 'population{}.csv'.format(mask_suffix)),

--- a/templates/2_Pixie_Cluster_Pixels.ipynb
+++ b/templates/2_Pixie_Cluster_Pixels.ipynb
@@ -904,7 +904,6 @@
     "    mapping = os.path.join(base_dir, pixel_meta_cluster_remap_name),\n",
     "    seg_dir=pixie_seg_dir,\n",
     "    mask_suffix=\"_pixel_mask\",\n",
-    "    mask_prefix=None,\n",
     "    seg_suffix_name=seg_suffix,\n",
     "    img_sub_folder=img_sub_folder\n",
     ")"

--- a/templates/2_Pixie_Cluster_Pixels.ipynb
+++ b/templates/2_Pixie_Cluster_Pixels.ipynb
@@ -904,6 +904,7 @@
     "    mapping = os.path.join(base_dir, pixel_meta_cluster_remap_name),\n",
     "    seg_dir=pixie_seg_dir,\n",
     "    mask_suffix=\"_pixel_mask\",\n",
+    "    mask_prefix=None,\n",
     "    seg_suffix_name=seg_suffix,\n",
     "    img_sub_folder=img_sub_folder\n",
     ")"

--- a/templates/2_Pixie_Cluster_Pixels.ipynb
+++ b/templates/2_Pixie_Cluster_Pixels.ipynb
@@ -898,7 +898,7 @@
    "source": [
     "plot_utils.create_mantis_dir(\n",
     "    fovs=subset_pixel_fovs,\n",
-    "    mantis_project_path=os.path.join(base_dir, pixel_output_dir, \"mantis\"),\n",
+    "    mantis_project_path=os.path.join(base_dir, \"mantis\"),\n",
     "    img_data_path=tiff_dir,\n",
     "    mask_output_dir=os.path.join(base_dir, pixel_output_dir, \"pixel_masks\"),\n",
     "    mapping = os.path.join(base_dir, pixel_meta_cluster_remap_name),\n",
@@ -926,7 +926,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.11.4"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/templates/3_Pixie_Cluster_Cells.ipynb
+++ b/templates/3_Pixie_Cluster_Cells.ipynb
@@ -920,7 +920,6 @@
     "    seg_dir=os.path.join(base_dir, segmentation_dir),\n",
     "    cluster_type='cell',\n",
     "    mask_suffix=\"_cell_mask\",\n",
-    "    mask_prefix=None,\n",
     "    seg_suffix_name=seg_suffix,\n",
     "    img_sub_folder=img_sub_folder\n",
     ")"

--- a/templates/3_Pixie_Cluster_Cells.ipynb
+++ b/templates/3_Pixie_Cluster_Cells.ipynb
@@ -920,6 +920,7 @@
     "    seg_dir=os.path.join(base_dir, segmentation_dir),\n",
     "    cluster_type='cell',\n",
     "    mask_suffix=\"_cell_mask\",\n",
+    "    mask_prefix=None,\n",
     "    seg_suffix_name=seg_suffix,\n",
     "    img_sub_folder=img_sub_folder\n",
     ")"

--- a/templates/3_Pixie_Cluster_Cells.ipynb
+++ b/templates/3_Pixie_Cluster_Cells.ipynb
@@ -913,7 +913,7 @@
    "source": [
     "plot_utils.create_mantis_dir(\n",
     "    fovs=subset_cell_fovs,\n",
-    "    mantis_project_path=os.path.join(base_dir, \"pixie\", cell_output_dir, \"mantis\"),\n",
+    "    mantis_project_path=os.path.join(base_dir, \"mantis\"),\n",
     "    img_data_path=tiff_dir,\n",
     "    mask_output_dir=os.path.join(base_dir, \"pixie\", cell_output_dir, \"cell_masks\"),\n",
     "    mapping = os.path.join(base_dir, cell_meta_cluster_remap_name),\n",
@@ -942,7 +942,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.4"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/templates/4_Post_Clustering.ipynb
+++ b/templates/4_Post_Clustering.ipynb
@@ -152,7 +152,7 @@
     "    os.makedirs(mask_dir)\n",
     "\n",
     "# create directory to hold full mantis output\n",
-    "mantis_dir = os.path.join(post_cluster_dir, 'mantis')\n",
+    "mantis_dir = os.path.join(base_dir, 'mantis')\n",
     "if not os.path.exists(mantis_dir):\n",
     "    os.makedirs(mantis_dir)\n",
     "    \n",
@@ -272,8 +272,8 @@
    "outputs": [],
    "source": [
     "# create directory that can be read into Mantis\n",
-    "create_mantis_project(cell_table=cell_table, fovs=testing_fovs, seg_dir=segmentation_dir, pop_col='cell_meta_cluster', mask_dir=mask_dir,\n",
-    "                          mantis_dir=mantis_dir, image_dir=image_dir)"
+    "create_mantis_project(cell_table=cell_table, fovs=testing_fovs, seg_dir=segmentation_dir, pop_col='cell_meta_cluster', \n",
+    "                      mask_dir=mask_dir, mantis_dir=mantis_dir, image_dir=image_dir)"
    ]
   },
   {
@@ -376,8 +376,8 @@
    "outputs": [],
    "source": [
     "# create directory that can be read into Mantis\n",
-    "create_mantis_project(cell_table=cell_table, fovs=testing_fovs, seg_dir=segmentation_dir, pop_col='cell_meta_cluster', mask_dir=mask_dir,\n",
-    "                      mantis_dir=mantis_dir, image_dir=image_dir)\n",
+    "create_mantis_project(cell_table=cell_table, fovs=testing_fovs, seg_dir=segmentation_dir, pop_col='cell_meta_cluster', \n",
+    "                      mask_dir=mask_dir, mantis_dir=mantis_dir, image_dir=image_dir)\n",
     "\n",
     "# create dataframe with counts of the specified markers\n",
     "marker_counts_df = cell_table.loc[np.isin(cell_table['fov'], testing_fovs), ['fov', 'label'] + functional_markers]\n",
@@ -494,7 +494,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -507,7 +507,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/templates/generic_cell_clustering.ipynb
+++ b/templates/generic_cell_clustering.ipynb
@@ -724,7 +724,6 @@
     "    seg_dir=os.path.join(base_dir, segmentation_dir),\n",
     "    cluster_type='cell',\n",
     "    mask_suffix=\"_cell_mask\",\n",
-    "    mask_prefix=None,\n",
     "    seg_suffix_name=seg_suffix,\n",
     "    new_mask_suffix='_generic_cell_mask'\n",
     ")"

--- a/templates/generic_cell_clustering.ipynb
+++ b/templates/generic_cell_clustering.ipynb
@@ -717,14 +717,15 @@
    "source": [
     "plot_utils.create_mantis_dir(\n",
     "    fovs=subset_cell_fovs,\n",
-    "    mantis_project_path=os.path.join(base_dir, \"pixie\", cell_output_dir, \"mantis\"),\n",
+    "    mantis_project_path=os.path.join(base_dir, \"mantis\"),\n",
     "    img_data_path=tiff_dir,\n",
     "    mask_output_dir=os.path.join(base_dir, \"pixie\", cell_output_dir, \"cell_masks\"),\n",
     "    mapping = os.path.join(base_dir, cell_meta_cluster_remap_name),\n",
     "    seg_dir=os.path.join(base_dir, segmentation_dir),\n",
     "    cluster_type='cell',\n",
     "    mask_suffix=\"_cell_mask\",\n",
-    "    seg_suffix_name=seg_suffix\n",
+    "    seg_suffix_name=seg_suffix,\n",
+    "    new_mask_suffix='_generic_cell_mask'\n",
     ")"
    ]
   }

--- a/templates/generic_cell_clustering.ipynb
+++ b/templates/generic_cell_clustering.ipynb
@@ -724,6 +724,7 @@
     "    seg_dir=os.path.join(base_dir, segmentation_dir),\n",
     "    cluster_type='cell',\n",
     "    mask_suffix=\"_cell_mask\",\n",
+    "    mask_prefix=None,\n",
     "    seg_suffix_name=seg_suffix,\n",
     "    new_mask_suffix='_generic_cell_mask'\n",
     ")"

--- a/tests/phenotyping/post_cluster_utils_test.py
+++ b/tests/phenotyping/post_cluster_utils_test.py
@@ -91,7 +91,7 @@ def test_create_mantis_project(tmp_path):
     # make sure that the mask found in each mantis directory is correct
     for fov in fovs:
         # mask should only include 0, 1, and 2 for background, population_1, and population_2
-        mask = io.imread(os.path.join(mask_dir, fov + "_cell_mask.tiff"))
+        mask = io.imread(os.path.join(mask_dir, fov + "_post_clustering_cell_mask.tiff"))
         assert set(np.unique(mask)) == set([0, 1, 2])
 
         # mask should be non-zero in the same places as original

--- a/tests/utils/plot_utils_test.py
+++ b/tests/utils/plot_utils_test.py
@@ -376,8 +376,9 @@ def mantis_data(
 
 @pytest.mark.parametrize("_mapping", ["df", "mapping_path"])
 @pytest.mark.parametrize("_seg_none", [True, False])
+@pytest.mark.parametrize("new_suffix", [True, False])
 def test_create_mantis_dir(
-        mantis_data: _mantis, _seg_none: bool, _mapping: str, cluster_type: str):
+        mantis_data: _mantis, _seg_none: bool, _mapping: str, cluster_type: str, new_suffix: bool):
     md = mantis_data
 
     # Image segmentation full path, and None
@@ -393,6 +394,10 @@ def test_create_mantis_dir(
     else:
         _m = md.mapping_path
 
+    mask_suff = md.mask_suffix
+    if new_suffix:
+        mask_suff = "_new_mask"
+
     # Test mapping csv, and df
     for mapping in [md.df, md.mapping_path]:
         plot_utils.create_mantis_dir(
@@ -405,7 +410,8 @@ def test_create_mantis_dir(
             seg_dir=image_segmentation_full_path,
             cluster_type=cluster_type,
             seg_suffix_name=seg_suffix_name,
-            img_sub_folder=md.img_sub_folder
+            img_sub_folder=md.img_sub_folder,
+            new_mask_suffix=mask_suff
         )
 
         # Testing file existence and correctness
@@ -414,7 +420,7 @@ def test_create_mantis_dir(
             output_path = os.path.join(md.mantis_project_path, fov)
 
             # 1. Mask tiff tests
-            mask_path = os.path.join(output_path, "population{}.tiff".format(md.mask_suffix))
+            mask_path = os.path.join(output_path, "population{}.tiff".format(mask_suff))
             original_mask_path: str = os.path.join(md.mask_output_dir, '%s_mask.tiff' % fov)
 
             # 1.a. Assert that the mask path exists
@@ -446,7 +452,7 @@ def test_create_mantis_dir(
             else:
                 original_mapping_df = pd.read_csv(md.mapping_path)
             new_mapping_df = pd.read_csv(
-                os.path.join(output_path, "population{}.csv".format(md.mask_suffix)))
+                os.path.join(output_path, "population{}.csv".format(mask_suff)))
 
             # 3.a. Assert that metacluster col equals the region_id col
             metacluster_col = original_mapping_df[[f"{cluster_type}_meta_cluster"]]

--- a/tests/utils/plot_utils_test.py
+++ b/tests/utils/plot_utils_test.py
@@ -377,10 +377,8 @@ def mantis_data(
 @pytest.mark.parametrize("_mapping", ["df", "mapping_path"])
 @pytest.mark.parametrize("_seg_none", [True, False])
 @pytest.mark.parametrize("new_suffix", [True, False])
-@pytest.mark.parametrize("mask_prefix", ["prefix_", None])
 def test_create_mantis_dir(
-        mantis_data: _mantis, _seg_none: bool, _mapping: str, cluster_type: str, new_suffix: bool,
-        mask_prefix):
+        mantis_data: _mantis, _seg_none: bool, _mapping: str, cluster_type: str, new_suffix: bool):
     md = mantis_data
 
     # Image segmentation full path, and None
@@ -400,14 +398,6 @@ def test_create_mantis_dir(
     if new_suffix:
         mask_suff = "_new_mask"
 
-    # empty prefix or rename mask tiffs
-    if not mask_prefix:
-        mask_prefix = ""
-    else:
-        for mask in io_utils.list_files(md.mask_output_dir):
-            os.rename(os.path.join(md.mask_output_dir, mask),
-                      os.path.join(md.mask_output_dir, mask_prefix + mask))
-
     # Test mapping csv, and df
     for mapping in [md.df, md.mapping_path]:
         plot_utils.create_mantis_dir(
@@ -416,7 +406,6 @@ def test_create_mantis_dir(
             img_data_path=md.fov_path,
             mask_output_dir=md.mask_output_dir,
             mask_suffix=md.mask_suffix,
-            mask_prefix=mask_prefix,
             mapping=_m,
             seg_dir=image_segmentation_full_path,
             cluster_type=cluster_type,
@@ -431,7 +420,7 @@ def test_create_mantis_dir(
             output_path = os.path.join(md.mantis_project_path, fov)
 
             # 1. Mask tiff tests
-            mask_path = os.path.join(output_path, f"{mask_prefix}population{mask_suff}.tiff")
+            mask_path = os.path.join(output_path, f"population{mask_suff}.tiff")
             original_mask_path: str = os.path.join(md.mask_output_dir, '%s_mask.tiff' % fov)
 
             # 1.a. Assert that the mask path exists
@@ -463,7 +452,7 @@ def test_create_mantis_dir(
             else:
                 original_mapping_df = pd.read_csv(md.mapping_path)
             new_mapping_df = pd.read_csv(
-                os.path.join(output_path, f"{mask_prefix}population{mask_suff}.csv"))
+                os.path.join(output_path, f"population{mask_suff}.csv"))
 
             # 3.a. Assert that metacluster col equals the region_id col
             metacluster_col = original_mapping_df[[f"{cluster_type}_meta_cluster"]]


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #669 and closes #1059.  Creates a single top level mantis directory for notebooks 2, 3, and 4, to avoid duplicate files. 

**How did you implement your changes**

- Set the mantis folder to be created as one subdirectory within the base_dir, rather than within each specific notebook folder.
- Change the output masks from notebook 4 to be named with `_post_clustering_cell_mask` instead of just `_cell_mask` to avoid overwriting notebook 3 cell cluster output files.
- Change the output masks from the generic_cell_clustering notebook to be named `_generic_cell_mask`.

**Remaining issues**

- [x] Run mantis generation in all clustering notebooks 