### PR TITLE
Interactive files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "dill>=0.3.5,<0.4",
     "feather-format>=0.4.1,<1",
     "importlib-metadata>=5.0",
+    "ipyfilechooser>=0.6.0",
     "ipympl>=0.9.2,<1.0.0",
     "ipython>=8.4,<9",
     "jupyterlab>=3.4.3,<4",

--- a/templates/2_Pixie_Cluster_Pixels.ipynb
+++ b/templates/2_Pixie_Cluster_Pixels.ipynb
@@ -46,11 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you're using your own data, use the widget below to set `base_dir`. Otherwise, skip to the next cell.\n",
-    "\n",
-    "* `base_dir`: the path to all of your imaging data. This directory will also store all of the directories/files created during pixel clustering.\n",
-    "\n",
-    "**NOTE: data on external volumes are mounted in `/Volumes`. To access data on your personal computer, navigate to `/Users/{username}`.**"
+    "If you're using your own data, leave `use_example_dataset` as `False`. If you'd like to test teh features in `ark` with an example dataset, set to `True`."
    ]
   },
   {
@@ -61,24 +57,54 @@
    },
    "outputs": [],
    "source": [
-    "base_dir_fc = FileChooser(\"/\")\n",
-    "display(base_dir_fc)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "base_dir = base_dir_fc.select_path if \"base_dir_fc\" in locals() else \"../data/example/dataset\""
+    "use_example_dataset = False"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you would like to test the features in ark with an example dataset, run the cell below. It will download a dataset consisting of 11 FOVs with 22 channels. You may find more information about the example dataset in the [README](../README.md#example-dataset).\n",
+    "Set `base_dir`. If you're using the example dataset, this will default to `\"../data/example/dataset\"`. Otherwise, you will be prompted to interactively choose the path.\n",
+    "\n",
+    "**NOTE: data on external volumes are mounted in `/Volumes`. To access data on your personal computer, navigate to `/Users/{username}`.**\n",
+    "\n",
+    "* `base_dir`: the path to all of your imaging data. This directory will also store all of the directories/files created during pixel clustering.the path to all of your imaging data. This directory will also store all of the directories/files created during pixel clustering."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "if use_example_dataset:\n",
+    "    base_dir = \"../data/example/dataset\"\n",
+    "else:\n",
+    "    def assign_base_dir(chooser):\n",
+    "        global base_dir\n",
+    "        base_dir = chooser.selected_path\n",
+    "\n",
+    "    base_dir_fc = FileChooser(\"/Users/alkong/Desktop/angelo/TONIC_testing/\")\n",
+    "    base_dir_fc.register_callback(assign_base_dir)\n",
+    "    display(base_dir_fc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-09-14T20:19:20.504860Z",
+     "iopub.status.busy": "2023-09-14T20:19:20.504266Z",
+     "iopub.status.idle": "2023-09-14T20:19:20.519290Z",
+     "shell.execute_reply": "2023-09-14T20:19:20.516279Z",
+     "shell.execute_reply.started": "2023-09-14T20:19:20.504812Z"
+    },
+    "tags": []
+   },
+   "source": [
+    "If you're using the example dataset to test the features in ark, this cell will ownload a dataset consisting of 11 FOVs with 22 channels. You may find more information about the example dataset in the [README](../README.md#example-dataset).\n",
     "\n",
     "If you are using your own data, skip the cell below.\n",
     "\n",
@@ -95,7 +121,8 @@
    },
    "outputs": [],
    "source": [
-    "example_dataset.get_example_dataset(dataset=\"cluster_pixels\", save_dir = base_dir, overwrite_existing = False)"
+    "if use_example_dataset:\n",
+    "    example_dataset.get_example_dataset(dataset=\"cluster_pixels\", save_dir = base_dir, overwrite_existing = False)"
    ]
   },
   {
@@ -111,11 +138,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* `tiff_dir`: path to the directory containing your imaging data. Images should be single-channel TIFFs.\n",
-    "* `img_sub_folder`: if `tiff_dir` contains an additional subfolder structure, override `None` with the appropriate folder name\n",
-    "* `segmentation_dir`: path to the directory containing your segmentations (which can be generated using `1_Segment_Image_Data.ipynb`). Set this argument to `None` if you do not have segmentation labels or wish to run pixel clustering without them (they are required for cell clustering)\n",
-    "* `seg_suffix`: the suffix plus the file extension of the segmented images for each FOV. Note that these should be the same for all FOVs. This argument will be ignored if `segmentation_dir` is set to `None`\n",
-    "* `pixie_seg_dir`: the created path from the `segmentation_dir`. Is `None` if `segmentation_dir` is `None`."
+    "* `tiff_dir`: interactively set the path to the directory containing your imaging data. Images should be single-channel TIFFs. If using the example dataset, this will default to `{base_dir}/image_data`. **`tiff_dir` should be placed in your `base_dir`.**"
    ]
   },
   {
@@ -126,22 +149,25 @@
    },
    "outputs": [],
    "source": [
-    "# skip this cell to use the example dataset defaults\n",
-    "tiff_dir_fc = FileChooser(base_dir)\n",
-    "display(tiff_dir_fc)"
+    "img_sub_folder = None\n",
+    "\n",
+    "if use_example_dataset:\n",
+    "    tiff_dir = os.path.join(base_dir, \"image_data\")\n",
+    "else:\n",
+    "    def assign_tiff_dir(chooser):\n",
+    "        global tiff_dir\n",
+    "        tiff_dir = chooser.selected_path\n",
+    "\n",
+    "    tiff_dir_fc = FileChooser(base_dir)\n",
+    "    tiff_dir_fc.register_callback(assign_tiff_dir)\n",
+    "    display(tiff_dir_fc)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "# skip this cell to use the example dataset defaults\n",
-    "segmentation_dir_fc = FileChooser(base_dir)\n",
-    "display(segmentation_dir_fc)"
+    "* `pixie_seg_dir`: interactively set the path to the directory containing your segmentations (which can be generated using `1_Segment_Image_Data.ipynb`). Skip this cell if you do not have any segmentation labels or wish to run pixel clustering without them (they are required for cell clustering). **`pixie_seg_dir` should be placed in your `base_dir`.**"
    ]
   },
   {
@@ -150,8 +176,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tiff_dir = tiff_dir_fc.select_path if \"tiff_dir_fc\" in locals() else os.path.join(base_dir, \"image_data\")\n",
-    "pixie_seg_dir = segmentation_dir_fc.select_path if \"segmentation_dir_fc\" in locals() else os.path.join(base_dir, \"segmentation\", \"deepcell_output\")"
+    "if use_example_dataset:\n",
+    "    pixie_seg_dir = os.path.join(base_dir, \"segmentation\", \"deepcell_output\")\n",
+    "else:\n",
+    "    def assign_seg_dir(chooser):\n",
+    "        global pixie_seg_dir\n",
+    "        pixie_seg_dir = chooser.selected_path\n",
+    "\n",
+    "    pixie_seg_dir_fc = FileChooser(base_dir)\n",
+    "    pixie_seg_dir_fc.register_callback(assign_seg_dir)\n",
+    "    display(pixie_seg_dir_fc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* `img_sub_folder`: if `tiff_dir` contains an additional subfolder structure, override `None` with the appropriate folder name\n",
+    "* `seg_suffix`: the suffix plus the file extension of the segmented images for each FOV. Note that these should be the same for all FOVs. This argument will be ignored if `segmentation_dir` is unset"
    ]
   },
   {
@@ -161,28 +203,12 @@
    "outputs": [],
    "source": [
     "img_sub_folder = None\n",
-    "seg_suffix = \"_whole_cell.tiff\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "file_path"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# tiff_dir = os.path.join(base_dir, \"image_data\")\n",
-    "# img_sub_folder = None\n",
-    "# segmentation_dir = os.path.join(\"segmentation\", \"deepcell_output\")\n",
-    "# seg_suffix = '_whole_cell.tiff'\n",
+    "seg_suffix = \"_whole_cell.tiff\"\n",
     "\n",
-    "# if segmentation_dir is not None:\n",
-    "#     pixie_seg_dir = os.path.join(base_dir, segmentation_dir)\n",
-    "# else:\n",
-    "#     pixie_seg_dir = None"
+    "if \"pixie_seg_dir\" in globals():\n",
+    "    segmentation_dir = pixie_seg_dir.remove(base_dir + \"/\", \"\")\n",
+    "else:\n",
+    "    segmentation_dir = None"
    ]
   },
   {
@@ -985,7 +1011,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.11.5"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/templates/2_Pixie_Cluster_Pixels.ipynb
+++ b/templates/2_Pixie_Cluster_Pixels.ipynb
@@ -18,6 +18,7 @@
    "outputs": [],
    "source": [
     "# import required packages\n",
+    "from ipyfilechooser import FileChooser\n",
     "import json\n",
     "import os\n",
     "from datetime import datetime as dt\n",
@@ -38,24 +39,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 0: Set root directory and download the example dataset\n",
+    "## 0: Set root directory and download the example dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you're using your own data, use the widget below to set `base_dir`. Otherwise, skip to the next cell.\n",
     "\n",
-    "Here we are using the example data located in `data/example_dataset`. To use your own data, change `base_dir` to point to your own sub-directory within the data folder.\n",
+    "* `base_dir`: the path to all of your imaging data. This directory will also store all of the directories/files created during pixel clustering.\n",
     "\n",
-    "* `base_dir`: the path to all of your imaging data. This directory will also store all of the directories/files created during pixel clustering."
+    "**NOTE: data on external volumes are mounted in `/Volumes`. To access data on your personal computer, navigate to `/Users/{username}`.**"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": [
-     "base_dir"
-    ]
+    "tags": []
    },
    "outputs": [],
    "source": [
-    "base_dir = \"../data/example_dataset\""
+    "base_dir_fc = FileChooser(\"/\")\n",
+    "display(base_dir_fc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_dir = base_dir_fc.select_path if \"base_dir_fc\" in locals() else \"../data/example/dataset\""
    ]
   },
   {
@@ -106,21 +122,67 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# skip this cell to use the example dataset defaults\n",
+    "tiff_dir_fc = FileChooser(base_dir)\n",
+    "display(tiff_dir_fc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# skip this cell to use the example dataset defaults\n",
+    "segmentation_dir_fc = FileChooser(base_dir)\n",
+    "display(segmentation_dir_fc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tiff_dir = tiff_dir_fc.select_path if \"tiff_dir_fc\" in locals() else os.path.join(base_dir, \"image_data\")\n",
+    "pixie_seg_dir = segmentation_dir_fc.select_path if \"segmentation_dir_fc\" in locals() else os.path.join(base_dir, \"segmentation\", \"deepcell_output\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img_sub_folder = None\n",
+    "seg_suffix = \"_whole_cell.tiff\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "tags": [
      "file_path"
     ]
    },
    "outputs": [],
    "source": [
-    "tiff_dir = os.path.join(base_dir, \"image_data\")\n",
-    "img_sub_folder = None\n",
-    "segmentation_dir = os.path.join(\"segmentation\", \"deepcell_output\")\n",
-    "seg_suffix = '_whole_cell.tiff'\n",
+    "# tiff_dir = os.path.join(base_dir, \"image_data\")\n",
+    "# img_sub_folder = None\n",
+    "# segmentation_dir = os.path.join(\"segmentation\", \"deepcell_output\")\n",
+    "# seg_suffix = '_whole_cell.tiff'\n",
     "\n",
-    "if segmentation_dir is not None:\n",
-    "    pixie_seg_dir = os.path.join(base_dir, segmentation_dir)\n",
-    "else:\n",
-    "    pixie_seg_dir = None"
+    "# if segmentation_dir is not None:\n",
+    "#     pixie_seg_dir = os.path.join(base_dir, segmentation_dir)\n",
+    "# else:\n",
+    "#     pixie_seg_dir = None"
    ]
   },
   {
@@ -303,7 +365,7 @@
     "pixel_cluster_utils.filter_with_nuclear_mask(\n",
     "    fovs=fovs,\n",
     "    tiff_dir=tiff_dir,\n",
-    "    seg_dir=os.path.join(base_dir, segmentation_dir),\n",
+    "    seg_dir=pixie_seg_dir,\n",
     "    channel=filter_channel,\n",
     "    nuc_seg_suffix=\"_nuclear.tiff\",\n",
     "    img_sub_folder=img_sub_folder,\n",
@@ -923,7 +985,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.9.17"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/templates/2_Pixie_Cluster_Pixels.ipynb
+++ b/templates/2_Pixie_Cluster_Pixels.ipynb
@@ -46,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you're using your own data, leave `use_example_dataset` as `False`. If you'd like to test teh features in `ark` with an example dataset, set to `True`."
+    "If you're using your own data, leave `use_example_dataset` as `False`. If you'd like to test the features in `ark` with an example dataset, set to `True`."
    ]
   },
   {
@@ -104,9 +104,9 @@
     "tags": []
    },
    "source": [
-    "If you're using the example dataset to test the features in ark, this cell will ownload a dataset consisting of 11 FOVs with 22 channels. You may find more information about the example dataset in the [README](../README.md#example-dataset).\n",
+    "If you're using the example dataset to test the features in ark, this cell will download a dataset consisting of 11 FOVs with 22 channels. You may find more information about the example dataset in the [README](../README.md#example-dataset).\n",
     "\n",
-    "If you are using your own data, skip the cell below.\n",
+    "If you're using your own data, skip the cell below.\n",
     "\n",
     "* `overwrite_existing`: If set to `False`, it will not overwrite existing data in `data/example_dataset`. Recommended setting to `False` if you are running Notebooks 1,2,3 and 4 in succession. Set to `True` if you are just running Notebook 2."
    ]
@@ -205,7 +205,7 @@
     "img_sub_folder = None\n",
     "seg_suffix = \"_whole_cell.tiff\"\n",
     "\n",
-    "if \"pixie_seg_dir\" in globals():\n",
+    "if \"pixie_seg_dir\" in globals() or \"pixie_seg_dir\" in locals():\n",
     "    segmentation_dir = pixie_seg_dir.remove(base_dir + \"/\", \"\")\n",
     "else:\n",
     "    segmentation_dir = None"

--- a/templates/3_Pixie_Cluster_Cells.ipynb
+++ b/templates/3_Pixie_Cluster_Cells.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -11,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -29,6 +27,7 @@
    "outputs": [],
    "source": [
     "# import required packages\n",
+    "from ipyfilechooser import FileChooser\n",
     "import json\n",
     "import os\n",
     "from datetime import datetime as dt\n",
@@ -48,7 +47,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -72,11 +70,20 @@
    "outputs": [],
    "source": [
     "# define the home directory (should contain pixel_output_dir from pixel clustering notebook)\n",
-    "base_dir = \"../data/example_dataset/\""
+    "base_dir_fc = FileChooser(\"/\")\n",
+    "display(base_dir_fc)"
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_dir = base_dir_fc.select_path if \"base_dir_fc\" in locals() else \"../data/example/dataset\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -101,7 +108,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -111,13 +117,32 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "`cell_clustering_params_name` should be `cell_clustering_params.json` contained in `{pixel_cluster_prefix}_pixel_output_dir`. Make sure to set `base_dir` and `pixel_output_dir` to the same value used in `2_Pixie_Cluster_Pixels.ipynb`.\n",
     "\n",
     "NOTE: `{pixel_cluster_prefix}` is set in `2_Pixie_Cluster_Pixels.ipynb`. If you did not explicity set a `{pixel_cluster_prefix}` in `2_Pixie_Cluster_Pixels.ipynb`, the prefix defaults to the timestamp of the run. Please check the run directory (`base_dir` as set in `2_Pixie_Cluster_Pixels.ipynb`) to see the prefix that was used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_clustering_params_fc = FileChooser(\"/\")\n",
+    "display(cell_clustering_params_fc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_clustering_params_path = cell_clustering_params_fc.select_path if \"cell_clustering_params_fc\" in locals() \\\n",
+    "    else os.path.join(base_dir, \"pixie\", \"example_pixel_output_dir\", \"cell_clustering_params.json\")"
    ]
   },
   {
@@ -141,7 +166,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -184,11 +208,30 @@
     "pc_chan_avg_meta_cluster_name = cell_clustering_params['pc_chan_avg_meta_cluster_name']\n",
     "\n",
     "# define the cell table path\n",
-    "cell_table_path = os.path.join(base_dir, 'segmentation', 'cell_table', 'cell_table_size_normalized.csv')"
+    "# cell_table_path = os.path.join(base_dir, 'segmentation', 'cell_table', 'cell_table_size_normalized.csv')"
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_table_fc = FileChooser(\"/\")\n",
+    "display(cell_table_fc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_table_path = cell_table_fc.select_path if \"cell_table_fc\" in locals() \\\n",
+    "    else os.path.join(base_dir, \"segmentation\", \"cell_table\", \"cell_table_size_normalized.csv\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -196,7 +239,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -221,7 +263,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -267,7 +308,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -297,7 +337,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -345,7 +384,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -390,7 +428,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -398,7 +435,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -406,7 +442,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -439,7 +474,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -447,7 +481,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -490,7 +523,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -498,7 +530,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -517,7 +548,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -580,7 +610,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -588,7 +617,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -596,7 +624,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -649,7 +676,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -704,7 +730,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -729,7 +754,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -756,7 +780,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -783,7 +806,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -820,7 +842,7 @@
     "data_utils.generate_and_save_cell_cluster_masks(\n",
     "    fovs=subset_cell_fovs,\n",
     "    save_dir=os.path.join(base_dir, \"pixie\", cell_output_dir),\n",
-    "    seg_dir=os.path.join(base_dir, segmentation_dir),\n",
+    "    seg_dir=segmentation_dir,\n",
     "    cell_data=cluster_counts_size_norm,\n",
     "    seg_suffix=seg_suffix,\n",
     "    sub_dir='cell_masks',\n",
@@ -829,7 +851,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -857,7 +878,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -894,7 +914,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -902,7 +921,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -925,7 +943,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -950,7 +967,7 @@
     "    img_data_path=tiff_dir,\n",
     "    mask_output_dir=os.path.join(base_dir, \"pixie\", cell_output_dir, \"cell_masks\"),\n",
     "    mapping = os.path.join(base_dir, cell_meta_cluster_remap_name),\n",
-    "    seg_dir=os.path.join(base_dir, segmentation_dir),\n",
+    "    seg_dir=segmentation_dir,\n",
     "    cluster_type='cell',\n",
     "    mask_suffix=\"_cell_mask\",\n",
     "    seg_suffix_name=seg_suffix\n",
@@ -974,7 +991,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.9.17"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/templates/3_Pixie_Cluster_Cells.ipynb
+++ b/templates/3_Pixie_Cluster_Cells.ipynb
@@ -48,50 +48,65 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## 0: Set root directory and download the example dataset\n",
-    "\n",
-    "Here we are using the example data located in `data/example_dataset`. To use your own data, change `base_dir` to point to your own sub-directory within the data folder.\n",
-    "\n",
-    "* `base_dir`: the path to all of your imaging data. Should contain a directory for your images, segmentations, and cell table (which can be generated from `1_Segment_Image_Data.ipynb`). This directory will also store all of the directories/files created during cell clustering."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "base_dir"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# define the home directory (should contain pixel_output_dir from pixel clustering notebook)\n",
-    "base_dir_fc = FileChooser(\"/\")\n",
-    "display(base_dir_fc)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
-    "base_dir = base_dir_fc.select_path if \"base_dir_fc\" in locals() else \"../data/example/dataset\""
+    "## 0: Set root directory and download the example dataset"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you would like to test the features in ark with an example dataset, run the cell below. It will download a dataset consisting of 11 FOVs with 22 channels. You may find more information about the example dataset in the [README](../README.md#example-dataset).\n",
+    "If you're using your own data, leave `use_example_dataset` as `False`. If you'd like to test the features in `ark` with an example dataset, set to `True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "use_example_dataset = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set `base_dir`. If you're using the example dataset, this will default to `\"../data/example/dataset\"`. Otherwise, you will be prompted to interactively choose the path.\n",
     "\n",
-    "If you are using your own data, skip the cell below.\n",
+    "**NOTE: data on external volumes are mounted in `/Volumes`. To access data on your personal computer, navigate to `/Users/{username}`.**\n",
     "\n",
-    "* `overwrite_existing`: If set to `False`, it will not overwrite existing data in `data/example_dataset`. Recommended setting to `False` if you are running Notebooks 1,2,3 and 4 in succession. Set to `True` if you are just running Notebook 3."
+    "* `base_dir`: the path to all of your imaging data. This directory will also store all of the directories/files created during pixel clustering.the path to all of your imaging data. This directory will also store all of the directories/files created during pixel clustering."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_example_dataset:\n",
+    "    base_dir = \"../data/example/dataset\"\n",
+    "else:\n",
+    "    def assign_base_dir(chooser):\n",
+    "        global base_dir\n",
+    "        base_dir = chooser.selected_path\n",
+    "\n",
+    "    base_dir_fc = FileChooser(\"/Users/alkong/Desktop/angelo/TONIC_testing/\")\n",
+    "    base_dir_fc.register_callback(assign_base_dir)\n",
+    "    display(base_dir_fc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you're using the example dataset to test the features in ark, this cell will download a dataset consisting of 11 FOVs with 22 channels. You may find more information about the example dataset in the [README](../README.md#example-dataset).\n",
+    "\n",
+    "If you're using your own data, skip the cell below.\n",
+    "\n",
+    "* `overwrite_existing`: If set to `False`, it will not overwrite existing data in `data/example_dataset`. Recommended setting to `False` if you are running Notebooks 1,2,3 and 4 in succession. Set to `True` if you are just running Notebook 2."
    ]
   },
   {
@@ -104,7 +119,8 @@
    },
    "outputs": [],
    "source": [
-    "example_dataset.get_example_dataset(dataset=\"cluster_cells\", save_dir = base_dir, overwrite_existing = False)"
+    "if use_example_dataset:\n",
+    "    example_dataset.get_example_dataset(dataset=\"cluster_cells\", save_dir = base_dir, overwrite_existing = False)"
    ]
   },
   {
@@ -120,9 +136,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`cell_clustering_params_name` should be `cell_clustering_params.json` contained in `{pixel_cluster_prefix}_pixel_output_dir`. Make sure to set `base_dir` and `pixel_output_dir` to the same value used in `2_Pixie_Cluster_Pixels.ipynb`.\n",
+    "* `cell_clustering_params_name`: interactively set the path to `cell_clustering_params.json` contained in `{pixel_cluster_prefix}_pixel_output_dir`. If using the example dataset, this will default to `{base_dir}/pixie/example_pixel_output_dir/cell_clustering_params.json`.\n",
     "\n",
-    "NOTE: `{pixel_cluster_prefix}` is set in `2_Pixie_Cluster_Pixels.ipynb`. If you did not explicity set a `{pixel_cluster_prefix}` in `2_Pixie_Cluster_Pixels.ipynb`, the prefix defaults to the timestamp of the run. Please check the run directory (`base_dir` as set in `2_Pixie_Cluster_Pixels.ipynb`) to see the prefix that was used."
+    "**NOTE: `{pixel_cluster_prefix}` is set in `2_Pixie_Cluster_Pixels.ipynb`. If you did not explicity set a `{pixel_cluster_prefix}` in `2_Pixie_Cluster_Pixels.ipynb`, the prefix defaults to the timestamp of the run. Please check the run directory (`base_dir` as set in `2_Pixie_Cluster_Pixels.ipynb`) to see the prefix that was used.**"
    ]
   },
   {
@@ -131,18 +147,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cell_clustering_params_fc = FileChooser(\"/\")\n",
-    "display(cell_clustering_params_fc)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cell_clustering_params_path = cell_clustering_params_fc.select_path if \"cell_clustering_params_fc\" in locals() \\\n",
-    "    else os.path.join(base_dir, \"pixie\", \"example_pixel_output_dir\", \"cell_clustering_params.json\")"
+    "if use_example_dataset:\n",
+    "    cell_clustering_params_path = os.path.join(base_dir, \"pixie\", \"example_pixel_output_dir\", \"cell_clustering_params.json\")\n",
+    "else:\n",
+    "    def assign_cell_params_path(chooser):\n",
+    "        global cell_clustering_params_path\n",
+    "        cell_clustering_params_path = chooser.selected_path\n",
+    "\n",
+    "    cell_clustering_params_fc = FileChooser(base_dir)\n",
+    "    cell_clustering_params_fc.register_callback(assign_cell_params_path)\n",
+    "    display(cell_clustering_params_fc)"
    ]
   },
   {
@@ -177,11 +191,7 @@
     "* `seg_suffix`: suffix plus the file extension of the segmented images for each FOV\n",
     "* `pixel_data_dir`: name of the directory containing pixel data with the pixel SOM and meta cluster assignments\n",
     "* `pc_chan_avg_som_cluster_name`: name of the file containing the average channel expression per pixel SOM cluster, used for the visualization of weighted channel average per cell\n",
-    "* `pc_chan_avg_meta_cluster_name`: name of the file containing the average channel expression per pixel meta cluster, used for the visualization of weighted channel average per cell\n",
-    "\n",
-    "Additionally, define the following parameter:\n",
-    "\n",
-    "* `cell_table_path`: path to the cell table where each row in the table is one cell, must contain `fov`, `label`, and `cell_size` columns. Can be created by `1_Segment_Image_Data.ipynb`, should be placed in `segmentation_dir` by default. You can use either the normalized or arcsinh versions (only columns that are used are `fov`, `label`, and `cell_size`)."
+    "* `pc_chan_avg_meta_cluster_name`: name of the file containing the average channel expression per pixel meta cluster, used for the visualization of weighted channel average per cell"
    ]
   },
   {
@@ -195,8 +205,8 @@
    "outputs": [],
    "source": [
     "# load the params\n",
-    "with open(os.path.join(base_dir, \"pixie\", pixel_output_dir, cell_clustering_params_name)) as fh:\n",
-    "    cell_clustering_params = json.load(fh)\n",
+    "with open(cell_clustering_params_path) as ccpp:\n",
+    "    cell_clustering_params = json.load(ccpp)\n",
     "    \n",
     "# assign the params to variables\n",
     "fovs = cell_clustering_params['fovs']\n",
@@ -205,30 +215,32 @@
     "seg_suffix = cell_clustering_params['seg_suffix']\n",
     "pixel_data_dir = cell_clustering_params['pixel_data_dir']\n",
     "pc_chan_avg_som_cluster_name = cell_clustering_params['pc_chan_avg_som_cluster_name']\n",
-    "pc_chan_avg_meta_cluster_name = cell_clustering_params['pc_chan_avg_meta_cluster_name']\n",
+    "pc_chan_avg_meta_cluster_name = cell_clustering_params['pc_chan_avg_meta_cluster_name']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* `cell_table_path`: path to the cell table where each row in the table is one cell, must contain `fov`, `label`, and `cell_size` columns. Can be created by `1_Segment_Image_Data.ipynb`, should be placed in `segmentation_dir` by default. You can use either the normalized or arcsinh versions (only columns that are used are `fov`, `label`, and `cell_size`). If using the example dataset, this will default to `\"{base_dir}/segmentation/cell_table/cell_table_size_normalized.csv\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_example_dataset:\n",
+    "    cell_table_path = os.path.join(base_dir, \"segmentation\", \"cell_table\", \"cell_table_size_normalized.csv\")\n",
+    "else:\n",
+    "    def assign_cell_table_path(chooser):\n",
+    "        global cell_table_path\n",
+    "        cell_table_path = chooser.selected_path\n",
     "\n",
-    "# define the cell table path\n",
-    "# cell_table_path = os.path.join(base_dir, 'segmentation', 'cell_table', 'cell_table_size_normalized.csv')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cell_table_fc = FileChooser(\"/\")\n",
-    "display(cell_table_fc)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cell_table_path = cell_table_fc.select_path if \"cell_table_fc\" in locals() \\\n",
-    "    else os.path.join(base_dir, \"segmentation\", \"cell_table\", \"cell_table_size_normalized.csv\")"
+    "    cell_table_path_fc = FileChooser(base_dir)\n",
+    "    cell_table_path_fc.register_callback(assign_cell_table_path)\n",
+    "    display(cell_table_path_fc)"
    ]
   },
   {
@@ -991,7 +1003,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.11.5"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #1029. Add interactive file selection to the notebooks.

**How did you implement your changes**

Use `ipyfilechooser` to allow users to interactively set home directories, such as `base_dir`, `tiff_dir`, etc.

**Remaining issues**

Start with notebooks 2 and 3. Gradually expand to include the others.
