### PR TITLE
Fix kmeans notebook mask generation

### DIFF
--- a/templates/example_neighborhood_analysis_script.ipynb
+++ b/templates/example_neighborhood_analysis_script.ipynb
@@ -614,10 +614,10 @@
     "\n",
     "# generate and save the neighborhood masks for the fovs to display\n",
     "data_utils.generate_and_save_neighborhood_cluster_masks(\n",
-    "    subset_neighborhood_fovs,\n",
-    "    overlay_out_dir,\n",
-    "    all_data_cluster_labeled,\n",
-    "    segmentation_dir,\n",
+    "    fovs=subset_neighborhood_fovs,\n",
+    "    save_dir=overlay_out_dir,\n",
+    "    seg_dir=segmentation_dir,\n",
+    "    neighborhood_data=all_data_cluster_labeled,\n",
     "    name_suffix='_neighborhood_mask'\n",
     ")"
    ]

--- a/templates/example_neighborhood_analysis_script.ipynb
+++ b/templates/example_neighborhood_analysis_script.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,7 +8,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -39,7 +37,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -62,7 +59,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -81,7 +77,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -89,7 +84,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -102,7 +96,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -182,7 +175,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -190,7 +182,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -215,7 +206,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -246,7 +236,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -273,7 +262,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -281,7 +269,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -302,7 +289,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -310,7 +296,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -358,7 +343,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -366,7 +350,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -421,7 +404,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -429,7 +411,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -466,7 +447,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -474,7 +454,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -529,7 +508,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -563,7 +541,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -597,7 +574,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -605,7 +581,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -688,7 +663,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -696,7 +670,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -704,7 +677,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -729,7 +701,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -744,10 +715,10 @@
    "source": [
     "# generate and save the neighborhood masks for all the fovs\n",
     "data_utils.generate_and_save_neighborhood_cluster_masks(\n",
-    "    all_fovs,\n",
-    "    overlay_out_dir,\n",
-    "    all_data_cluster_labeled,\n",
-    "    segmentation_dir,\n",
+    "    fovs=all_fovs,\n",
+    "    save_dir=overlay_out_dir,\n",
+    "    seg_dir=segmentation_dir,\n",
+    "    neighborhood_data=all_data_cluster_labeled,\n",
     "    name_suffix='_neighborhood_mask'\n",
     ")"
    ]
@@ -768,7 +739,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #1129. 
Fixes `generate_and_save_neighborhood_cluster_masks()` call in the kmeans notebook.

**How did you implement your changes**

Adds argument keywords to avoid incorrect ordering.

**Remaining issues**

N/A
