### PR TITLE
Enforce consistent channel ordering in Pixie

### DIFF
--- a/templates/2_Pixie_Cluster_Pixels.ipynb
+++ b/templates/2_Pixie_Cluster_Pixels.ipynb
@@ -336,7 +336,10 @@
     "            \"CD163_nuc_exclude\", \"CK17\", \"Collagen1\", \"Fibronectin\", \n",
     "            \"ECAD_smoothed\", \"HLADR\", \"SMA\", \"Vim\"]\n",
     "blur_factor = 2\n",
-    "subset_proportion = 0.1"
+    "subset_proportion = 0.1\n",
+    "\n",
+    "# ensures consistent ordering of channel names across files\n",
+    "channels = sorted(channels)"
    ]
   },
   {
@@ -928,7 +931,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.10.14"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
**What is the purpose of this PR?**

Users may not always specify channels in strictly alphabetical order when running pixel-level Pixie. Additionally, Python's definition of sorting differs significantly from how we normally think of sorting, especially with capitalization. To prevent confusion, we need a consistent, non-stochastic ordering of channel names.

**How did you implement your changes**

Add a line to call Python's `sorted` function after defining the `channels` list. This ensures `channels` adheres to Python's sorting conventions.

**Remaining issues**

Not sure if cross-platform compatibility will be an issue, but `sorted` should be OS-agnostic.