### PR TITLE
Add 3-D image stitching workflow to `Image_Stitching.ipynb`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["ark-analysis[test]", "twine>=6.2.0", "packaging>=24.2"]
+dev = ["ark-analysis[test]", "twine>=6.2.0", "packaging>=26.1"]
 colors = ["palettable", "cmasher", "cmocean", "colorcet", "scienceplots"]
 test = [
     "attrs",

--- a/src/ark/utils/data_utils.py
+++ b/src/ark/utils/data_utils.py
@@ -750,8 +750,75 @@ def split_img_stack(stack_dir, output_dir, stack_list, indices, names, channels_
             image_utils.save_image(save_path, channel)
 
 
+def _load_tiled_img_data(data_dir, fovs, expected_fovs, channel, single_dir, file_ext="tiff",
+                         img_sub_folder=""):
+    """ Loads a set of tiled images into an xarray, preserving multi-channel image data
+
+    This is a local equivalent of alpineer's `load_utils.load_tiled_img_data`. Unlike that
+    version, it does not collapse each loaded image into a single channel slot, so images with
+    more than two dimensions (e.g. RGB overlays/colored masks) can be tiled without corruption.
+
+    Args:
+        data_dir (str):
+            directory containing folders of images
+        fovs (list):
+            list of fovs to load data for
+        expected_fovs (list):
+            list of all expected RnCm fovs names in the tiled grid
+        channel (str):
+            single image name to load
+        single_dir (bool):
+            whether the images are stored in a single directory rather than within fov subdirs
+        file_ext (str):
+            the file type of existing images
+        img_sub_folder (str):
+            optional name of image sub-folder within each fov
+
+    Returns:
+        xarray.DataArray:
+            xarray with shape [fovs, x_dim, y_dim, depth]
+    """
+
+    io_utils.validate_paths(data_dir)
+
+    if single_dir:
+        test_path = os.path.join(data_dir, fovs[0] + "_" + channel + "." + file_ext)
+    else:
+        test_path = os.path.join(data_dir, fovs[0], img_sub_folder, channel + "." + file_ext)
+    test_img = io.imread(test_path)
+    depth = 1 if test_img.ndim == 2 else test_img.shape[-1]
+
+    img_data = np.zeros(
+        (len(expected_fovs), test_img.shape[0], test_img.shape[1], depth), dtype=test_img.dtype
+    )
+
+    for idx, fov_name in enumerate(expected_fovs):
+        # leave missing fovs as zeros
+        if fov_name not in fovs:
+            continue
+
+        if single_dir:
+            temp_img = io.imread(os.path.join(data_dir, fov_name + "_" + channel + "." + file_ext))
+        else:
+            temp_img = io.imread(
+                os.path.join(data_dir, fov_name, img_sub_folder, channel + "." + file_ext))
+
+        if temp_img.ndim == 2:
+            img_data[idx, :temp_img.shape[0], :temp_img.shape[1], 0] = temp_img
+        else:
+            img_data[idx, :temp_img.shape[0], :temp_img.shape[1], :] = temp_img
+
+    row_coords, col_coords = range(img_data.shape[1]), range(img_data.shape[2])
+    img_xr = xr.DataArray(
+        img_data,
+        coords=[expected_fovs, row_coords, col_coords, range(depth)],
+        dims=["fovs", "rows", "cols", "channels"],
+    )
+    return img_xr
+
+
 def stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=None, channels=None,
-                           segmentation=False, clustering=False):
+                           segmentation=False, clustering=False, single_dir_suffix=None):
     """ Creates stitched images for the specified channels based on the FOV folder names
 
     Args:
@@ -767,6 +834,11 @@ def stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=None, channels
             if stitching images from the single segmentation dir
         clustering (bool or str):
             if stitching images from the single pixel or cell mask dir, specify 'pixel' / 'cell'
+        single_dir_suffix (str):
+            if stitching images from a single flat directory not covered by `segmentation` or
+            `clustering` (e.g. a segmentation overlay or Pixie colored mask visualization dir),
+            the filename suffix identifying each FOV's image, e.g.
+            '_nuclear_channel_membrane_channel_overlay.tiff' or '_pixel_mask_colored.tiff'
     """
 
     io_utils.validate_paths(data_dir)
@@ -779,6 +851,10 @@ def stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=None, channels
         raise ValueError('If stitching images from the pixie pipeline, the clustering arg must be '
                          'set to either \"pixel\" or \"cell\".')
 
+    if sum(bool(mode) for mode in [segmentation, clustering, single_dir_suffix]) > 1:
+        raise ValueError('Only one of segmentation, clustering, or single_dir_suffix may be '
+                         'specified at a time.')
+
     # retrieve valid fov names
     if segmentation:
         fovs = ns.natsorted(io_utils.list_files(data_dir, substrs='_whole_cell.tiff'))
@@ -786,6 +862,9 @@ def stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=None, channels
     elif clustering:
         fovs = ns.natsorted(io_utils.list_files(data_dir, substrs=f'_{clustering}_mask.tiff'))
         fovs = io_utils.extract_delimited_names(fovs, delimiter=f'_{clustering}_mask.tiff')
+    elif single_dir_suffix:
+        fovs = ns.natsorted(io_utils.list_files(data_dir, substrs=single_dir_suffix))
+        fovs = io_utils.extract_delimited_names(fovs, delimiter=single_dir_suffix)
     else:
         fovs = ns.natsorted(io_utils.list_folders(data_dir))
         # ignore previous toffy stitching in fov directory
@@ -811,8 +890,10 @@ def stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=None, channels
         raise ValueError(f"Invalid FOVs found in directory, {data_dir}. FOV names "
                          f"{bad_fov_names} should have the form RnCm.")
 
+    single_dir = any([segmentation, clustering, single_dir_suffix])
+
     # retrieve all extracted channel names and verify list if provided
-    if not segmentation and not clustering:
+    if not single_dir:
         channel_imgs = io_utils.list_files(
             dir_name=os.path.join(data_dir, fovs[0], img_sub_folder),
             substrs=EXTENSION_TYPES["IMAGE"])
@@ -837,12 +918,14 @@ def stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=None, channels
         stitched_subdir = os.path.join(stitched_dir, prefix)
         if not os.path.exists(stitched_subdir):
             os.makedirs(stitched_subdir)
-        image_data = load_utils.load_tiled_img_data(data_dir, fovs, expected_fovs, chan,
-                                                    single_dir=any([segmentation, clustering]),
-                                                    file_ext=file_ext[1:],
-                                                    img_sub_folder=img_sub_folder)
+        image_data = _load_tiled_img_data(data_dir, fovs, expected_fovs, chan,
+                                          single_dir=single_dir,
+                                          file_ext=file_ext[1:],
+                                          img_sub_folder=img_sub_folder)
         stitched_data = data_utils.stitch_images(image_data, num_cols)
-        current_img = stitched_data.loc['stitched_image', :, :, chan].values
+        current_img = stitched_data.loc['stitched_image'].values
+        if current_img.shape[-1] == 1:
+            current_img = current_img[..., 0]
         image_utils.save_image(os.path.join(stitched_subdir, chan + '_stitched' + file_ext),
                                current_img)
 

--- a/templates/Image_Stitching.ipynb
+++ b/templates/Image_Stitching.ipynb
@@ -1,19 +1,10 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e6396ae5-6cd6-476c-8215-1b8cea4c2b00",
    "metadata": {},
-   "source": [
-    "# Image Stitching\n",
-    "The purpose of this notebook is to examine images according to the original tiled FOV shape. **Note: the FOV names for your data are expected to contain a grid name identifier of the form RnCm (e.g. example_data_R1C3, example_data_R2C1) which indicates the relative location of each FOV.**\n",
-    "\n",
-    "There are three different types of images you can stitch together, which are all stored in different directories and have individual code sections you can run below:\n",
-    "1. channel images \n",
-    "2. segmentated images (must have completed notebook `1_Segment_Image_Data`)\n",
-    "3. clustered images (must have completed notebook `2_Pixie_Cluster_Pixels` or `3_Pixie_Cluster_Cells`)"
-   ]
+   "source": "# Image Stitching\nThe purpose of this notebook is to examine images according to the original tiled FOV shape. **Note: the FOV names for your data are expected to contain a grid name identifier of the form RnCm (e.g. example_data_R1C3, example_data_R2C1) which indicates the relative location of each FOV.**\n\nThere are four different types of images you can stitch together, which are all stored in different directories and have individual code sections you can run below:\n1. channel images\n2. segmentated images (must have completed notebook `1_Segment_Image_Data`)\n3. clustered images (must have completed notebook `2_Pixie_Cluster_Pixels` or `3_Pixie_Cluster_Cells`)\n4. visualization/overlay images stored in a single flat directory with a custom filename suffix (e.g. segmentation overlays or Pixie colored cluster masks), including RGB images"
   },
   {
    "cell_type": "code",
@@ -27,7 +18,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "8ecd7b8c-b55b-4aa8-9306-65a9eca6b692",
    "metadata": {},
@@ -39,7 +29,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "977f8d09-85a6-4db2-9c88-189710566c8e",
    "metadata": {},
@@ -66,7 +55,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "de1ae179-c815-4fdf-a9cc-eb72e72b97aa",
    "metadata": {},
@@ -93,7 +81,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9cb51103-359f-42fc-86b7-b51331fe62f8",
    "metadata": {},
@@ -118,11 +105,25 @@
     "\n",
     "stitch_images_by_shape(clustering_dir, stitched_dir, img_sub_folder=None, channels=None, segmentation=False, clustering=clustering)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d613bea",
+   "source": "### Stitch Visualization/Overlay Images\nImages are expected to be contained directly within the `visualization_dir`, one image per FOV (RGB/color images are supported).\n* `single_dir_suffix`: the filename suffix identifying each FOV's image in the directory, e.g. `'_nuclear_channel_membrane_channel_overlay.tiff'` for segmentation overlays saved via `plot_utils.create_overlay` (see `1_Segment_Image_Data`), or `'_pixel_mask_colored.tiff'` / `'_cell_mask_colored.tiff'` for Pixie's colored cluster mask visualizations saved via `plot_utils.save_colored_masks` (see `2_Pixie_Cluster_Pixels` / `3_Pixie_Cluster_Cells`)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "05398451",
+   "source": "# set up file paths\nvisualization_dir = '../data/path_to_visualization_data'\nstitched_dir = '../data/stitched_visualization_images'\n\nsingle_dir_suffix = '_nuclear_channel_membrane_channel_overlay.tiff'   # or e.g. '_pixel_mask_colored.tiff'\n\nstitch_images_by_shape(visualization_dir, stitched_dir, img_sub_folder=None, channels=None, single_dir_suffix=single_dir_suffix)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -135,7 +136,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/tests/utils/data_utils_test.py
+++ b/tests/utils/data_utils_test.py
@@ -718,10 +718,12 @@ def stitching_fovs(request: str) -> Iterator[List[str]]:
     yield fovs
 
 
-@pytest.mark.parametrize('segmentation, clustering, subdir',
-                         [(False, False, 'TIFs'), (True, False, ''), (False, 'cell', ''),
-                          (False, 'pixel', '')])
-def test_stitch_images_by_shape(segmentation, clustering, subdir, stitching_fovs):
+@pytest.mark.parametrize('segmentation, clustering, subdir, single_dir_suffix',
+                         [(False, False, 'TIFs', None), (True, False, '', None),
+                          (False, 'cell', '', None), (False, 'pixel', '', None),
+                          (False, False, '', '_overlay.tiff')])
+def test_stitch_images_by_shape(segmentation, clustering, subdir, single_dir_suffix,
+                                stitching_fovs):
 
     # validation checks (only once)
     if clustering == 'pixel':
@@ -755,6 +757,11 @@ def test_stitch_images_by_shape(segmentation, clustering, subdir, stitching_fovs
                 data_utils.stitch_images_by_shape(data_dir, stitched_dir,
                                                   segmentation=segmentation, clustering='not_cell')
 
+            # specifying more than one flat-dir mode at once should raise an error
+            with pytest.raises(ValueError, match="Only one of segmentation, clustering"):
+                data_utils.stitch_images_by_shape(data_dir, stitched_dir, segmentation=True,
+                                                  single_dir_suffix='_overlay.tiff')
+
             # check for existing previous stitched images
             os.makedirs(os.path.join(stitched_dir))
             with pytest.raises(ValueError, match="already exists"):
@@ -770,6 +777,8 @@ def test_stitch_images_by_shape(segmentation, clustering, subdir, stitching_fovs
             chans = ['nuclear', 'whole_cell']
         elif clustering:
             chans = [clustering + '_mask']
+        elif single_dir_suffix:
+            chans = ['overlay']
         else:
             chans = [f"chan{i}" for i in range(5)]
             # check that ignores toffy stitching in fov level dir
@@ -778,14 +787,15 @@ def test_stitch_images_by_shape(segmentation, clustering, subdir, stitching_fovs
         filelocs, data_xr = test_utils.create_paired_xarray_fovs(
             data_dir, stitching_fovs, chans,
             img_shape=(10, 10), fills=True, sub_dir=subdir, dtype=np.float32,
-            single_dir=any([segmentation, clustering])
+            single_dir=any([segmentation, clustering, single_dir_suffix])
         )
 
         # bad channel name should raise an error
         with pytest.raises(ValueError, match="Not all values given in list"):
             data_utils.stitch_images_by_shape(data_dir, stitched_dir, channels='bad_channel',
                                               img_sub_folder=subdir, segmentation=segmentation,
-                                              clustering=clustering)
+                                              clustering=clustering,
+                                              single_dir_suffix=single_dir_suffix)
 
         # test successful stitching
         if len(stitching_fovs) == 13*13*2:
@@ -796,7 +806,8 @@ def test_stitch_images_by_shape(segmentation, clustering, subdir, stitching_fovs
             prefixes = ["run_1"]
 
         data_utils.stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=subdir,
-                                          segmentation=segmentation, clustering=clustering)
+                                          segmentation=segmentation, clustering=clustering,
+                                          single_dir_suffix=single_dir_suffix)
         for prefix in prefixes:
             stitched_subdir = os.path.join(stitched_dir, prefix)
             assert sorted(io_utils.list_files(stitched_subdir)) == \
@@ -812,15 +823,52 @@ def test_stitch_images_by_shape(segmentation, clustering, subdir, stitching_fovs
         random_channel = chans[random.randint(0, len(chans) - 1)]
         data_utils.stitch_images_by_shape(data_dir, stitched_dir, img_sub_folder=subdir,
                                           channels=[random_channel], segmentation=segmentation,
-                                          clustering=clustering)
+                                          clustering=clustering,
+                                          single_dir_suffix=single_dir_suffix)
         for prefix in prefixes:
             stitched_subdir = os.path.join(stitched_dir, prefix)
             assert sorted(io_utils.list_files(stitched_subdir)) == \
                 [random_channel + '_stitched.tiff']
 
         # remove stitched_images from fov list
-        if not segmentation and not clustering:
+        if not segmentation and not clustering and not single_dir_suffix:
             stitching_fovs.pop()
+
+
+def test_stitch_images_by_shape_rgb():
+    # 2x2 RnCm grid, distinct color per fov so we can check tile placement
+    fovs = [f"R{n}C{m}" for n in range(1, 3) for m in range(1, 3)]
+    colors = {
+        "R1C1": (255, 0, 0),
+        "R1C2": (0, 255, 0),
+        "R2C1": (0, 0, 255),
+        "R2C2": (255, 255, 0),
+    }
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        data_dir = os.path.join(temp_dir, 'images')
+        stitched_dir = os.path.join(temp_dir, 'stitched_images')
+        os.makedirs(data_dir)
+
+        for fov in fovs:
+            rgb_img = np.zeros((10, 10, 3), dtype=np.uint8)
+            rgb_img[..., :] = colors[fov]
+            image_utils.save_image(os.path.join(data_dir, f"{fov}_overlay.tiff"), rgb_img)
+
+        data_utils.stitch_images_by_shape(data_dir, stitched_dir,
+                                          single_dir_suffix='_overlay.tiff')
+
+        stitched_subdir = os.path.join(stitched_dir, "unnamed_tile")
+        stitched_img = io.imread(os.path.join(stitched_subdir, "overlay_stitched.tiff"))
+
+        # 2 x 2 fovs with img size 10, so the stitched image is 20 x 20 x 3
+        assert stitched_img.shape == (20, 20, 3)
+
+        # verify each fov's color landed in the correct tile position
+        assert tuple(stitched_img[0, 0, :]) == colors["R1C1"]
+        assert tuple(stitched_img[0, 10, :]) == colors["R1C2"]
+        assert tuple(stitched_img[10, 0, :]) == colors["R2C1"]
+        assert tuple(stitched_img[10, 10, :]) == colors["R2C2"]
 
 
 def test_convert_ct_fov_to_adata(tmp_path: pytest.TempPathFactory):

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ requires-dist = [
     { name = "multiprocess", specifier = ">=0.70.13" },
     { name = "natsort", specifier = ">=8,<9" },
     { name = "numpy", specifier = ">=1.20,<1.24" },
-    { name = "packaging", marker = "extra == 'dev'", specifier = ">=24.2" },
+    { name = "packaging", marker = "extra == 'dev'", specifier = ">=26.1" },
     { name = "palettable", specifier = ">=3.3.0,<4" },
     { name = "palettable", marker = "extra == 'colors'" },
     { name = "pandas", specifier = ">=2" },
@@ -4408,11 +4408,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**What is the purpose of this PR?**

The existing stitching workflow does not support 3-D image stitching of segmented and Pixie-clustered data. This PR adds support for both.

**How did you implement your changes**

Add a 3rd dimension to the stitching workflow, and ensure suffixes for segmented images are loaded correctly.