### PR TITLE
Change python version in conda env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ data/*
 .venv/
 .virtual_documents
 .history/
+requirements-dev.lock
+requirements.lock
+.editorconfig

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ark_env
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.10
   - pip
   - hdf5
   - pip:


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Fixes an issue with creating conda environments, as there are no `scikit-image` wheels for python 3.11.

**How did you implement your changes**
Changed the `yml` file and set it to python 3.10.


**Remaining issues**

We should probably update the fiber segmentation filtering function to use the new version of `frangi()`, `scikit-image >=0.20`. The most recent release is on `0.23.1`.

Related Issues:

- #1060
