### PR TITLE
Don't require user to have all pixel SOM clusters represented during assignment

### DIFF
--- a/src/ark/phenotyping/cluster_helpers.py
+++ b/src/ark/phenotyping/cluster_helpers.py
@@ -217,6 +217,9 @@ class PixelSOMCluster(PixieSOMCluster):
         # we can just normalize train_data now since that's what we'll be training on
         self.train_data = self.normalize_data(self.train_data)
 
+        # define each SOM cluster seen
+        self.som_clusters_seen = set()
+
     def normalize_data(self, external_data: pd.DataFrame) -> pd.DataFrame:
         """Uses `norm_data` to normalize a dataset
 
@@ -291,6 +294,9 @@ class PixelSOMCluster(PixieSOMCluster):
 
         # assign SOM clusters to external_data
         external_data_norm['pixel_som_cluster'] = som_labels
+
+        # update the total number of SOM clusters
+        self.som_clusters_seen.update(list(np.unique(som_labels)))
 
         return external_data_norm
 

--- a/src/ark/phenotyping/pixel_cluster_utils.py
+++ b/src/ark/phenotyping/pixel_cluster_utils.py
@@ -332,9 +332,9 @@ def compute_pixel_cluster_channel_avg(fovs, channels, base_dir, pixel_cluster_co
         valid_cluster_cols=['pixel_som_cluster', 'pixel_meta_cluster']
     )
 
-    # verify num_pixel_clusters is valid
-    if num_pixel_clusters <= 0:
-        raise ValueError("Number of pixel clusters desired must be a positive integer")
+    # verify num_pixel_clusters is valid if set
+    if num_pixel_clusters is not None and num_pixel_clusters <= 0:
+        raise ValueError("If set, number of pixel clusters desired must be a positive integer")
 
     # verify fovs subset value is valid
     if num_fovs_subset <= 0:

--- a/src/ark/phenotyping/pixel_cluster_utils.py
+++ b/src/ark/phenotyping/pixel_cluster_utils.py
@@ -292,7 +292,7 @@ def filter_with_nuclear_mask(fovs: List, tiff_dir: str, seg_dir: str, channel: s
 
 
 def compute_pixel_cluster_channel_avg(fovs, channels, base_dir, pixel_cluster_col,
-                                      num_pixel_clusters=None,
+                                      num_pixel_clusters,
                                       pixel_data_dir='pixel_mat_data',
                                       num_fovs_subset=100, seed=42, keep_count=False):
     """Compute the average channel values across each pixel SOM cluster.

--- a/src/ark/phenotyping/pixel_cluster_utils.py
+++ b/src/ark/phenotyping/pixel_cluster_utils.py
@@ -292,7 +292,7 @@ def filter_with_nuclear_mask(fovs: List, tiff_dir: str, seg_dir: str, channel: s
 
 
 def compute_pixel_cluster_channel_avg(fovs, channels, base_dir, pixel_cluster_col,
-                                      num_pixel_clusters,
+                                      num_pixel_clusters=None,
                                       pixel_data_dir='pixel_mat_data',
                                       num_fovs_subset=100, seed=42, keep_count=False):
     """Compute the average channel values across each pixel SOM cluster.
@@ -309,7 +309,7 @@ def compute_pixel_cluster_channel_avg(fovs, channels, base_dir, pixel_cluster_co
         pixel_cluster_col (str):
             Name of the column to group by
         num_pixel_clusters (int):
-            The number of pixel clusters that are desired
+            The number of pixel clusters that are desired, if None then no fixed amount required
         pixel_data_dir (str):
             Name of the directory containing the pixel data with cluster labels
         num_fovs_subset (float):
@@ -392,7 +392,7 @@ def compute_pixel_cluster_channel_avg(fovs, channels, base_dir, pixel_cluster_co
     )[channels + ['count']].sum().reset_index()
 
     # error out if any clusters were lost during the averaging process
-    if sum_count_totals.shape[0] < num_pixel_clusters:
+    if num_pixel_clusters is not None and sum_count_totals.shape[0] < num_pixel_clusters:
         raise ValueError(
             'Averaged data contains just %d clusters out of %d. '
             'Average expression file not written. '

--- a/src/ark/phenotyping/pixel_som_clustering.py
+++ b/src/ark/phenotyping/pixel_som_clustering.py
@@ -216,9 +216,10 @@ def cluster_pixels(fovs, base_dir, pixel_pysom, data_dir='pixel_mat_data',
         pixel_data_columns=sample_fov.columns.values
     )
 
-    # if overwrite flag set, run on all FOVs in data_dir
+    # if overwrite flag set, run on all FOVs in data_dir, make sure to reset SOM clusters seen
     if overwrite:
         print('Overwrite flag set, reassigning SOM cluster labels to all FOVs')
+        pixel_pysom.som_clusters_seen = set()
         os.mkdir(data_path + '_temp')
         fovs_list = io_utils.remove_file_extensions(
             io_utils.list_files(data_path, substrs='.feather')

--- a/src/ark/phenotyping/pixel_som_clustering.py
+++ b/src/ark/phenotyping/pixel_som_clustering.py
@@ -122,7 +122,7 @@ def run_pixel_som_assignment(pixel_data_path, pixel_pysom_obj, overwrite, num_pa
 
     # if the overwrite flag was set in cluster_pixels, drop the pixel_som_cluster column
     if overwrite:
-        fov_data = fov_data.drop(columns="pixel_som_cluster")
+        fov_data = fov_data.drop(columns="pixel_som_cluster", errors="ignore")
 
     # assign the SOM labels to fov_data, overwrite flag indicates if data needs normalization
     fov_data = pixel_pysom_obj.assign_som_clusters(

--- a/src/ark/phenotyping/pixel_som_clustering.py
+++ b/src/ark/phenotyping/pixel_som_clustering.py
@@ -306,7 +306,7 @@ def _ignore_extended_attributes(func: Callable, filename: str, exc_info: Tuple[A
 
 def generate_som_avg_files(fovs, channels, base_dir, pixel_pysom, data_dir='pixel_data_dir',
                            pc_chan_avg_som_cluster_name='pixel_channel_avg_som_cluster.csv',
-                           num_fovs_subset=100, require_all_som_clusters=False, seed=42,
+                           num_fovs_subset=100, require_all_som_clusters=True, seed=42,
                            overwrite=False):
     """Computes and saves the average channel expression across pixel SOM clusters.
 
@@ -356,7 +356,7 @@ def generate_som_avg_files(fovs, channels, base_dir, pixel_pysom, data_dir='pixe
         channels,
         base_dir,
         'pixel_som_cluster',
-        pixel_pysom.weights.shape[0] if require_all_som_clusters else None,
+        len(pixel_pysom.som_clusters_seen) if require_all_som_clusters else None,
         data_dir,
         num_fovs_subset=num_fovs_subset,
         seed=seed,

--- a/src/ark/phenotyping/pixel_som_clustering.py
+++ b/src/ark/phenotyping/pixel_som_clustering.py
@@ -306,7 +306,8 @@ def _ignore_extended_attributes(func: Callable, filename: str, exc_info: Tuple[A
 
 def generate_som_avg_files(fovs, channels, base_dir, pixel_pysom, data_dir='pixel_data_dir',
                            pc_chan_avg_som_cluster_name='pixel_channel_avg_som_cluster.csv',
-                           num_fovs_subset=100, seed=42, overwrite=False):
+                           num_fovs_subset=100, require_all_som_clusters=False, seed=42,
+                           overwrite=False):
     """Computes and saves the average channel expression across pixel SOM clusters.
 
     Args:
@@ -324,6 +325,8 @@ def generate_som_avg_files(fovs, channels, base_dir, pixel_pysom, data_dir='pixe
             The name of the file to save the average channel expression across all SOM clusters
         num_fovs_subset (int):
             The number of FOVs to subset on for SOM cluster channel averaging
+        require_all_som_clusters (bool):
+            Whether to require all SOM clusters to have at least one pixel assigned
         seed (int):
             The random seed to set for subsetting FOVs
         overwrite (bool):
@@ -353,7 +356,7 @@ def generate_som_avg_files(fovs, channels, base_dir, pixel_pysom, data_dir='pixe
         channels,
         base_dir,
         'pixel_som_cluster',
-        pixel_pysom.weights.shape[0],
+        pixel_pysom.weights.shape[0] if require_all_som_clusters else None,
         data_dir,
         num_fovs_subset=num_fovs_subset,
         seed=seed,

--- a/tests/phenotyping/pixel_cluster_utils_test.py
+++ b/tests/phenotyping/pixel_cluster_utils_test.py
@@ -473,11 +473,18 @@ def test_compute_pixel_cluster_channel_avg(cluster_col, keep_count, corrupt):
             result = np.repeat(np.array([[0.1, 0.2, 0.3]]), repeats=num_repeats, axis=0)
             assert np.array_equal(result, np.round(cluster_avg[cluster_avg_cols].values, 1))
 
+        # if a hard threshold is set, ensure if not all SOM clusters assigned error out
         with pytest.raises(ValueError, match='Average expression file not written'):
             pixel_cluster_utils.compute_pixel_cluster_channel_avg(
                 fovs[1:], chans, temp_dir, cluster_col, 1000,
                 'pixel_mat_consensus', num_fovs_subset=1, keep_count=keep_count
             )
+
+        # otherwise, the function should run to completion
+        pixel_cluster_utils.compute_pixel_cluster_channel_avg(
+            fovs[1:], chans, temp_dir, cluster_col, None,
+            'pixel_mat_consensus', num_fovs_subset=1, keep_count=keep_count
+        )
 
 
 def test_find_fovs_missing_col_no_temp():

--- a/tests/phenotyping/pixel_som_clustering_test.py
+++ b/tests/phenotyping/pixel_som_clustering_test.py
@@ -379,6 +379,7 @@ def test_generate_som_avg_files(capsys):
         pixel_pysom = cluster_helpers.PixelSOMCluster(
             pixel_data_path, norm_vals_path, weights_path, fovs, chan_list
         )
+        pixel_pysom.som_clusters_seen = set(list(np.arange(3)))
 
         # test base generation with all subsetted FOVs
         pixel_som_clustering.generate_som_avg_files(
@@ -424,13 +425,14 @@ def test_generate_som_avg_files(capsys):
         os.remove(pc_som_avg_file)
 
         # ensure error gets thrown when not all SOM clusters make it in if flag specified
+        pixel_pysom.som_clusters_seen = set(list(np.arange(200)))
         with pytest.raises(ValueError):
             pixel_som_clustering.generate_som_avg_files(
-                fovs, chan_list, temp_dir, pixel_pysom, 'pixel_data_dir', num_fovs_subset=1,
-                require_all_som_clusters=True
+                fovs, chan_list, temp_dir, pixel_pysom, 'pixel_data_dir', num_fovs_subset=1
             )
 
         # otherwise, ensure function runs even if not SOM clusters all make it in
         pixel_som_clustering.generate_som_avg_files(
-            fovs, chan_list, temp_dir, pixel_pysom, 'pixel_data_dir', num_fovs_subset=1
+            fovs, chan_list, temp_dir, pixel_pysom, 'pixel_data_dir', num_fovs_subset=1,
+            require_all_som_clusters=False
         )

--- a/tests/phenotyping/pixel_som_clustering_test.py
+++ b/tests/phenotyping/pixel_som_clustering_test.py
@@ -408,7 +408,7 @@ def test_generate_som_avg_files(capsys):
         # test overwrite functionality
         capsys.readouterr()
 
-        # run SOM averaging with overwrite flg
+        # run SOM averaging with overwrite flag
         pixel_som_clustering.generate_som_avg_files(
             fovs, chan_list, temp_dir, pixel_pysom, 'pixel_data_dir', num_fovs_subset=3,
             overwrite=True
@@ -423,8 +423,14 @@ def test_generate_som_avg_files(capsys):
         # remove average SOM file for final test
         os.remove(pc_som_avg_file)
 
-        # ensure error gets thrown when not all SOM clusters make it in
+        # ensure error gets thrown when not all SOM clusters make it in if flag specified
         with pytest.raises(ValueError):
             pixel_som_clustering.generate_som_avg_files(
-                fovs, chan_list, temp_dir, pixel_pysom, 'pixel_data_dir', num_fovs_subset=1
+                fovs, chan_list, temp_dir, pixel_pysom, 'pixel_data_dir', num_fovs_subset=1,
+                require_all_som_clusters=True
             )
+
+        # otherwise, ensure function runs even if not SOM clusters all make it in
+        pixel_som_clustering.generate_som_avg_files(
+            fovs, chan_list, temp_dir, pixel_pysom, 'pixel_data_dir', num_fovs_subset=1
+        )


### PR DESCRIPTION
**What is the purpose of this PR?**

During SOM clustering, it is possible in some cases that not all unique clusters discovered during training will be present in the dataset. In these cases, it's too strict for the SOM cluster mapping function to require all the SOM clusters to be represented.

**How did you implement your changes**

Add an additional parameter to the SOM cluster assignment function that is defaulted to not require all the SOM clusters to be present. This can be explicitly set to revert back to the original format.

The underlying averaging function is also adjusted accordingly.
