### PR TITLE
Set `yticklabels = True` for heatmap visualiations in Pixie

### DIFF
--- a/src/ark/analysis/visualize.py
+++ b/src/ark/analysis/visualize.py
@@ -129,7 +129,8 @@ def draw_heatmap(data, x_labels, y_labels, dpi=None, center_val=None, min_val=No
         data_df, cmap=colormap, center=center_val,
         vmin=min_val, vmax=max_val, row_colors=row_colors, row_cluster=row_cluster,
         col_colors=col_colors, col_cluster=col_cluster,
-        cbar_kws={'ticks': cbar_ticks}
+        cbar_kws={'ticks': cbar_ticks},
+        yticklabels=True
     )
 
     # ensure the row color axis doesn't have a label attacked to it


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #1146. When there are too many labels on the y-axis of a heatmap, Seaborn may not show all of them. There needs to be a way to accomplish this so that even if the user has multiple channels on the y-axis, for example, all of them can be mapped to one column.

**How did you implement your changes**

Pass in `yticklabels=True` by default to `sns.clustermap` per @cliu72's tests.