### PR TITLE
Ensure proper handling of `np.nan` in `regionprops`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
             enable-cache: true
             cache-dependency-glob: "uv.lock"

--- a/src/ark/segmentation/regionprops_extraction.py
+++ b/src/ark/segmentation/regionprops_extraction.py
@@ -18,7 +18,7 @@ def major_minor_axis_ratio(prop, **kwargs):
             major axis length / minor axis length
     """
     if prop.minor_axis_length == 0:
-        return np.float('NaN')
+        return np.nan
     else:
         return prop.major_axis_length / prop.minor_axis_length
 


### PR DESCRIPTION
**What is the purpose of this PR?**

The current version of `regionprops_extraction.major_minor_axis_ratio` uses `np.float("NaN")`, which works inconsistently in the latest versions of `numpy`.

**How did you implement your changes**

Convert to `np.nan`, which is more universal.