### PR TITLE
Only load whole cell masks if `nuclear_counts=False` in `generate_cell_table`

### DIFF
--- a/src/ark/segmentation/marker_quantification.py
+++ b/src/ark/segmentation/marker_quantification.py
@@ -529,9 +529,14 @@ def generate_cell_table(segmentation_dir, tiff_dir, img_sub_folder="TIFs",
         whole_cell_file = fov_name + '_whole_cell.tiff'
         nuclear_file = fov_name + '_nuclear.tiff'
 
-        # for each label given in the argument. read in that mask for the fov, and proceed with label and table appending
+        # for each label given in the argument, read in that mask for the fov, and proceed with
+        # label and table appending
         mask_files = io_utils.list_files(segmentation_dir, substrs=fov_name)
         mask_types = process_lists(fov_names=fovs, mask_names=mask_files)
+
+        # remove nuclear from mask_types if nuclear_counts False
+        if not nuclear_counts and "nuclear" in mask_types:
+            mask_types.remove("nuclear")
 
         for mask_type in mask_types:
             # load the segmentation labels in

--- a/tests/segmentation/marker_quantification_test.py
+++ b/tests/segmentation/marker_quantification_test.py
@@ -735,18 +735,20 @@ def test_generate_cell_table_tree_loading():
             img_sub_folder=img_sub_folder, is_mibitiff=False, fovs=fovs_subset,
             nuclear_counts=True)
 
-        assert norm_data_nuc.shape[0] == norm_data_fov_sub.shape[0]
+        # setting nuclear_counts True generates data for both whole_cell and nuclear
+        # so there should be double the number of rows
+        assert norm_data_nuc.shape[0] == norm_data_fov_sub.shape[0] * 2
         assert norm_data_nuc.shape[1] == norm_data_fov_sub.shape[1] * 2
         misc_utils.verify_in_list(
             nuclear_col='nc_ratio',
             nuc_cell_table_cols=norm_data_nuc.columns.values
         )
 
-        assert arcsinh_data_nuc.shape[0] == arcsinh_data_fov_sub.shape[0]
+        assert arcsinh_data_nuc.shape[0] == arcsinh_data_fov_sub.shape[0] * 2
         assert arcsinh_data_nuc.shape[1] == norm_data_fov_sub.shape[1] * 2
         misc_utils.verify_in_list(
             nuclear_col='nc_ratio',
-            nuc_cell_table_cols=norm_data_nuc.columns.values
+            nuc_cell_table_cols=arcsinh_data_nuc.columns.values
         )
 
 
@@ -822,18 +824,20 @@ def test_generate_cell_table_mibitiff_loading():
             img_sub_folder=tiff_dir, is_mibitiff=True, fovs=fovs_subset,
             nuclear_counts=True)
 
-        assert norm_data_nuc.shape[0] == norm_data_fov_sub.shape[0]
+        # setting nuclear_counts True generates data for both whole_cell and nuclear
+        # so there should be double the number of rows
+        assert norm_data_nuc.shape[0] == norm_data_fov_sub.shape[0] * 2
         assert norm_data_nuc.shape[1] == norm_data_fov_sub.shape[1] * 2
         misc_utils.verify_in_list(
             nuclear_col='nc_ratio',
             nuc_cell_table_cols=norm_data_nuc.columns.values
         )
 
-        assert arcsinh_data_nuc.shape[0] == arcsinh_data_fov_sub.shape[0]
+        assert arcsinh_data_nuc.shape[0] == arcsinh_data_fov_sub.shape[0] * 2
         assert arcsinh_data_nuc.shape[1] == norm_data_fov_sub.shape[1] * 2
         misc_utils.verify_in_list(
             nuclear_col='nc_ratio',
-            nuc_cell_table_cols=norm_data_nuc.columns.values
+            nuc_cell_table_cols=arcsinh_data_nuc.columns.values
         )
 
 
@@ -873,7 +877,8 @@ def test_generate_cell_table_extractions():
 
         default_norm_data, _ = marker_quantification.generate_cell_table(
             segmentation_dir=temp_dir, tiff_dir=tiff_dir,
-            img_sub_folder=img_sub_folder, is_mibitiff=False
+            img_sub_folder=img_sub_folder, is_mibitiff=False,
+            nuclear_counts=True
         )
 
         # verify total intensity extraction, same for whole_cell and nuclear mask types


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #1097. Updates `generate_cell_table` to be compatible with updated ezSeg pipeline when nuclear masks need to be discarded.

**How did you implement your changes**

By default, the updated `generate_cell_table` loads in all the masks, including nuclear, and adds them to the cell table. For pixel clustering, only the whole cell data is needed, so if `nuclear_counts=False`, this mask type should not appear in the table.

**Remaining issues**

Integration testing with Pixie/Nimbus needed.