### PR TITLE
Fiber stats bugs

### DIFF
--- a/src/ark/segmentation/fiber_segmentation.py
+++ b/src/ark/segmentation/fiber_segmentation.py
@@ -487,8 +487,8 @@ def generate_tile_stats(fov_table, fov_fiber_img, fov_length, tile_length, min_f
         columns=['fov', 'tile_y', 'tile_x', 'pixel_density', 'fiber_density',
                  'avg_alignment_score'])
 
-    for metric in properties:
-        fov_tile_stats[f"avg_{metric}"] = tile_stats.T[0]
+    for i, metric in enumerate(properties):
+        fov_tile_stats[f"avg_{metric}"] = tile_stats.T[i]
 
     return fov_tile_stats
 
@@ -540,9 +540,9 @@ def generate_summary_stats(fiber_object_table, fibseg_dir, tile_length=512, min_
         avg_stats = fov_table[properties].mean().array
 
         # density
-        fov_p_density, fov_p_density = calculate_density(fov_table, fov_length**2)
+        fov_p_density, fov_f_density = calculate_density(fov_table, fov_length**2)
         fov_pixel_density.append(fov_p_density)
-        fov_fiber_density.append(fov_p_density)
+        fov_fiber_density.append(fov_f_density)
 
         # tile level stats
         fov_tile_stats = generate_tile_stats(fov_table, fov_fiber_img, fov_length, tile_length,
@@ -559,7 +559,7 @@ def generate_summary_stats(fiber_object_table, fibseg_dir, tile_length=512, min_
 
     fov_prop_stats = np.vstack(fov_avg_stats)
     for i, metric in enumerate(properties):
-        fov_stats[f"avg_{metric}"] = fov_prop_stats.T[0]
+        fov_stats[f"avg_{metric}"] = fov_prop_stats.T[i]
 
     fov_stats.to_csv(os.path.join(fibseg_dir, f'fiber_stats_table.csv'), index=False)
 

--- a/tests/segmentation/fiber_segmentation_test.py
+++ b/tests/segmentation/fiber_segmentation_test.py
@@ -185,7 +185,6 @@ def test_generate_tile_stats(min_fiber_num):
         tile_stats = fiber_segmentation.generate_tile_stats(
             fov_fiber_table, fov_fiber_img, fov_length, tile_length, min_fiber_num,
             temp_dir, save_tiles=True)
-        print(tile_stats)
 
         # check tile level values
         # 0,0 tile, fov1 should exclude fiber 6 since located in different tile
@@ -234,7 +233,7 @@ def test_generate_summary_stats(mocker: MockerFixture, min_fiber_num):
         'major_axis_length': random.sample(range(1, 20), 12),
         'minor_axis_length': random.sample(range(1, 20), 12),
         'orientation': [random.uniform(-1.57, 1.57) for _ in range(12)],
-        'area': [1]*12,
+        'area': [2]*12,
         'eccentricity': [random.uniform(0, 1) for _ in range(12)],
         'euler_number': [random.choice([0, 1]) for _ in range(12)],
         'alignment_score': random.sample(range(10, 40), 12),
@@ -271,3 +270,6 @@ def test_generate_summary_stats(mocker: MockerFixture, min_fiber_num):
             np.mean(fiber_object_table.minor_axis_length[0:6])
         assert fov_stats.avg_minor_axis_length[1] == \
             np.mean(fiber_object_table.minor_axis_length[6:12])
+
+        # check fiber and pixel density different
+        assert fov_stats.pixel_density[1] != fov_stats.fiber_density[1]

--- a/tests/segmentation/fiber_segmentation_test.py
+++ b/tests/segmentation/fiber_segmentation_test.py
@@ -9,7 +9,6 @@ from typing import Generator
 import numpy as np
 import pandas as pd
 import pytest
-import skimage.io as io
 from alpineer import io_utils, test_utils, misc_utils
 from pytest_mock import MockerFixture
 
@@ -186,12 +185,15 @@ def test_generate_tile_stats(min_fiber_num):
         tile_stats = fiber_segmentation.generate_tile_stats(
             fov_fiber_table, fov_fiber_img, fov_length, tile_length, min_fiber_num,
             temp_dir, save_tiles=True)
+        print(tile_stats)
 
         # check tile level values
         # 0,0 tile, fov1 should exclude fiber 6 since located in different tile
         tile_0_0 = tile_stats[np.logical_and(tile_stats.tile_y == 0, tile_stats.tile_x == 0)]
         assert tile_0_0.avg_major_axis_length[0] \
             == np.mean(fov_fiber_table.major_axis_length[0:5])
+        assert tile_0_0.avg_minor_axis_length[0] \
+            == np.mean(fov_fiber_table.minor_axis_length[0:5])
         assert tile_0_0.avg_alignment_score[0] \
             == np.mean(fov_fiber_table.alignment_score[0:5])
 
@@ -263,3 +265,9 @@ def test_generate_summary_stats(mocker: MockerFixture, min_fiber_num):
             np.mean(fiber_object_table.major_axis_length[0:6])
         assert fov_stats.avg_major_axis_length[1] == \
             np.mean(fiber_object_table.major_axis_length[6:12])
+
+        # check second metric has correct calculated stat
+        assert fov_stats.avg_minor_axis_length[0] ==\
+            np.mean(fiber_object_table.minor_axis_length[0:6])
+        assert fov_stats.avg_minor_axis_length[1] == \
+            np.mean(fiber_object_table.minor_axis_length[6:12])


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Fixes bugs in `generate_summary_stats` and `generate_tile_stats`, which was causing all the metric averages for a fiberto be the same at the first metric value. Also set pixel density and fiber values to different variables.

**How did you implement your changes**

Fix a few silly typos.
Add tests to check for different calculated stats.

**Remaining issues**

 N/A
