### PR TITLE
Ensure `_temp` dir does not interfere with pixel SOM and consensus cluster assignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,15 @@ dependencies = [
     "zstandard>=0.19.0,<1",
     "zarr",
     "python-dateutil>=2.9.0",
-    "ark-analysis[colors]",
+    "palettable",
+    "cmasher",
+    "cmocean",
+    "colorcet",
+    "scienceplots",
 ]
 
 [project.optional-dependencies]
 dev = ["ark-analysis[test]", "twine"]
-colors = ["palettable", "cmasher", "cmocean", "colorcet", "scienceplots"]
 test = [
     "attrs",
     "coveralls[toml]",

--- a/src/ark/phenotyping/pixel_cluster_utils.py
+++ b/src/ark/phenotyping/pixel_cluster_utils.py
@@ -142,6 +142,35 @@ def normalize_rows(pixel_data, channels, include_seg_label=True):
     return pixel_data_sub
 
 
+def identify_seen_pixel_clusters(base_dir, data_dir, fovs, cluster_col="pixel_som_cluster"):
+    """Identifies all the seen pixel clusters in a cohort
+
+    Args:
+        base_dir (str):
+            The path to the data directory
+        data_dir (str):
+            Name of the directory which contains the full preprocessed pixel data
+        fovs (list):
+            The list of fovs to subset on
+        cluster_col (str):
+            The cluster column to count over
+    Returns:
+        list:
+            The list of all pixel clusters 
+    """
+    misc_utils.verify_in_list(
+        cluster_col=cluster_col,
+        pixel_cluster_col_types=["pixel_som_cluster", "pixel_meta_cluster"]
+    )
+
+    pixel_clusters_seen = set()
+    for fov in fovs:
+        fov_data = feather.read_dataframe(os.path.join(base_dir, data_dir, fov + ".feather"))
+        pixel_clusters_seen.update(list(np.unique(fov_data[cluster_col])))
+
+    return pixel_clusters_seen
+
+
 def check_for_modified_channels(tiff_dir, test_fov, img_sub_folder, channels):
     """Checks to make sure the user selected newly modified channels
 

--- a/src/ark/phenotyping/pixel_meta_clustering.py
+++ b/src/ark/phenotyping/pixel_meta_clustering.py
@@ -97,7 +97,12 @@ def pixel_consensus_cluster(fovs, channels, base_dir, max_k=20, cap=3,
     # if overwrite flag set, run on all FOVs in data_dir
     if overwrite:
         print('Overwrite flag set, reassigning meta cluster labels to all FOVs')
+
+        # reset temp state if run interrupted early
+        if os.path.exists(os.path.join(pixel_data_path + '_temp')):
+            rmtree(os.path.join(pixel_data_path + '_temp'))
         os.mkdir(pixel_data_path + '_temp')
+
         fovs_list = io_utils.remove_file_extensions(
             io_utils.list_files(pixel_data_path, substrs='.feather')
         )

--- a/src/ark/phenotyping/pixel_som_clustering.py
+++ b/src/ark/phenotyping/pixel_som_clustering.py
@@ -220,7 +220,12 @@ def cluster_pixels(fovs, base_dir, pixel_pysom, data_dir='pixel_mat_data',
     if overwrite:
         print('Overwrite flag set, reassigning SOM cluster labels to all FOVs')
         pixel_pysom.som_clusters_seen = set()
+
+        # reset temp state if run interrupted early
+        if os.path.exists(os.path.join(data_path + '_temp')):
+            rmtree(os.path.join(data_path + '_temp'))
         os.mkdir(data_path + '_temp')
+
         fovs_list = io_utils.remove_file_extensions(
             io_utils.list_files(data_path, substrs='.feather')
         )
@@ -235,6 +240,12 @@ def cluster_pixels(fovs, base_dir, pixel_pysom, data_dir='pixel_mat_data',
 
     # if there are no FOVs left without SOM labels don't run function
     if len(fovs_list) == 0:
+        # ensure on a full restart, all SOM clusters get loaded in
+        if pixel_pysom.som_clusters_seen is None or len(pixel_pysom.som_clusters_seen) == 0:
+            pixel_pysom.som_clusters_seen = pixel_cluster_utils.identify_seen_pixel_clusters(
+                base_dir, data_dir, fovs
+            )
+
         print("There are no more FOVs to assign SOM labels to, skipping")
         return
 

--- a/tests/phenotyping/pixel_cluster_utils_test.py
+++ b/tests/phenotyping/pixel_cluster_utils_test.py
@@ -156,6 +156,35 @@ def test_normalize_rows():
     assert np.all(fov_pixel_matrix_sub.drop(columns=meta_cols).values == [1 / 3, 2 / 3])
 
 
+def test_identify_seen_pixel_clusters():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.mkdir(os.path.join(temp_dir, "pixel_mat_data"))
+        fovs = ["fov1", "fov2", "fov3"]
+
+        for i, fov in enumerate(fovs):
+            fov_df = pd.DataFrame.from_dict(
+                {
+                    "pixel_som_cluster": np.arange(1, 11) + i,
+                    "pixel_meta_cluster": np.arange(1, 11) + i
+                }
+            )
+            feather.write_dataframe(
+                fov_df, os.path.join(temp_dir, "pixel_mat_data", fov + ".feather")
+            )
+
+        # test som cluster ID functionality
+        pixel_clusters_seen = pixel_cluster_utils.identify_seen_pixel_clusters(
+            temp_dir, "pixel_mat_data", fovs
+        )
+        assert list(pixel_clusters_seen) == list(np.arange(1, 13))
+
+        # test meta cluster ID functionality
+        pixel_clusters_seen = pixel_cluster_utils.identify_seen_pixel_clusters(
+            temp_dir, "pixel_mat_data", fovs, cluster_col="pixel_meta_cluster"
+        )
+        assert list(pixel_clusters_seen) == list(np.arange(1, 13))
+
+
 @parametrize('chan_names, err_str', [(['CK18', 'CK17', 'CK18_smoothed'], 'selected CK18'),
                                      (['CK17', 'CK18', 'CK17_nuc_include'], 'selected CK17')])
 def test_check_for_modified_channels(chan_names, err_str):

--- a/tests/phenotyping/pixel_meta_clustering_test.py
+++ b/tests/phenotyping/pixel_meta_clustering_test.py
@@ -226,6 +226,21 @@ def test_pixel_consensus_cluster_base(multiprocess, capsys):
         # further ensures that all FOVs were overwritten
         assert "There are no more FOVs to assign meta labels to" not in output
 
+        # run SOM cluster assignment with overwrite flag AND a temp dir
+        os.mkdir(os.path.join(temp_dir, 'pixel_mat_data_temp'))
+        pixel_cc = pixel_meta_clustering.pixel_consensus_cluster(
+            fovs=fovs, channels=chans, base_dir=temp_dir, overwrite=True
+        )
+
+        # test is otherwise the same as overwrite
+        output = capsys.readouterr().out
+        desired_status_updates = \
+            "Overwrite flag set, reassigning meta cluster labels to all FOVs\n"
+        assert desired_status_updates in output
+
+        # further ensures that all FOVs were overwritten
+        assert "There are no more FOVs to assign meta labels to" not in output
+
 
 @parametrize('multiprocess', [True, False])
 def test_pixel_consensus_cluster_corrupt(multiprocess, capsys):

--- a/tests/phenotyping/pixel_som_clustering_test.py
+++ b/tests/phenotyping/pixel_som_clustering_test.py
@@ -272,6 +272,31 @@ def test_cluster_pixels_base(multiprocess, capsys):
         # further ensures that all FOVs were overwritten
         assert "There are no more FOVs to assign SOM labels to" not in output
 
+        # run SOM cluster assignment with overwrite flag AND a temp dir
+        os.mkdir(os.path.join(temp_dir, 'pixel_mat_data_temp'))
+        pixel_som_clustering.cluster_pixels(
+            fovs, temp_dir, pixel_pysom, 'pixel_mat_data', multiprocess=multiprocess,
+            overwrite=True
+        )
+
+        # test is otherwise the same as overwrite
+        output = capsys.readouterr().out
+        desired_status_updates = \
+            "Overwrite flag set, reassigning SOM cluster labels to all FOVs\n"
+        assert desired_status_updates in output
+
+        # further ensures that all FOVs were overwritten
+        assert "There are no more FOVs to assign SOM labels to" not in output
+
+        # test functionality where pixel pysom's seen clusters needs to be determined
+        pixel_pysom.som_clusters_seen = set()
+        pixel_som_clustering.cluster_pixels(
+            fovs, temp_dir, pixel_pysom, 'pixel_mat_data', multiprocess=multiprocess
+        )
+
+        # can't determine if all SOM clusters will be assigned, but absolutely more than zero
+        assert len(pixel_pysom.som_clusters_seen) > 0
+
 
 @parametrize('multiprocess', [True, False])
 def test_cluster_pixels_corrupt(multiprocess, capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -241,7 +242,6 @@ wheels = [
 
 [[package]]
 name = "ark-analysis"
-version = "0.7.2.dev4+g59887c6.d20241004"
 source = { editable = "." }
 dependencies = [
     { name = "alpineer" },
@@ -396,6 +396,7 @@ requires-dist = [
     { name = "zarr" },
     { name = "zstandard", specifier = ">=0.19.0,<1" },
 ]
+provides-extras = ["colors", "dev", "lab-ext", "test"]
 
 [[package]]
 name = "array-api-compat"
@@ -1405,7 +1406,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -2348,6 +2349,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/7ec7fddc92e50714ea3745631f79bd9c96424cb2702632521028e57d3a36/multiprocess-0.70.16-py310-none-any.whl", hash = "sha256:c4a9944c67bd49f823687463660a2d6daae94c289adff97e0f9d696ba6371d02", size = 134824 },
     { url = "https://files.pythonhosted.org/packages/50/15/b56e50e8debaf439f44befec5b2af11db85f6e0f344c3113ae0be0593a91/multiprocess-0.70.16-py311-none-any.whl", hash = "sha256:af4cabb0dac72abfb1e794fa7855c325fd2b55a10a44628a3c1ad3311c04127a", size = 143519 },
     { url = "https://files.pythonhosted.org/packages/0a/7d/a988f258104dcd2ccf1ed40fdc97e26c4ac351eeaf81d76e266c52d84e2f/multiprocess-0.70.16-py312-none-any.whl", hash = "sha256:fc0544c531920dde3b00c29863377f87e1632601092ea2daca74e4beb40faa2e", size = 146741 },
+    { url = "https://files.pythonhosted.org/packages/ea/89/38df130f2c799090c978b366cfdf5b96d08de5b29a4a293df7f7429fa50b/multiprocess-0.70.16-py38-none-any.whl", hash = "sha256:a71d82033454891091a226dfc319d0cfa8019a4e888ef9ca910372a446de4435", size = 132628 },
     { url = "https://files.pythonhosted.org/packages/da/d9/f7f9379981e39b8c2511c9e0326d212accacb82f12fbfdc1aa2ce2a7b2b6/multiprocess-0.70.16-py39-none-any.whl", hash = "sha256:a0bafd3ae1b732eac64be2e72038231c1ba97724b60b09400d68f229fcc2fbf3", size = 133351 },
 ]
 
@@ -2885,8 +2887,6 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/c7/8c6872f7372eb6a6b2e4708b88419fb46b857f7a2e1892966b851cc79fc9/psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2", size = 508067 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/66/78c9c3020f573c58101dc43a44f6855d01bbbd747e24da2f0c4491200ea3/psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35", size = 249766 },
-    { url = "https://files.pythonhosted.org/packages/e1/3f/2403aa9558bea4d3854b0e5e567bc3dd8e9fbc1fc4453c0aa9aafeb75467/psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1", size = 253024 },
     { url = "https://files.pythonhosted.org/packages/0b/37/f8da2fbd29690b3557cca414c1949f92162981920699cd62095a984983bf/psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0", size = 250961 },
     { url = "https://files.pythonhosted.org/packages/35/56/72f86175e81c656a01c4401cd3b1c923f891b31fbcebe98985894176d7c9/psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0", size = 287478 },
     { url = "https://files.pythonhosted.org/packages/19/74/f59e7e0d392bc1070e9a70e2f9190d652487ac115bb16e2eff6b22ad1d24/psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd", size = 290455 },
@@ -4124,7 +4124,7 @@ name = "tqdm"
 version = "4.66.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/83/6ba9844a41128c62e810fddddd72473201f3eacde02046066142a2d96cc5/tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad", size = 169504 }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -286,13 +286,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-colors = [
-    { name = "cmasher" },
-    { name = "cmocean" },
-    { name = "colorcet" },
-    { name = "palettable" },
-    { name = "scienceplots" },
-]
 dev = [
     { name = "attrs" },
     { name = "coveralls" },
@@ -331,12 +324,11 @@ test = [
 requires-dist = [
     { name = "alpineer", specifier = "==0.1.12" },
     { name = "anndata" },
-    { name = "ark-analysis", extras = ["colors"] },
     { name = "attrs", marker = "extra == 'dev'" },
     { name = "attrs", marker = "extra == 'test'" },
-    { name = "cmasher", marker = "extra == 'colors'" },
-    { name = "cmocean", marker = "extra == 'colors'" },
-    { name = "colorcet", marker = "extra == 'colors'" },
+    { name = "cmasher" },
+    { name = "cmocean" },
+    { name = "colorcet" },
     { name = "coveralls", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "coveralls", extras = ["toml"], marker = "extra == 'test'" },
     { name = "datasets", specifier = ">=2.6,<3.0" },
@@ -356,8 +348,8 @@ requires-dist = [
     { name = "multiprocess", specifier = ">=0.70.13" },
     { name = "natsort", specifier = ">=8,<9" },
     { name = "numpy", specifier = ">=1.20,<1.24" },
+    { name = "palettable" },
     { name = "palettable", specifier = ">=3.3.0,<4" },
-    { name = "palettable", marker = "extra == 'colors'" },
     { name = "pandas", specifier = ">=2" },
     { name = "pillow", specifier = ">=9,<10" },
     { name = "pyflowsom", specifier = ">=0.1.16" },
@@ -378,7 +370,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-lsp-server", extras = ["all"], marker = "extra == 'lab-ext'" },
     { name = "requests", specifier = ">=2.20,<3" },
-    { name = "scienceplots", marker = "extra == 'colors'" },
+    { name = "scienceplots" },
     { name = "scikit-image", specifier = "<0.19.3" },
     { name = "scikit-learn", specifier = ">=1.1,<2" },
     { name = "scipy", specifier = ">=1.7,<2" },
@@ -396,7 +388,7 @@ requires-dist = [
     { name = "zarr" },
     { name = "zstandard", specifier = ">=0.19.0,<1" },
 ]
-provides-extras = ["colors", "dev", "lab-ext", "test"]
+provides-extras = ["dev", "lab-ext", "test"]
 
 [[package]]
 name = "array-api-compat"


### PR DESCRIPTION
**What is the purpose of this PR?**

If a run is restarted from the beginning, or if a `_temp` dir still exists due to a crash, this creates a strange limbo state where the pipeline:

1. Will attempt to create an already existing `_temp` folder if an `overwrite` is forced (which is often the recommended solution in case the run is completely unsalvageable)
2. Cannot identify what all the seen SOM clusters are if all FOVs have already been assigned (because it simply "passes through" the assignment step, where this normally happens)

**How did you implement your changes**

To address these issues:

1. If a `_temp` directory is seen on `overwrite=True`, delete it first
2. If the `pixel_pysom` object contains no SOM references in `som_clusters_seen`, invokes a new function, `pixel_cluster_utils.identify_seen_pixel_clusters`, to populate this. The function does extend support to meta clusters as well, though this case is not directly invoked in the pipeline.